### PR TITLE
Link domains to their canonical URLs

### DIFF
--- a/assets/data/tables/analytics/domains.json
+++ b/assets/data/tables/analytics/domains.json
@@ -1,3170 +1,3962 @@
 {
   "data": [
     {
+      "Canonical": "http://404.gov",
       "Domain": "404.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://9-11commission.gov",
       "Domain": "9-11commission.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://911.gov",
       "Domain": "911.gov",
       "Participates in DAP?": 1
     },
     {
+      "Canonical": "http://911commission.gov",
       "Domain": "911commission.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://www.abandonedmines.gov",
       "Domain": "abandonedmines.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://abilityone.gov",
       "Domain": "abilityone.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://abmc.gov",
       "Domain": "abmc.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://www.access-board.gov",
       "Domain": "access-board.gov",
       "Participates in DAP?": 1
     },
     {
+      "Canonical": "http://achp.gov",
       "Domain": "achp.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://acl.gov",
       "Domain": "acl.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "https://www.acquisition.gov",
       "Domain": "acquisition.gov",
       "Participates in DAP?": 1
     },
     {
+      "Canonical": "https://www.acus.gov",
       "Domain": "acus.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://acwi.gov",
       "Domain": "acwi.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://www.ada.gov",
       "Domain": "ada.gov",
       "Participates in DAP?": 1
     },
     {
+      "Canonical": "http://adlnet.gov",
       "Domain": "adlnet.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://www.admongo.gov",
       "Domain": "admongo.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://www.adr.gov",
       "Domain": "adr.gov",
       "Participates in DAP?": 1
     },
     {
+      "Canonical": "http://www.advantage.gov",
       "Domain": "advantage.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "https://afadvantage.gov",
       "Domain": "afadvantage.gov",
       "Participates in DAP?": 1
     },
     {
+      "Canonical": "http://www.aff.gov",
       "Domain": "aff.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "https://www.afrh.gov",
       "Domain": "afrh.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://www.agingstats.gov",
       "Domain": "agingstats.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://www.ahrq.gov",
       "Domain": "ahrq.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "https://aids.gov",
       "Domain": "aids.gov",
       "Participates in DAP?": 1
     },
     {
+      "Canonical": "http://airnow.gov",
       "Domain": "airnow.gov",
       "Participates in DAP?": 1
     },
     {
+      "Canonical": "http://alaskacenters.gov",
       "Domain": "alaskacenters.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://www.alertaenlinea.gov",
       "Domain": "alertaenlinea.gov",
       "Participates in DAP?": 1
     },
     {
+      "Canonical": "http://www.altusandc.gov",
       "Domain": "altusandc.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://alzheimers.gov",
       "Domain": "alzheimers.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "https://www.ama.gov",
       "Domain": "ama.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://amberalert.gov",
       "Domain": "amberalert.gov",
       "Participates in DAP?": 1
     },
     {
+      "Canonical": "http://americanlatinomuseum.gov",
       "Domain": "americanlatinomuseum.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://www.americathebeautifulquarters.gov",
       "Domain": "americathebeautifulquarters.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "https://www.ameslab.gov",
       "Domain": "ameslab.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://amtrakoig.gov",
       "Domain": "amtrakoig.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://www.anl.gov",
       "Domain": "anl.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://www.anstaskforce.gov",
       "Domain": "anstaskforce.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://aoa.gov",
       "Domain": "aoa.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://www.arc.gov",
       "Domain": "arc.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://archives.gov",
       "Domain": "archives.gov",
       "Participates in DAP?": 1
     },
     {
+      "Canonical": "http://arctic.gov",
       "Domain": "arctic.gov",
       "Participates in DAP?": 1
     },
     {
+      "Canonical": "http://arcticgas.gov",
       "Domain": "arcticgas.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://www.arm.gov",
       "Domain": "arm.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://www.ars-grin.gov",
       "Domain": "ars-grin.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://arts.gov",
       "Domain": "arts.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "https://www.asap.gov",
       "Domain": "asap.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "https://www.asc.gov",
       "Domain": "asc.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://www.atf.gov",
       "Domain": "atf.gov",
       "Participates in DAP?": 1
     },
     {
+      "Canonical": "http://www.autocommunities.gov",
       "Domain": "autocommunities.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://aviationweather.gov",
       "Domain": "aviationweather.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://ayudaconmibanco.gov",
       "Domain": "ayudaconmibanco.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://www.bam.gov",
       "Domain": "bam.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://bankanswers.gov",
       "Domain": "bankanswers.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://bankcustomer.gov",
       "Domain": "bankcustomer.gov",
       "Participates in DAP?": 1
     },
     {
+      "Canonical": "http://bankcustomerassistance.gov",
       "Domain": "bankcustomerassistance.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://bankhelp.gov",
       "Domain": "bankhelp.gov",
       "Participates in DAP?": 1
     },
     {
+      "Canonical": "http://banknet.gov",
       "Domain": "banknet.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://www.bbg.gov",
       "Domain": "bbg.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://bea.gov",
       "Domain": "bea.gov",
       "Participates in DAP?": 1
     },
     {
+      "Canonical": "http://www.benefits.gov",
       "Domain": "benefits.gov",
       "Participates in DAP?": 1
     },
     {
+      "Canonical": "http://bep.gov",
       "Domain": "bep.gov",
       "Participates in DAP?": 1
     },
     {
+      "Canonical": "https://bfem.gov",
       "Domain": "bfem.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://bia.gov",
       "Domain": "bia.gov",
       "Participates in DAP?": 1
     },
     {
+      "Canonical": "http://www.bioeco.gov",
       "Domain": "bioeco.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://bioethics.gov",
       "Domain": "bioethics.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://biomassboard.gov",
       "Domain": "biomassboard.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://biometrics.gov",
       "Domain": "biometrics.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://biopreferred.gov",
       "Domain": "biopreferred.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "https://www.bja.gov",
       "Domain": "bja.gov",
       "Participates in DAP?": 1
     },
     {
+      "Canonical": "http://bjs.gov",
       "Domain": "bjs.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://www.bldrdoc.gov",
       "Domain": "bldrdoc.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://www.blm.gov",
       "Domain": "blm.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://www.bls.gov",
       "Domain": "bls.gov",
       "Participates in DAP?": 1
     },
     {
+      "Canonical": "http://www.bnl.gov",
       "Domain": "bnl.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://www.boem.gov",
       "Domain": "boem.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://boemre.gov",
       "Domain": "boemre.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://bondpro.gov",
       "Domain": "bondpro.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://www.bop.gov",
       "Domain": "bop.gov",
       "Participates in DAP?": 1
     },
     {
+      "Canonical": "http://www.bpa.gov",
       "Domain": "bpa.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://brac.gov",
       "Domain": "brac.gov",
       "Participates in DAP?": 1
     },
     {
+      "Canonical": "http://www.broadband.gov",
       "Domain": "broadband.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://broadbandmap.gov",
       "Domain": "broadbandmap.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://www.bsee.gov",
       "Domain": "bsee.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://buyaccessible.gov",
       "Domain": "buyaccessible.gov",
       "Participates in DAP?": 1
     },
     {
+      "Canonical": "http://buyusa.gov",
       "Domain": "buyusa.gov",
       "Participates in DAP?": 1
     },
     {
+      "Canonical": "http://www.c3.gov",
       "Domain": "c3.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://www.cancer.gov",
       "Domain": "cancer.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "https://cao.gov",
       "Domain": "cao.gov",
       "Participates in DAP?": 1
     },
     {
+      "Canonical": "http://www.capnhq.gov",
       "Domain": "capnhq.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://www.carboncyclescience.gov",
       "Domain": "carboncyclescience.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://www.casl.gov",
       "Domain": "casl.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://cbca.gov",
       "Domain": "cbca.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://www.cbp.gov",
       "Domain": "cbp.gov",
       "Participates in DAP?": 1
     },
     {
+      "Canonical": "http://ccac.gov",
       "Domain": "ccac.gov",
       "Participates in DAP?": 1
     },
     {
+      "Canonical": "http://www.ccr.gov",
       "Domain": "ccr.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://www.cdc.gov",
       "Domain": "cdc.gov",
       "Participates in DAP?": 1
     },
     {
+      "Canonical": "http://cdfifund.gov",
       "Domain": "cdfifund.gov",
       "Participates in DAP?": 1
     },
     {
+      "Canonical": "http://cendi.gov",
       "Domain": "cendi.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://census.gov",
       "Domain": "census.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://cfa.gov",
       "Domain": "cfa.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "https://www.cfda.gov",
       "Domain": "cfda.gov",
       "Participates in DAP?": 1
     },
     {
+      "Canonical": "http://www.cflhd.gov",
       "Domain": "cflhd.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "https://cfo.gov",
       "Domain": "cfo.gov",
       "Participates in DAP?": 1
     },
     {
+      "Canonical": "http://www.cftc.gov",
       "Domain": "cftc.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://www.challenge.gov",
       "Domain": "challenge.gov",
       "Participates in DAP?": 1
     },
     {
+      "Canonical": "http://change.gov",
       "Domain": "change.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://chcoc.gov",
       "Domain": "chcoc.gov",
       "Participates in DAP?": 1
     },
     {
+      "Canonical": "http://www.childreninadversity.gov",
       "Domain": "childreninadversity.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://www.childstats.gov",
       "Domain": "childstats.gov",
       "Participates in DAP?": 1
     },
     {
+      "Canonical": "https://childwelfare.gov",
       "Domain": "childwelfare.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://choosemyplate.gov",
       "Domain": "choosemyplate.gov",
       "Participates in DAP?": 1
     },
     {
+      "Canonical": "http://www.christophercolumbusfoundation.gov",
       "Domain": "christophercolumbusfoundation.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "https://www.cia.gov",
       "Domain": "cia.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "https://cio.gov",
       "Domain": "cio.gov",
       "Participates in DAP?": 1
     },
     {
+      "Canonical": "http://civilianresponsecorps.gov",
       "Domain": "civilianresponsecorps.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://civilrightsusa.gov",
       "Domain": "civilrightsusa.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://climate.gov",
       "Domain": "climate.gov",
       "Participates in DAP?": 1
     },
     {
+      "Canonical": "http://www.clinicaltrial.gov",
       "Domain": "clinicaltrial.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "https://clinicaltrials.gov",
       "Domain": "clinicaltrials.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://clintonlibrary.gov",
       "Domain": "clintonlibrary.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://cms.gov",
       "Domain": "cms.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://www.cmts.gov",
       "Domain": "cmts.gov",
       "Participates in DAP?": 1
     },
     {
+      "Canonical": "http://cncsoig.gov",
       "Domain": "cncsoig.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "https://www.cnss.gov",
       "Domain": "cnss.gov",
       "Participates in DAP?": 1
     },
     {
+      "Canonical": "http://coast2050.gov",
       "Domain": "coast2050.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://coastalamerica.gov",
       "Domain": "coastalamerica.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://collegedrinkingprevention.gov",
       "Domain": "collegedrinkingprevention.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://www.commerce.gov",
       "Domain": "commerce.gov",
       "Participates in DAP?": 1
     },
     {
+      "Canonical": "http://comptrollerofthecurrency.gov",
       "Domain": "comptrollerofthecurrency.gov",
       "Participates in DAP?": 1
     },
     {
+      "Canonical": "http://computersforlearning.gov",
       "Domain": "computersforlearning.gov",
       "Participates in DAP?": 1
     },
     {
+      "Canonical": "http://www.connect.gov",
       "Domain": "connect.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://www.consumer.gov",
       "Domain": "consumer.gov",
       "Participates in DAP?": 1
     },
     {
+      "Canonical": "http://www.consumerfinance.gov",
       "Domain": "consumerfinance.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "https://consumersentinel.gov",
       "Domain": "consumersentinel.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://www.consumidor.gov",
       "Domain": "consumidor.gov",
       "Participates in DAP?": 1
     },
     {
+      "Canonical": "http://continentalshelf.gov",
       "Domain": "continentalshelf.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "https://www.contractdirectory.gov",
       "Domain": "contractdirectory.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://www.coralreef.gov",
       "Domain": "coralreef.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://www.counterwmd.gov",
       "Domain": "counterwmd.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "https://www.cpars.gov",
       "Domain": "cpars.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "https://www.cpnireporting.gov",
       "Domain": "cpnireporting.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://www.cpsc.gov",
       "Domain": "cpsc.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://www.crimesolutions.gov",
       "Domain": "crimesolutions.gov",
       "Participates in DAP?": 1
     },
     {
+      "Canonical": "http://crimevictims.gov",
       "Domain": "crimevictims.gov",
       "Participates in DAP?": 1
     },
     {
+      "Canonical": "http://www.crt2014-2024review.gov",
       "Domain": "crt2014-2024review.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://www.csb.gov",
       "Domain": "csb.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://www.csosa.fed.us",
       "Domain": "csosa.fed.us",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://csosa.gov",
       "Domain": "csosa.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://cttso.gov",
       "Domain": "cttso.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "https://www.cuidadodesalud.gov",
       "Domain": "cuidadodesalud.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://www.cupcao.gov",
       "Domain": "cupcao.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://cwc.gov",
       "Domain": "cwc.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://www.data.gov",
       "Domain": "data.gov",
       "Participates in DAP?": 1
     },
     {
+      "Canonical": "http://www.dea.gov",
       "Domain": "dea.gov",
       "Participates in DAP?": 1
     },
     {
+      "Canonical": "http://deadiversion.gov",
       "Domain": "deadiversion.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://www.defense.gov",
       "Domain": "defense.gov",
       "Participates in DAP?": 1
     },
     {
+      "Canonical": "http://denali.gov",
       "Domain": "denali.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://dfafacts.gov",
       "Domain": "dfafacts.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://www.dhs.gov",
       "Domain": "dhs.gov",
       "Participates in DAP?": 1
     },
     {
+      "Canonical": "http://www.digitalgov.gov",
       "Domain": "digitalgov.gov",
       "Participates in DAP?": 1
     },
     {
+      "Canonical": "http://www.digitalliteracy.gov",
       "Domain": "digitalliteracy.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "https://www.directoasucuenta.gov",
       "Domain": "directoasucuenta.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "https://www.disability.gov",
       "Domain": "disability.gov",
       "Participates in DAP?": 1
     },
     {
+      "Canonical": "http://www.disasterassistance.gov",
       "Domain": "disasterassistance.gov",
       "Participates in DAP?": 1
     },
     {
+      "Canonical": "http://disasterhousing.gov",
       "Domain": "disasterhousing.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://distracteddriving.gov",
       "Domain": "distracteddriving.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://www.distraction.gov",
       "Domain": "distraction.gov",
       "Participates in DAP?": 1
     },
     {
+      "Canonical": "http://www.dnfsb.gov",
       "Domain": "dnfsb.gov",
       "Participates in DAP?": 1
     },
     {
+      "Canonical": "http://www.dni.gov",
       "Domain": "dni.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://www.dnsops.gov",
       "Domain": "dnsops.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "https://www.docline.gov",
       "Domain": "docline.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://www.dod.gov",
       "Domain": "dod.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://www.doeal.gov",
       "Domain": "doeal.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://www.doi.gov",
       "Domain": "doi.gov",
       "Participates in DAP?": 1
     },
     {
+      "Canonical": "http://www.doioig.gov",
       "Domain": "doioig.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://dol-esa.gov",
       "Domain": "dol-esa.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://dol.gov",
       "Domain": "dol.gov",
       "Participates in DAP?": 1
     },
     {
+      "Canonical": "http://doleta.gov",
       "Domain": "doleta.gov",
       "Participates in DAP?": 1
     },
     {
+      "Canonical": "https://donotcall.gov",
       "Domain": "donotcall.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://www.dot.gov",
       "Domain": "dot.gov",
       "Participates in DAP?": 1
     },
     {
+      "Canonical": "https://www.dotgov.gov",
       "Domain": "dotgov.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://dottrafficrecords.gov",
       "Domain": "dottrafficrecords.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://dottrcc.gov",
       "Domain": "dottrcc.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://dra.gov",
       "Domain": "dra.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://www.drought.gov",
       "Domain": "drought.gov",
       "Participates in DAP?": 1
     },
     {
+      "Canonical": "http://www.drugabuse.gov",
       "Domain": "drugabuse.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "https://www.dsac.gov",
       "Domain": "dsac.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://e3.gov",
       "Domain": "e3.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://www.eac.gov",
       "Domain": "eac.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "https://economicinclusion.gov",
       "Domain": "economicinclusion.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://econsumer.gov",
       "Domain": "econsumer.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://ecopartnerships.gov",
       "Domain": "ecopartnerships.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "https://www.ecpic.gov",
       "Domain": "ecpic.gov",
       "Participates in DAP?": 1
     },
     {
+      "Canonical": "http://www.ed.gov",
       "Domain": "ed.gov",
       "Participates in DAP?": 1
     },
     {
+      "Canonical": "http://eda.gov",
       "Domain": "eda.gov",
       "Participates in DAP?": 1
     },
     {
+      "Canonical": "http://www.edpubs.gov",
       "Domain": "edpubs.gov",
       "Participates in DAP?": 1
     },
     {
+      "Canonical": "http://www.education.gov",
       "Domain": "education.gov",
       "Participates in DAP?": 1
     },
     {
+      "Canonical": "http://eeoc.gov",
       "Domain": "eeoc.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "https://www.eftps.gov",
       "Domain": "eftps.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://www.eia.gov",
       "Domain": "eia.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://eisenhowermemorial.gov",
       "Domain": "eisenhowermemorial.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://www.eldercare.gov",
       "Domain": "eldercare.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "https://www.employeeexpress.gov",
       "Domain": "employeeexpress.gov",
       "Participates in DAP?": 1
     },
     {
+      "Canonical": "https://empowhr.gov",
       "Domain": "empowhr.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://ems.gov",
       "Domain": "ems.gov",
       "Participates in DAP?": 1
     },
     {
+      "Canonical": "http://endingthedocumentgame.gov",
       "Domain": "endingthedocumentgame.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://energy.gov",
       "Domain": "energy.gov",
       "Participates in DAP?": 1
     },
     {
+      "Canonical": "http://www.energycodes.gov",
       "Domain": "energycodes.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://www.energystar.gov",
       "Domain": "energystar.gov",
       "Participates in DAP?": 1
     },
     {
+      "Canonical": "http://epa.gov",
       "Domain": "epa.gov",
       "Participates in DAP?": 1
     },
     {
+      "Canonical": "http://www.epls.gov",
       "Domain": "epls.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://esa.gov",
       "Domain": "esa.gov",
       "Participates in DAP?": 1
     },
     {
+      "Canonical": "http://www.esc.gov",
       "Domain": "esc.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://espanolforlawenforcement.gov",
       "Domain": "espanolforlawenforcement.gov",
       "Participates in DAP?": 1
     },
     {
+      "Canonical": "https://www.esrs.gov",
       "Domain": "esrs.gov",
       "Participates in DAP?": 1
     },
     {
+      "Canonical": "https://www.eta-find.gov",
       "Domain": "eta-find.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://www.ethicsburg.gov",
       "Domain": "ethicsburg.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://www.evergladesrestoration.gov",
       "Domain": "evergladesrestoration.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://www.execsec.gov",
       "Domain": "execsec.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://www.exim.gov",
       "Domain": "exim.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://export.gov",
       "Domain": "export.gov",
       "Participates in DAP?": 1
     },
     {
+      "Canonical": "http://eyenote.gov",
       "Domain": "eyenote.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://www.faa.gov",
       "Domain": "faa.gov",
       "Participates in DAP?": 1
     },
     {
+      "Canonical": "http://www.faasafety.gov",
       "Domain": "faasafety.gov",
       "Participates in DAP?": 1
     },
     {
+      "Canonical": "http://faca.gov",
       "Domain": "faca.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://facadatabase.gov",
       "Domain": "facadatabase.gov",
       "Participates in DAP?": 1
     },
     {
+      "Canonical": "http://fafsa.gov",
       "Domain": "fafsa.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://www.fai.gov",
       "Domain": "fai.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "https://www.fan.gov",
       "Domain": "fan.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "https://fapiis.gov",
       "Domain": "fapiis.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://www.fara.gov",
       "Domain": "fara.gov",
       "Participates in DAP?": 1
     },
     {
+      "Canonical": "https://www.farmerclaims.gov",
       "Domain": "farmerclaims.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "https://fatherhood.gov",
       "Domain": "fatherhood.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://www.fbi.gov",
       "Domain": "fbi.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://www.fbiic.gov",
       "Domain": "fbiic.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "https://www.fbijobs.gov",
       "Domain": "fbijobs.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "https://www.fbo.gov",
       "Domain": "fbo.gov",
       "Participates in DAP?": 1
     },
     {
+      "Canonical": "http://fca.gov",
       "Domain": "fca.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://www.fcc.gov",
       "Domain": "fcc.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://www.fcg.gov",
       "Domain": "fcg.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://fcsic.gov",
       "Domain": "fcsic.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://fcsm.gov",
       "Domain": "fcsm.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://www.fda.gov",
       "Domain": "fda.gov",
       "Participates in DAP?": 1
     },
     {
+      "Canonical": "https://fdic.gov",
       "Domain": "fdic.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://fdicbets.gov",
       "Domain": "fdicbets.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://fdicig.gov",
       "Domain": "fdicig.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://fdicoig.gov",
       "Domain": "fdicoig.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://fdicseguro.gov",
       "Domain": "fdicseguro.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://www.fdms.gov",
       "Domain": "fdms.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "https://www.fdr.gov",
       "Domain": "fdr.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://feb.gov",
       "Domain": "feb.gov",
       "Participates in DAP?": 1
     },
     {
+      "Canonical": "http://fec.gov",
       "Domain": "fec.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "https://www.fedcenter.gov",
       "Domain": "fedcenter.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://www.federalaccountability.gov",
       "Domain": "federalaccountability.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://federalinvestments.gov",
       "Domain": "federalinvestments.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://federalreserve.gov",
       "Domain": "federalreserve.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://federalreserveconsumerhelp.gov",
       "Domain": "federalreserveconsumerhelp.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://fedidcard.gov",
       "Domain": "fedidcard.gov",
       "Participates in DAP?": 1
     },
     {
+      "Canonical": "http://fedinvest.gov",
       "Domain": "fedinvest.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "https://fedpartnership.gov",
       "Domain": "fedpartnership.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://www.fedramp.gov",
       "Domain": "fedramp.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://fedrealestate.gov",
       "Domain": "fedrealestate.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://fedrooms.gov",
       "Domain": "fedrooms.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://fedshirevets.gov",
       "Domain": "fedshirevets.gov",
       "Participates in DAP?": 1
     },
     {
+      "Canonical": "http://fedstats.gov",
       "Domain": "fedstats.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://feedthefuture.gov",
       "Domain": "feedthefuture.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://www.fema.gov",
       "Domain": "fema.gov",
       "Participates in DAP?": 1
     },
     {
+      "Canonical": "https://www.femalefarmerclaims.gov",
       "Domain": "femalefarmerclaims.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://ferc.gov",
       "Domain": "ferc.gov",
       "Participates in DAP?": 1
     },
     {
+      "Canonical": "http://fercalt.gov",
       "Domain": "fercalt.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://www.ffiec.gov",
       "Domain": "ffiec.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://fgdc.gov",
       "Domain": "fgdc.gov",
       "Participates in DAP?": 1
     },
     {
+      "Canonical": "http://www.fhfa.gov",
       "Domain": "fhfa.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://www.fhfaoig.gov",
       "Domain": "fhfaoig.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://fido.gov",
       "Domain": "fido.gov",
       "Participates in DAP?": 1
     },
     {
+      "Canonical": "http://fightingmalaria.gov",
       "Domain": "fightingmalaria.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://financialresearch.gov",
       "Domain": "financialresearch.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://fincen.gov",
       "Domain": "fincen.gov",
       "Participates in DAP?": 1
     },
     {
+      "Canonical": "http://findyouthinfo.gov",
       "Domain": "findyouthinfo.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://www.firecode.gov",
       "Domain": "firecode.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://www.fireleadership.gov",
       "Domain": "fireleadership.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://www.firescience.gov",
       "Domain": "firescience.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://firstnet.gov",
       "Domain": "firstnet.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://www.firstresponder.gov",
       "Domain": "firstresponder.gov",
       "Participates in DAP?": 1
     },
     {
+      "Canonical": "https://www.firstrespondertraining.gov",
       "Domain": "firstrespondertraining.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://www.fiscalcommission.gov",
       "Domain": "fiscalcommission.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://www.fishwatch.gov",
       "Domain": "fishwatch.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://fitness.gov",
       "Domain": "fitness.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "https://www.fleta.gov",
       "Domain": "fleta.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "https://www.fletc.gov",
       "Domain": "fletc.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "https://www.flightschoolcandidates.gov",
       "Domain": "flightschoolcandidates.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "https://www.floodsmart.gov",
       "Domain": "floodsmart.gov",
       "Participates in DAP?": 1
     },
     {
+      "Canonical": "http://flra.gov",
       "Domain": "flra.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://www.flu.gov",
       "Domain": "flu.gov",
       "Participates in DAP?": 1
     },
     {
+      "Canonical": "http://www.fmc.gov",
       "Domain": "fmc.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://www.fmcs.gov",
       "Domain": "fmcs.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://fmi.gov",
       "Domain": "fmi.gov",
       "Participates in DAP?": 1
     },
     {
+      "Canonical": "http://fnal.gov",
       "Domain": "fnal.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://www.foia.gov",
       "Domain": "foia.gov",
       "Participates in DAP?": 1
     },
     {
+      "Canonical": "http://www.foodsafety.gov",
       "Domain": "foodsafety.gov",
       "Participates in DAP?": 1
     },
     {
+      "Canonical": "http://www.foodsafetyworkinggroup.gov",
       "Domain": "foodsafetyworkinggroup.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://fordlibrarymuseum.gov",
       "Domain": "fordlibrarymuseum.gov",
       "Participates in DAP?": 1
     },
     {
+      "Canonical": "http://foreignassistance.gov",
       "Domain": "foreignassistance.gov",
       "Participates in DAP?": 1
     },
     {
+      "Canonical": "http://forestsandrangelands.gov",
       "Domain": "forestsandrangelands.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://www.forfeiture.gov",
       "Domain": "forfeiture.gov",
       "Participates in DAP?": 1
     },
     {
+      "Canonical": "http://www.fpds.gov",
       "Domain": "fpds.gov",
       "Participates in DAP?": 1
     },
     {
+      "Canonical": "http://frcc.gov",
       "Domain": "frcc.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://frtib.gov",
       "Domain": "frtib.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://frtr.gov",
       "Domain": "frtr.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://www.fs.fed.us",
       "Domain": "fs.fed.us",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://www.fsapubs.gov",
       "Domain": "fsapubs.gov",
       "Participates in DAP?": 1
     },
     {
+      "Canonical": "https://www.fsd.gov",
       "Domain": "fsd.gov",
       "Participates in DAP?": 1
     },
     {
+      "Canonical": "http://www.fsgb.gov",
       "Domain": "fsgb.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "https://www.fsrs.gov",
       "Domain": "fsrs.gov",
       "Participates in DAP?": 1
     },
     {
+      "Canonical": "https://www.ftc.gov",
       "Domain": "ftc.gov",
       "Participates in DAP?": 1
     },
     {
+      "Canonical": "https://ftccomplaintassistant.gov",
       "Domain": "ftccomplaintassistant.gov",
       "Participates in DAP?": 1
     },
     {
+      "Canonical": "https://ftcefile.gov",
       "Domain": "ftcefile.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "https://www.fttesttwai.gov",
       "Domain": "fttesttwai.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://fueleconomy.gov",
       "Domain": "fueleconomy.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://www.fvap.gov",
       "Domain": "fvap.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://www.fws.gov",
       "Domain": "fws.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "https://www.g5.gov",
       "Domain": "g5.gov",
       "Participates in DAP?": 1
     },
     {
+      "Canonical": "http://www.gcdamp.gov",
       "Domain": "gcdamp.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://www.gcmrc.gov",
       "Domain": "gcmrc.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://www.genome.gov",
       "Domain": "genome.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://www.geocommunicator.gov",
       "Domain": "geocommunicator.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://www.geomac.gov",
       "Domain": "geomac.gov",
       "Participates in DAP?": 1
     },
     {
+      "Canonical": "http://geoplatform.gov",
       "Domain": "geoplatform.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://ghi.gov",
       "Domain": "ghi.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://www.ginniemae.gov",
       "Domain": "ginniemae.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://girlshealth.gov",
       "Domain": "girlshealth.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://www.globalchange.gov",
       "Domain": "globalchange.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://www.globalhealth.gov",
       "Domain": "globalhealth.gov",
       "Participates in DAP?": 1
     },
     {
+      "Canonical": "http://www.globe.gov",
       "Domain": "globe.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "https://www.godirect.gov",
       "Domain": "godirect.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://www.goes-r.gov",
       "Domain": "goes-r.gov",
       "Participates in DAP?": 1
     },
     {
+      "Canonical": "http://golearn.gov",
       "Domain": "golearn.gov",
       "Participates in DAP?": 1
     },
     {
+      "Canonical": "http://www.govloans.gov",
       "Domain": "govloans.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://www.govsales.gov",
       "Domain": "govsales.gov",
       "Participates in DAP?": 1
     },
     {
+      "Canonical": "http://www.gps.gov",
       "Domain": "gps.gov",
       "Participates in DAP?": 1
     },
     {
+      "Canonical": "http://www.grants.gov",
       "Domain": "grants.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "https://grantsolutions.gov",
       "Domain": "grantsolutions.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://greengov.gov",
       "Domain": "greengov.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://www.gsa.gov",
       "Domain": "gsa.gov",
       "Participates in DAP?": 1
     },
     {
+      "Canonical": "https://gsaadvantage.gov",
       "Domain": "gsaadvantage.gov",
       "Participates in DAP?": 1
     },
     {
+      "Canonical": "http://www.gsaauctions.gov",
       "Domain": "gsaauctions.gov",
       "Participates in DAP?": 1
     },
     {
+      "Canonical": "http://www.gsadvantage.gov",
       "Domain": "gsadvantage.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "https://www.gsaig.gov",
       "Domain": "gsaig.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://gsaxcess.gov",
       "Domain": "gsaxcess.gov",
       "Participates in DAP?": 1
     },
     {
+      "Canonical": "http://www.guideline.gov",
       "Domain": "guideline.gov",
       "Participates in DAP?": 1
     },
     {
+      "Canonical": "https://www.gwa.gov",
       "Domain": "gwa.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://www.hanford.gov",
       "Domain": "hanford.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://harp.gov",
       "Domain": "harp.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://health.gov",
       "Domain": "health.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "https://www.healthcare.gov",
       "Domain": "healthcare.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://www.healthdata.gov",
       "Domain": "healthdata.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://healthfinder.gov",
       "Domain": "healthfinder.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://www.healthindicators.gov",
       "Domain": "healthindicators.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://healthit.gov",
       "Domain": "healthit.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://www.healthypeople.gov",
       "Domain": "healthypeople.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://helpwithmybank.gov",
       "Domain": "helpwithmybank.gov",
       "Participates in DAP?": 1
     },
     {
+      "Canonical": "http://helpwithmycheckingaccount.gov",
       "Domain": "helpwithmycheckingaccount.gov",
       "Participates in DAP?": 1
     },
     {
+      "Canonical": "http://helpwithmycreditcard.gov",
       "Domain": "helpwithmycreditcard.gov",
       "Participates in DAP?": 1
     },
     {
+      "Canonical": "http://helpwithmycreditcardbank.gov",
       "Domain": "helpwithmycreditcardbank.gov",
       "Participates in DAP?": 1
     },
     {
+      "Canonical": "http://helpwithmymortgage.gov",
       "Domain": "helpwithmymortgage.gov",
       "Participates in DAP?": 1
     },
     {
+      "Canonical": "http://helpwithmymortgagebank.gov",
       "Domain": "helpwithmymortgagebank.gov",
       "Participates in DAP?": 1
     },
     {
+      "Canonical": "http://www.hhs.gov",
       "Domain": "hhs.gov",
       "Participates in DAP?": 1
     },
     {
+      "Canonical": "https://www.hispanicfarmerclaims.gov",
       "Domain": "hispanicfarmerclaims.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://homesales.gov",
       "Domain": "homesales.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://hrsa.gov",
       "Domain": "hrsa.gov",
       "Participates in DAP?": 1
     },
     {
+      "Canonical": "https://hru.gov",
       "Domain": "hru.gov",
       "Participates in DAP?": 1
     },
     {
+      "Canonical": "http://hsa.gov",
       "Domain": "hsa.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "https://hsr.gov",
       "Domain": "hsr.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://hud.gov",
       "Domain": "hud.gov",
       "Participates in DAP?": 1
     },
     {
+      "Canonical": "http://www.hudoig.gov",
       "Domain": "hudoig.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://www.humanrights.gov",
       "Domain": "humanrights.gov",
       "Participates in DAP?": 1
     },
     {
+      "Canonical": "http://hydrogen.gov",
       "Domain": "hydrogen.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "https://www.iad.gov",
       "Domain": "iad.gov",
       "Participates in DAP?": 1
     },
     {
+      "Canonical": "http://www.iaf.gov",
       "Domain": "iaf.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://iarpa-ideas.gov",
       "Domain": "iarpa-ideas.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://www.iarpa.gov",
       "Domain": "iarpa.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://www.iat.gov",
       "Domain": "iat.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "https://www.iawg.gov",
       "Domain": "iawg.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://ibwc.gov",
       "Domain": "ibwc.gov",
       "Participates in DAP?": 1
     },
     {
+      "Canonical": "http://www.ic3.gov",
       "Domain": "ic3.gov",
       "Participates in DAP?": 1
     },
     {
+      "Canonical": "https://www.icass.gov",
       "Domain": "icass.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://icbemp.gov",
       "Domain": "icbemp.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://www.ice.gov",
       "Domain": "ice.gov",
       "Participates in DAP?": 1
     },
     {
+      "Canonical": "http://icjointduty.gov",
       "Domain": "icjointduty.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://idmanagement.gov",
       "Domain": "idmanagement.gov",
       "Participates in DAP?": 1
     },
     {
+      "Canonical": "https://www.ignet.gov",
       "Domain": "ignet.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://www.ihs.gov",
       "Domain": "ihs.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://iiog.gov",
       "Domain": "iiog.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://www.imls.gov",
       "Domain": "imls.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://indianaffairs.gov",
       "Domain": "indianaffairs.gov",
       "Participates in DAP?": 1
     },
     {
+      "Canonical": "http://www.inel.gov",
       "Domain": "inel.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "https://inl.gov",
       "Domain": "inl.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://insurekidsnow.gov",
       "Domain": "insurekidsnow.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "https://www.integrity.gov",
       "Domain": "integrity.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://www.intelink.gov",
       "Domain": "intelink.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://intelligence.gov",
       "Domain": "intelligence.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://www.interior.gov",
       "Domain": "interior.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://invasivespecies.gov",
       "Domain": "invasivespecies.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://www.invasivespeciesinfo.gov",
       "Domain": "invasivespeciesinfo.gov",
       "Participates in DAP?": 1
     },
     {
+      "Canonical": "http://investor.gov",
       "Domain": "investor.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "https://www.ioss.gov",
       "Domain": "ioss.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "https://www.ipac.gov",
       "Domain": "ipac.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://ipcc-wg2.gov",
       "Domain": "ipcc-wg2.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://www.ipp.gov",
       "Domain": "ipp.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://www.iprcenter.gov",
       "Domain": "iprcenter.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://www.irs.gov",
       "Domain": "irs.gov",
       "Participates in DAP?": 1
     },
     {
+      "Canonical": "http://www.irsvideos.gov",
       "Domain": "irsvideos.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://ise.gov",
       "Domain": "ise.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "https://isotope.gov",
       "Domain": "isotope.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "https://isotopes.gov",
       "Domain": "isotopes.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://www.italladdsup.gov",
       "Domain": "italladdsup.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://www.itap.gov",
       "Domain": "itap.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "https://itdashboard.gov",
       "Domain": "itdashboard.gov",
       "Participates in DAP?": 1
     },
     {
+      "Canonical": "http://itds.gov",
       "Domain": "itds.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://www.itis.gov",
       "Domain": "itis.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "https://www.its.gov",
       "Domain": "its.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://www.jamesmadison.gov",
       "Domain": "jamesmadison.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://www.jccs.gov",
       "Domain": "jccs.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://jem.gov",
       "Domain": "jem.gov",
       "Participates in DAP?": 1
     },
     {
+      "Canonical": "http://www.jimmycarterlibrary.gov",
       "Domain": "jimmycarterlibrary.gov",
       "Participates in DAP?": 1
     },
     {
+      "Canonical": "http://www.jobcorps.gov",
       "Domain": "jobcorps.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://www.justice.gov",
       "Domain": "justice.gov",
       "Participates in DAP?": 1
     },
     {
+      "Canonical": "http://juvenilecouncil.gov",
       "Domain": "juvenilecouncil.gov",
       "Participates in DAP?": 1
     },
     {
+      "Canonical": "http://jwod.gov",
       "Domain": "jwod.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://klamathrestoration.gov",
       "Domain": "klamathrestoration.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://www.lacoast.gov",
       "Domain": "lacoast.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://landfire.gov",
       "Domain": "landfire.gov",
       "Participates in DAP?": 1
     },
     {
+      "Canonical": "http://www.landimaging.gov",
       "Domain": "landimaging.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://lanl.gov",
       "Domain": "lanl.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "https://www.latinofarmerclaims.gov",
       "Domain": "latinofarmerclaims.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://www.lbl.gov",
       "Domain": "lbl.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://lca.gov",
       "Domain": "lca.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://www.lcacommons.gov",
       "Domain": "lcacommons.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://www.lcrmscp.gov",
       "Domain": "lcrmscp.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "https://www.learnperformance.gov",
       "Domain": "learnperformance.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://www.lep.gov",
       "Domain": "lep.gov",
       "Participates in DAP?": 1
     },
     {
+      "Canonical": "http://www.letsmove.gov",
       "Domain": "letsmove.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "https://www.llnl.gov",
       "Domain": "llnl.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://lmrcouncil.gov",
       "Domain": "lmrcouncil.gov",
       "Participates in DAP?": 1
     },
     {
+      "Canonical": "http://lmvsci.gov",
       "Domain": "lmvsci.gov",
       "Participates in DAP?": 1
     },
     {
+      "Canonical": "http://locatorplus.gov",
       "Domain": "locatorplus.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://longtermcare.gov",
       "Domain": "longtermcare.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://www.lowermississippivalleyscience.gov",
       "Domain": "lowermississippivalleyscience.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://www.lps.gov",
       "Domain": "lps.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://www.lsc.gov",
       "Domain": "lsc.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "https://www.macpac.gov",
       "Domain": "macpac.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://www.makinghomeaffordable.gov",
       "Domain": "makinghomeaffordable.gov",
       "Participates in DAP?": 1
     },
     {
+      "Canonical": "http://malwareinvestigator.gov",
       "Domain": "malwareinvestigator.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://manufacturing.gov",
       "Domain": "manufacturing.gov",
       "Participates in DAP?": 1
     },
     {
+      "Canonical": "http://www.mapaplanet.gov",
       "Domain": "mapaplanet.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://marine.gov",
       "Domain": "marine.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://marinecadastre.gov",
       "Domain": "marinecadastre.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://www.marview.gov",
       "Domain": "marview.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "https://www.max.gov",
       "Domain": "max.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://www.mbda.gov",
       "Domain": "mbda.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "https://mcc.gov",
       "Domain": "mcc.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://www.mcrmc.gov",
       "Domain": "mcrmc.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://mda.gov",
       "Domain": "mda.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://medicaid.gov",
       "Domain": "medicaid.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://www.medicalcountermeasures.gov",
       "Domain": "medicalcountermeasures.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "https://www.medicalreservecorps.gov",
       "Domain": "medicalreservecorps.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://medicare.gov",
       "Domain": "medicare.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://medpac.gov",
       "Domain": "medpac.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://www.mentalhealth.gov",
       "Domain": "mentalhealth.gov",
       "Participates in DAP?": 1
     },
     {
+      "Canonical": "http://www.mitigationcommission.gov",
       "Domain": "mitigationcommission.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://mmc.gov",
       "Domain": "mmc.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://mms.gov",
       "Domain": "mms.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://moneyfactory.gov",
       "Domain": "moneyfactory.gov",
       "Participates in DAP?": 1
     },
     {
+      "Canonical": "http://www.moneyfactorystore.gov",
       "Domain": "moneyfactorystore.gov",
       "Participates in DAP?": 1
     },
     {
+      "Canonical": "http://www.mrlc.gov",
       "Domain": "mrlc.gov",
       "Participates in DAP?": 1
     },
     {
+      "Canonical": "http://msb.gov",
       "Domain": "msb.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://www.msha.gov",
       "Domain": "msha.gov",
       "Participates in DAP?": 1
     },
     {
+      "Canonical": "http://mspb.gov",
       "Domain": "mspb.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://mtbs.gov",
       "Domain": "mtbs.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://www.mycreditunion.gov",
       "Domain": "mycreditunion.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://myfdicinsurance.gov",
       "Domain": "myfdicinsurance.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "https://mymedicare.gov",
       "Domain": "mymedicare.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://www.mymoney.gov",
       "Domain": "mymoney.gov",
       "Participates in DAP?": 1
     },
     {
+      "Canonical": "http://nafri.gov",
       "Domain": "nafri.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://nagb.gov",
       "Domain": "nagb.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://namus.gov",
       "Domain": "namus.gov",
       "Participates in DAP?": 1
     },
     {
+      "Canonical": "http://nano.gov",
       "Domain": "nano.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://www.nasa.gov",
       "Domain": "nasa.gov",
       "Participates in DAP?": 1
     },
     {
+      "Canonical": "http://nationalbankhelp.gov",
       "Domain": "nationalbankhelp.gov",
       "Participates in DAP?": 1
     },
     {
+      "Canonical": "http://www.nationalgangcenter.gov",
       "Domain": "nationalgangcenter.gov",
       "Participates in DAP?": 1
     },
     {
+      "Canonical": "http://nationalhousing.gov",
       "Domain": "nationalhousing.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://nationalhousinglocator.gov",
       "Domain": "nationalhousinglocator.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://nationalmap.gov",
       "Domain": "nationalmap.gov",
       "Participates in DAP?": 1
     },
     {
+      "Canonical": "http://www.nationalservice.gov",
       "Domain": "nationalservice.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://www.nationsreportcard.gov",
       "Domain": "nationsreportcard.gov",
       "Participates in DAP?": 1
     },
     {
+      "Canonical": "http://www.navycash.gov",
       "Domain": "navycash.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://www.nbc.gov",
       "Domain": "nbc.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://nccrc.gov",
       "Domain": "nccrc.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://www.ncd.gov",
       "Domain": "ncd.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "https://ncirc.gov",
       "Domain": "ncirc.gov",
       "Participates in DAP?": 1
     },
     {
+      "Canonical": "http://ncix.gov",
       "Domain": "ncix.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "https://ncjrs.gov",
       "Domain": "ncjrs.gov",
       "Participates in DAP?": 1
     },
     {
+      "Canonical": "http://www.ncpc.gov",
       "Domain": "ncpc.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://www.ncpw.gov",
       "Domain": "ncpw.gov",
       "Participates in DAP?": 1
     },
     {
+      "Canonical": "http://www.ncrc.gov",
       "Domain": "ncrc.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://www.nctc.gov",
       "Domain": "nctc.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://www.ncua.gov",
       "Domain": "ncua.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://www.ndep.gov",
       "Domain": "ndep.gov",
       "Participates in DAP?": 1
     },
     {
+      "Canonical": "http://www.ndop.gov",
       "Domain": "ndop.gov",
       "Participates in DAP?": 1
     },
     {
+      "Canonical": "http://neglecteddiseases.gov",
       "Domain": "neglecteddiseases.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://www.neh.gov",
       "Domain": "neh.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://nehrp.gov",
       "Domain": "nehrp.gov",
       "Participates in DAP?": 1
     },
     {
+      "Canonical": "http://www.nel.gov",
       "Domain": "nel.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://www.nemi.gov",
       "Domain": "nemi.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://www.nersc.gov",
       "Domain": "nersc.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://www.newmoney.gov",
       "Domain": "newmoney.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "https://nfpors.gov",
       "Domain": "nfpors.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://www.nga.gov",
       "Domain": "nga.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://nhl.gov",
       "Domain": "nhl.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://www.nhtsa.gov",
       "Domain": "nhtsa.gov",
       "Participates in DAP?": 1
     },
     {
+      "Canonical": "http://www.nibin.gov",
       "Domain": "nibin.gov",
       "Participates in DAP?": 1
     },
     {
+      "Canonical": "http://nicic.gov",
       "Domain": "nicic.gov",
       "Participates in DAP?": 1
     },
     {
+      "Canonical": "https://www.niem.gov",
       "Domain": "niem.gov",
       "Participates in DAP?": 1
     },
     {
+      "Canonical": "http://www.nifc.gov",
       "Domain": "nifc.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://niftt.gov",
       "Domain": "niftt.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://nigc.gov",
       "Domain": "nigc.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://nih.gov",
       "Domain": "nih.gov",
       "Participates in DAP?": 1
     },
     {
+      "Canonical": "http://nihseniorhealth.gov",
       "Domain": "nihseniorhealth.gov",
       "Participates in DAP?": 1
     },
     {
+      "Canonical": "http://www.nij.gov",
       "Domain": "nij.gov",
       "Participates in DAP?": 1
     },
     {
+      "Canonical": "http://www.niosh.gov",
       "Domain": "niosh.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://nist.gov",
       "Domain": "nist.gov",
       "Participates in DAP?": 1
     },
     {
+      "Canonical": "https://www.nitrd.gov",
       "Domain": "nitrd.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://nixonlibrary.gov",
       "Domain": "nixonlibrary.gov",
       "Participates in DAP?": 1
     },
     {
+      "Canonical": "http://nlrb.gov",
       "Domain": "nlrb.gov",
       "Participates in DAP?": 1
     },
     {
+      "Canonical": "http://nls.gov",
       "Domain": "nls.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://www.nmb.gov",
       "Domain": "nmb.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://www.nmic.gov",
       "Domain": "nmic.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://nnlm.gov",
       "Domain": "nnlm.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://www.noaa.gov",
       "Domain": "noaa.gov",
       "Participates in DAP?": 1
     },
     {
+      "Canonical": "http://www.nolaenvironmental.gov",
       "Domain": "nolaenvironmental.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "https://www.notalone.gov",
       "Domain": "notalone.gov",
       "Participates in DAP?": 1
     },
     {
+      "Canonical": "http://www.nps.gov",
       "Domain": "nps.gov",
       "Participates in DAP?": 1
     },
     {
+      "Canonical": "http://www.nrc.gov",
       "Domain": "nrc.gov",
       "Participates in DAP?": 1
     },
     {
+      "Canonical": "http://www.nrel.gov",
       "Domain": "nrel.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://nro.gov",
       "Domain": "nro.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://nrojr.gov",
       "Domain": "nrojr.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "https://www.nsa.gov",
       "Domain": "nsa.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://nsep.gov",
       "Domain": "nsep.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://www.nsf.gov",
       "Domain": "nsf.gov",
       "Participates in DAP?": 1
     },
     {
+      "Canonical": "http://www.nsopw.gov",
       "Domain": "nsopw.gov",
       "Participates in DAP?": 1
     },
     {
+      "Canonical": "http://nswp.gov",
       "Domain": "nswp.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://www.ntdprogram.gov",
       "Domain": "ntdprogram.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://www.ntis.gov",
       "Domain": "ntis.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://www.ntsb.gov",
       "Domain": "ntsb.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://www.nutrition.gov",
       "Domain": "nutrition.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "https://www.nwbc.gov",
       "Domain": "nwbc.gov",
       "Participates in DAP?": 1
     },
     {
+      "Canonical": "http://www.nwcg.gov",
       "Domain": "nwcg.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://occ.gov",
       "Domain": "occ.gov",
       "Participates in DAP?": 1
     },
     {
+      "Canonical": "http://occhelps.gov",
       "Domain": "occhelps.gov",
       "Participates in DAP?": 1
     },
     {
+      "Canonical": "http://www.odni.gov",
       "Domain": "odni.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://www.oea.gov",
       "Domain": "oea.gov",
       "Participates in DAP?": 1
     },
     {
+      "Canonical": "http://www.ofcm.gov",
       "Domain": "ofcm.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "https://www.ofda.gov",
       "Domain": "ofda.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://ofee.gov",
       "Domain": "ofee.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://oge.gov",
       "Domain": "oge.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://ojjdp.gov",
       "Domain": "ojjdp.gov",
       "Participates in DAP?": 1
     },
     {
+      "Canonical": "http://ojp.gov",
       "Domain": "ojp.gov",
       "Participates in DAP?": 1
     },
     {
+      "Canonical": "http://www.onguardonline.gov",
       "Domain": "onguardonline.gov",
       "Participates in DAP?": 1
     },
     {
+      "Canonical": "http://onhir.gov",
       "Domain": "onhir.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://onlinewbc.gov",
       "Domain": "onlinewbc.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://onrr.gov",
       "Domain": "onrr.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "https://www.opensource.gov",
       "Domain": "opensource.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "https://www.opic.gov",
       "Domain": "opic.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://www.opm.gov",
       "Domain": "opm.gov",
       "Participates in DAP?": 1
     },
     {
+      "Canonical": "http://www.orau.gov",
       "Domain": "orau.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://www.organdonor.gov",
       "Domain": "organdonor.gov",
       "Participates in DAP?": 1
     },
     {
+      "Canonical": "http://www.ornl.gov",
       "Domain": "ornl.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "https://www.osac.gov",
       "Domain": "osac.gov",
       "Participates in DAP?": 1
     },
     {
+      "Canonical": "https://osc.gov",
       "Domain": "osc.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://osdbu.gov",
       "Domain": "osdbu.gov",
       "Participates in DAP?": 1
     },
     {
+      "Canonical": "https://www.osha.gov",
       "Domain": "osha.gov",
       "Participates in DAP?": 1
     },
     {
+      "Canonical": "http://oshrc.gov",
       "Domain": "oshrc.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://www.osmre.gov",
       "Domain": "osmre.gov",
       "Participates in DAP?": 1
     },
     {
+      "Canonical": "http://www.osti.gov",
       "Domain": "osti.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://ots.gov",
       "Domain": "ots.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://ourdocuments.gov",
       "Domain": "ourdocuments.gov",
       "Participates in DAP?": 1
     },
     {
+      "Canonical": "http://ovc.gov",
       "Domain": "ovc.gov",
       "Participates in DAP?": 1
     },
     {
+      "Canonical": "https://www.ovcttac.gov",
       "Domain": "ovcttac.gov",
       "Participates in DAP?": 1
     },
     {
+      "Canonical": "http://www.papahanaumokuakea.gov",
       "Domain": "papahanaumokuakea.gov",
       "Participates in DAP?": 1
     },
     {
+      "Canonical": "http://www.partner4solutions.gov",
       "Domain": "partner4solutions.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://patriotbonds.gov",
       "Domain": "patriotbonds.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "https://pay.gov",
       "Domain": "pay.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "https://paymentaccuracy.gov",
       "Domain": "paymentaccuracy.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://pbgc.gov",
       "Domain": "pbgc.gov",
       "Participates in DAP?": 1
     },
     {
+      "Canonical": "http://pcah.gov",
       "Domain": "pcah.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "https://pclob.gov",
       "Domain": "pclob.gov",
       "Participates in DAP?": 1
     },
     {
+      "Canonical": "http://peacecore.gov",
       "Domain": "peacecore.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://peacecorp.gov",
       "Domain": "peacecorp.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://www.peacecorps.gov",
       "Domain": "peacecorps.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://www.pepfar.gov",
       "Domain": "pepfar.gov",
       "Participates in DAP?": 1
     },
     {
+      "Canonical": "http://www.performance.gov",
       "Domain": "performance.gov",
       "Participates in DAP?": 1
     },
     {
+      "Canonical": "http://www.phe.gov",
       "Domain": "phe.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "https://pic.gov",
       "Domain": "pic.gov",
       "Participates in DAP?": 1
     },
     {
+      "Canonical": "http://www.plainlanguage.gov",
       "Domain": "plainlanguage.gov",
       "Participates in DAP?": 1
     },
     {
+      "Canonical": "http://pmf.gov",
       "Domain": "pmf.gov",
       "Participates in DAP?": 1
     },
     {
+      "Canonical": "http://pmi.gov",
       "Domain": "pmi.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://www.pnl.gov",
       "Domain": "pnl.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://www.pnnl.gov",
       "Domain": "pnnl.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://www.poolsafely.gov",
       "Domain": "poolsafely.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "https://www.ppirs.gov",
       "Domain": "ppirs.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://www.prc.gov",
       "Domain": "prc.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://preserveamerica.gov",
       "Domain": "preserveamerica.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://www.presidentialserviceawards.gov",
       "Domain": "presidentialserviceawards.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://www.presidio.gov",
       "Domain": "presidio.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://pretrialservices.gov",
       "Domain": "pretrialservices.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://www.protecciondelconsumidor.gov",
       "Domain": "protecciondelconsumidor.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://psa.gov",
       "Domain": "psa.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://www.psc.gov",
       "Domain": "psc.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://pscr.gov",
       "Domain": "pscr.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "https://psob.gov",
       "Domain": "psob.gov",
       "Participates in DAP?": 1
     },
     {
+      "Canonical": "https://www.qatesttwai.gov",
       "Domain": "qatesttwai.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://www.rcfl.gov",
       "Domain": "rcfl.gov",
       "Participates in DAP?": 1
     },
     {
+      "Canonical": "http://www.ready.gov",
       "Domain": "ready.gov",
       "Participates in DAP?": 1
     },
     {
+      "Canonical": "http://reaganlibrary.gov",
       "Domain": "reaganlibrary.gov",
       "Participates in DAP?": 1
     },
     {
+      "Canonical": "http://realestatesales.gov",
       "Domain": "realestatesales.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "https://www.realpropertyprofile.gov",
       "Domain": "realpropertyprofile.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://www.recalls.gov",
       "Domain": "recalls.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://www.recovery.gov",
       "Domain": "recovery.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://recoverymonth.gov",
       "Domain": "recoverymonth.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://www.recreation.gov",
       "Domain": "recreation.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://reginfo.gov",
       "Domain": "reginfo.gov",
       "Participates in DAP?": 1
     },
     {
+      "Canonical": "http://www.regulations.gov",
       "Domain": "regulations.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://relocatefeds.gov",
       "Domain": "relocatefeds.gov",
       "Participates in DAP?": 1
     },
     {
+      "Canonical": "http://reo.gov",
       "Domain": "reo.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://www.research.gov",
       "Domain": "research.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://restorethegulf.gov",
       "Domain": "restorethegulf.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://rivers.gov",
       "Domain": "rivers.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://rocis.gov",
       "Domain": "rocis.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://www.rrb.gov",
       "Domain": "rrb.gov",
       "Participates in DAP?": 1
     },
     {
+      "Canonical": "http://sac.gov",
       "Domain": "sac.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://www.safecom.gov",
       "Domain": "safecom.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://www.safercar.gov",
       "Domain": "safercar.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://www.saferproducts.gov",
       "Domain": "saferproducts.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://safertruck.gov",
       "Domain": "safertruck.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "https://safetyact.gov",
       "Domain": "safetyact.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://www.salmonrecovery.gov",
       "Domain": "salmonrecovery.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "https://www.sam.gov",
       "Domain": "sam.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://www.samhsa.gov",
       "Domain": "samhsa.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://www.sandia.gov",
       "Domain": "sandia.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://savingsbond.gov",
       "Domain": "savingsbond.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://savingsbonds.gov",
       "Domain": "savingsbonds.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://savingsbondwizard.gov",
       "Domain": "savingsbondwizard.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "https://www.sba.gov",
       "Domain": "sba.gov",
       "Participates in DAP?": 1
     },
     {
+      "Canonical": "http://www.sbir.gov",
       "Domain": "sbir.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://www.scidac.gov",
       "Domain": "scidac.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://www.science.gov",
       "Domain": "science.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://www.science360.gov",
       "Domain": "science360.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "https://www.sciencebase.gov",
       "Domain": "sciencebase.gov",
       "Participates in DAP?": 1
     },
     {
+      "Canonical": "http://www.sdr.gov",
       "Domain": "sdr.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://www.sec.gov",
       "Domain": "sec.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://www.secretservice.gov",
       "Domain": "secretservice.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://section508.gov",
       "Domain": "section508.gov",
       "Participates in DAP?": 1
     },
     {
+      "Canonical": "http://segurosocial.gov",
       "Domain": "segurosocial.gov",
       "Participates in DAP?": 1
     },
     {
+      "Canonical": "http://www.selectagents.gov",
       "Domain": "selectagents.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://www.serve.gov",
       "Domain": "serve.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "https://sftool.gov",
       "Domain": "sftool.gov",
       "Participates in DAP?": 1
     },
     {
+      "Canonical": "http://www.sharetheroadsafely.gov",
       "Domain": "sharetheroadsafely.gov",
       "Participates in DAP?": 1
     },
     {
+      "Canonical": "http://sierrawild.gov",
       "Domain": "sierrawild.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://www.sigtarp.gov",
       "Domain": "sigtarp.gov",
       "Participates in DAP?": 1
     },
     {
+      "Canonical": "http://www.siteidiq.gov",
       "Domain": "siteidiq.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://slgs.gov",
       "Domain": "slgs.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://smart.gov",
       "Domain": "smart.gov",
       "Participates in DAP?": 1
     },
     {
+      "Canonical": "http://www.smartcheck.gov",
       "Domain": "smartcheck.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "https://www.smartgrid.gov",
       "Domain": "smartgrid.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://smokefree.gov",
       "Domain": "smokefree.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://snap.gov",
       "Domain": "snap.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://sns.gov",
       "Domain": "sns.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://socialsecurity.gov",
       "Domain": "socialsecurity.gov",
       "Participates in DAP?": 1
     },
     {
+      "Canonical": "http://www.solardecathlon.gov",
       "Domain": "solardecathlon.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://www.srs.gov",
       "Domain": "srs.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://ssa.gov",
       "Domain": "ssa.gov",
       "Participates in DAP?": 1
     },
     {
+      "Canonical": "http://ssab.gov",
       "Domain": "ssab.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://www.sss.gov",
       "Domain": "sss.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://start2farm.gov",
       "Domain": "start2farm.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://www.state.gov",
       "Domain": "state.gov",
       "Participates in DAP?": 1
     },
     {
+      "Canonical": "http://stennis.gov",
       "Domain": "stennis.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://stopalcoholabuse.gov",
       "Domain": "stopalcoholabuse.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://www.stopbullying.gov",
       "Domain": "stopbullying.gov",
       "Participates in DAP?": 1
     },
     {
+      "Canonical": "http://www.stopfraud.gov",
       "Domain": "stopfraud.gov",
       "Participates in DAP?": 1
     },
     {
+      "Canonical": "http://www.stopmedicarefraud.gov",
       "Domain": "stopmedicarefraud.gov",
       "Participates in DAP?": 1
     },
     {
+      "Canonical": "https://strategicsourcing.gov",
       "Domain": "strategicsourcing.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "https://www.studentloans.gov",
       "Domain": "studentloans.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://www.supportthevoter.gov",
       "Domain": "supportthevoter.gov",
       "Participates in DAP?": 1
     },
     {
+      "Canonical": "http://www.surgeongeneral.gov",
       "Domain": "surgeongeneral.gov",
       "Participates in DAP?": 1
     },
     {
+      "Canonical": "http://sustainability.gov",
       "Domain": "sustainability.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://www.sustainablecommunities.gov",
       "Domain": "sustainablecommunities.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://swpa.gov",
       "Domain": "swpa.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "https://www.symbols.gov",
       "Domain": "symbols.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://taaps.gov",
       "Domain": "taaps.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://www.tax.gov",
       "Domain": "tax.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://telework.gov",
       "Domain": "telework.gov",
       "Participates in DAP?": 1
     },
     {
+      "Canonical": "http://thecoolspot.gov",
       "Domain": "thecoolspot.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://thepeoplesgarden.gov",
       "Domain": "thepeoplesgarden.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://time.gov",
       "Domain": "time.gov",
       "Participates in DAP?": 1
     },
     {
+      "Canonical": "http://tissueengineering.gov",
       "Domain": "tissueengineering.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://trade.gov",
       "Domain": "trade.gov",
       "Participates in DAP?": 1
     },
     {
+      "Canonical": "http://www.trafficsafetymarketing.gov",
       "Domain": "trafficsafetymarketing.gov",
       "Participates in DAP?": 1
     },
     {
+      "Canonical": "http://www.transportation.gov",
       "Domain": "transportation.gov",
       "Participates in DAP?": 1
     },
     {
+      "Canonical": "https://www.treaslockbox.gov",
       "Domain": "treaslockbox.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://www.treasury.gov",
       "Domain": "treasury.gov",
       "Participates in DAP?": 1
     },
     {
+      "Canonical": "http://treasuryauctions.gov",
       "Domain": "treasuryauctions.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://treasurydirect.gov",
       "Domain": "treasurydirect.gov",
       "Participates in DAP?": 1
     },
     {
+      "Canonical": "http://treasuryhunt.gov",
       "Domain": "treasuryhunt.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://treasuryscams.gov",
       "Domain": "treasuryscams.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://www.truman.gov",
       "Domain": "truman.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://www.tsa.gov",
       "Domain": "tsa.gov",
       "Participates in DAP?": 1
     },
     {
+      "Canonical": "https://www.tsp.gov",
       "Domain": "tsp.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://www.tsunami.gov",
       "Domain": "tsunami.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://tswg.gov",
       "Domain": "tswg.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://ttb.gov",
       "Domain": "ttb.gov",
       "Participates in DAP?": 1
     },
     {
+      "Canonical": "http://www.ttbonline.gov",
       "Domain": "ttbonline.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://tva.gov",
       "Domain": "tva.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://ucrdatatool.gov",
       "Domain": "ucrdatatool.gov",
       "Participates in DAP?": 1
     },
     {
+      "Canonical": "http://udall.gov",
       "Domain": "udall.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://www.unicor.gov",
       "Domain": "unicor.gov",
       "Participates in DAP?": 1
     },
     {
+      "Canonical": "http://www.unitedweride.gov",
       "Domain": "unitedweride.gov",
       "Participates in DAP?": 1
     },
     {
+      "Canonical": "https://unlocktalent.gov",
       "Domain": "unlocktalent.gov",
       "Participates in DAP?": 1
     },
     {
+      "Canonical": "http://urbanwaters.gov",
       "Domain": "urbanwaters.gov",
       "Participates in DAP?": 1
     },
     {
+      "Canonical": "https://www.us-cert.gov",
       "Domain": "us-cert.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://www.usa.gov",
       "Domain": "usa.gov",
       "Participates in DAP?": 1
     },
     {
+      "Canonical": "http://www.usability.gov",
       "Domain": "usability.gov",
       "Participates in DAP?": 1
     },
     {
+      "Canonical": "http://www.usaid.gov",
       "Domain": "usaid.gov",
       "Participates in DAP?": 1
     },
     {
+      "Canonical": "http://www.usaidallnet.gov",
       "Domain": "usaidallnet.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "https://www.usajobs.gov",
       "Domain": "usajobs.gov",
       "Participates in DAP?": 1
     },
     {
+      "Canonical": "https://usalearning.gov",
       "Domain": "usalearning.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://www.usandc.gov",
       "Domain": "usandc.gov",
       "Participates in DAP?": 1
     },
     {
+      "Canonical": "http://usap.gov",
       "Domain": "usap.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://www.usaperformance.gov",
       "Domain": "usaperformance.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "https://www.usaspending.gov",
       "Domain": "usaspending.gov",
       "Participates in DAP?": 1
     },
     {
+      "Canonical": "http://www.usbr.gov",
       "Domain": "usbr.gov",
       "Participates in DAP?": 1
     },
     {
+      "Canonical": "http://www.uscirf.gov",
       "Domain": "uscirf.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://www.uscis.gov",
       "Domain": "uscis.gov",
       "Participates in DAP?": 1
     },
     {
+      "Canonical": "http://www.usda.gov",
       "Domain": "usda.gov",
       "Participates in DAP?": 1
     },
     {
+      "Canonical": "http://usdebitcard.gov",
       "Domain": "usdebitcard.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://usembassy-mexico.gov",
       "Domain": "usembassy-mexico.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://www.usembassy.gov",
       "Domain": "usembassy.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://usgs.gov",
       "Domain": "usgs.gov",
       "Participates in DAP?": 1
     },
     {
+      "Canonical": "http://usich.gov",
       "Domain": "usich.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://www.usicn.gov",
       "Domain": "usicn.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://usint.gov",
       "Domain": "usint.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://usitc.gov",
       "Domain": "usitc.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://www.usmarshals.gov",
       "Domain": "usmarshals.gov",
       "Participates in DAP?": 1
     },
     {
+      "Canonical": "http://www.usmint.gov",
       "Domain": "usmint.gov",
       "Participates in DAP?": 1
     },
     {
+      "Canonical": "http://usmission.gov",
       "Domain": "usmission.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://usphs.gov",
       "Domain": "usphs.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://www.uspis.gov",
       "Domain": "uspis.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "https://uspsoig.gov",
       "Domain": "uspsoig.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://www.uspto.gov",
       "Domain": "uspto.gov",
       "Participates in DAP?": 1
     },
     {
+      "Canonical": "http://ustda.gov",
       "Domain": "ustda.gov",
       "Participates in DAP?": 1
     },
     {
+      "Canonical": "https://ustr.gov",
       "Domain": "ustr.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://www.utahfireinfo.gov",
       "Domain": "utahfireinfo.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://va.gov",
       "Domain": "va.gov",
       "Participates in DAP?": 1
     },
     {
+      "Canonical": "http://www.vaccines.gov",
       "Domain": "vaccines.gov",
       "Participates in DAP?": 1
     },
     {
+      "Canonical": "http://vallescaldera.gov",
       "Domain": "vallescaldera.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://www.vcf.gov",
       "Domain": "vcf.gov",
       "Participates in DAP?": 1
     },
     {
+      "Canonical": "http://vef.gov",
       "Domain": "vef.gov",
       "Participates in DAP?": 1
     },
     {
+      "Canonical": "http://www.vehiclehistory.gov",
       "Domain": "vehiclehistory.gov",
       "Participates in DAP?": 1
     },
     {
+      "Canonical": "http://www.vetbiz.gov",
       "Domain": "vetbiz.gov",
       "Participates in DAP?": 1
     },
     {
+      "Canonical": "http://www.vistacampus.gov",
       "Domain": "vistacampus.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://volunteer.gov",
       "Domain": "volunteer.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://www.volunteeringinamerica.gov",
       "Domain": "volunteeringinamerica.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://www.wapa.gov",
       "Domain": "wapa.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://watermonitor.gov",
       "Domain": "watermonitor.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://wdol.gov",
       "Domain": "wdol.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://www.weather.gov",
       "Domain": "weather.gov",
       "Participates in DAP?": 1
     },
     {
+      "Canonical": "http://webharvest.gov",
       "Domain": "webharvest.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://wethepeople.gov",
       "Domain": "wethepeople.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://www.whistleblowers.gov",
       "Domain": "whistleblowers.gov",
       "Participates in DAP?": 1
     },
     {
+      "Canonical": "https://www.whitehouse.gov",
       "Domain": "whitehouse.gov",
       "Participates in DAP?": 1
     },
     {
+      "Canonical": "http://whitehouseconferenceonaging.gov",
       "Domain": "whitehouseconferenceonaging.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://www.wildfire.gov",
       "Domain": "wildfire.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://www.wildlifeadaptationstrategy.gov",
       "Domain": "wildlifeadaptationstrategy.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://wizard.gov",
       "Domain": "wizard.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "https://www.wlci.gov",
       "Domain": "wlci.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "https://www.womenfarmerclaims.gov",
       "Domain": "womenfarmerclaims.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://womenshealth.gov",
       "Domain": "womenshealth.gov",
       "Participates in DAP?": 1
     },
     {
+      "Canonical": "https://www.workplace.gov",
       "Domain": "workplace.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://worldwar1centennial.gov",
       "Domain": "worldwar1centennial.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "https://www.wrp.gov",
       "Domain": "wrp.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://ymp.gov",
       "Domain": "ymp.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "https://youthgo.gov",
       "Domain": "youthgo.gov",
       "Participates in DAP?": 0
     },
     {
+      "Canonical": "http://www.youthrules.gov",
       "Domain": "youthrules.gov",
       "Participates in DAP?": 0
     }

--- a/assets/data/tables/https/domains.json
+++ b/assets/data/tables/https/domains.json
@@ -1,6 +1,7 @@
 {
   "data": [
     {
+      "Canonical": "http://www.18f.gov",
       "Domain": "18f.gov",
       "HTTPS Enabled?": 2,
       "HTTPS Enforced?": 1,
@@ -8,6 +9,7 @@
       "Strict Transport Security (HSTS)": 1
     },
     {
+      "Canonical": "http://404.gov",
       "Domain": "404.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -15,6 +17,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://9-11commission.gov",
       "Domain": "9-11commission.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -22,6 +25,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://911.gov",
       "Domain": "911.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -29,6 +33,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://911commission.gov",
       "Domain": "911commission.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -36,6 +41,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.aapi.gov",
       "Domain": "aapi.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -43,6 +49,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.abandonedmines.gov",
       "Domain": "abandonedmines.gov",
       "HTTPS Enabled?": 2,
       "HTTPS Enforced?": 1,
@@ -50,6 +57,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "http://abilityone.gov",
       "Domain": "abilityone.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -57,6 +65,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://abmc.gov",
       "Domain": "abmc.gov",
       "HTTPS Enabled?": 1,
       "HTTPS Enforced?": 1,
@@ -64,6 +73,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "http://www.access-board.gov",
       "Domain": "access-board.gov",
       "HTTPS Enabled?": 2,
       "HTTPS Enforced?": 1,
@@ -71,6 +81,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "http://www.acf.gov",
       "Domain": "acf.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -78,6 +89,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://achp.gov",
       "Domain": "achp.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -85,6 +97,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://acl.gov",
       "Domain": "acl.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -92,6 +105,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "https://www.acquisition.gov",
       "Domain": "acquisition.gov",
       "HTTPS Enabled?": 1,
       "HTTPS Enforced?": 3,
@@ -99,6 +113,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "https://www.acus.gov",
       "Domain": "acus.gov",
       "HTTPS Enabled?": 2,
       "HTTPS Enforced?": 3,
@@ -106,6 +121,7 @@
       "Strict Transport Security (HSTS)": 3
     },
     {
+      "Canonical": "http://acwi.gov",
       "Domain": "acwi.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -113,6 +129,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.ada.gov",
       "Domain": "ada.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -120,6 +137,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://adlnet.gov",
       "Domain": "adlnet.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -127,6 +145,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.admongo.gov",
       "Domain": "admongo.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -134,6 +153,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.adr.gov",
       "Domain": "adr.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -141,6 +161,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.advantage.gov",
       "Domain": "advantage.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -148,6 +169,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "https://afadvantage.gov",
       "Domain": "afadvantage.gov",
       "HTTPS Enabled?": 2,
       "HTTPS Enforced?": 3,
@@ -155,6 +177,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "http://www.aff.gov",
       "Domain": "aff.gov",
       "HTTPS Enabled?": 2,
       "HTTPS Enforced?": 1,
@@ -162,6 +185,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "https://www.afrh.gov",
       "Domain": "afrh.gov",
       "HTTPS Enabled?": 1,
       "HTTPS Enforced?": 3,
@@ -169,6 +193,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "http://africanamericanhistorymonth.gov",
       "Domain": "africanamericanhistorymonth.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -176,6 +201,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.afterschool.gov",
       "Domain": "afterschool.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -183,6 +209,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.agingstats.gov",
       "Domain": "agingstats.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -190,6 +217,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.ahcpr.gov",
       "Domain": "ahcpr.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -197,6 +225,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.ahrq.gov",
       "Domain": "ahrq.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -204,6 +233,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "https://aids.gov",
       "Domain": "aids.gov",
       "HTTPS Enabled?": 2,
       "HTTPS Enforced?": 3,
@@ -211,6 +241,7 @@
       "Strict Transport Security (HSTS)": 3
     },
     {
+      "Canonical": "http://airnow.gov",
       "Domain": "airnow.gov",
       "HTTPS Enabled?": 1,
       "HTTPS Enforced?": 1,
@@ -218,6 +249,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "http://alaskacenters.gov",
       "Domain": "alaskacenters.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -225,6 +257,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.alertaenlinea.gov",
       "Domain": "alertaenlinea.gov",
       "HTTPS Enabled?": 2,
       "HTTPS Enforced?": 1,
@@ -232,6 +265,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "http://www.altusandc.gov",
       "Domain": "altusandc.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -239,6 +273,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://alzheimers.gov",
       "Domain": "alzheimers.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -246,6 +281,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "https://www.ama.gov",
       "Domain": "ama.gov",
       "HTTPS Enabled?": 1,
       "HTTPS Enforced?": 3,
@@ -253,6 +289,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "http://amberalert.gov",
       "Domain": "amberalert.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -260,6 +297,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.america.gov",
       "Domain": "america.gov",
       "HTTPS Enabled?": 1,
       "HTTPS Enforced?": 1,
@@ -267,6 +305,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "http://www.americanjobcenter.gov",
       "Domain": "americanjobcenter.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -274,6 +313,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://americanlatinomuseum.gov",
       "Domain": "americanlatinomuseum.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -281,6 +321,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.americanmemory.gov",
       "Domain": "americanmemory.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -288,6 +329,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.americasgreatoutdoors.gov",
       "Domain": "americasgreatoutdoors.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -295,6 +337,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.americasheroesatwork.gov",
       "Domain": "americasheroesatwork.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -302,6 +345,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.americaslibrary.gov",
       "Domain": "americaslibrary.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -309,6 +353,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.americasstory.gov",
       "Domain": "americasstory.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -316,6 +361,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.americastory.gov",
       "Domain": "americastory.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -323,6 +369,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.americathebeautifulquarters.gov",
       "Domain": "americathebeautifulquarters.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -330,6 +377,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.americore.gov",
       "Domain": "americore.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -337,6 +385,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.americorp.gov",
       "Domain": "americorp.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -344,6 +393,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.americorps.gov",
       "Domain": "americorps.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -351,6 +401,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.americorpsconnect.gov",
       "Domain": "americorpsconnect.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -358,6 +409,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.americorpsweek.gov",
       "Domain": "americorpsweek.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -365,6 +417,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "https://www.ameslab.gov",
       "Domain": "ameslab.gov",
       "HTTPS Enabled?": 2,
       "HTTPS Enforced?": 3,
@@ -372,6 +425,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "http://amtrakoig.gov",
       "Domain": "amtrakoig.gov",
       "HTTPS Enabled?": 1,
       "HTTPS Enforced?": 1,
@@ -379,6 +433,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "http://www.anl.gov",
       "Domain": "anl.gov",
       "HTTPS Enabled?": 2,
       "HTTPS Enforced?": 0,
@@ -386,6 +441,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "http://www.annualcreditreport.gov",
       "Domain": "annualcreditreport.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -393,6 +449,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.anstaskforce.gov",
       "Domain": "anstaskforce.gov",
       "HTTPS Enabled?": 1,
       "HTTPS Enforced?": 1,
@@ -400,6 +457,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "http://aoa.gov",
       "Domain": "aoa.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -407,6 +465,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.aoc.gov",
       "Domain": "aoc.gov",
       "HTTPS Enabled?": 2,
       "HTTPS Enforced?": 0,
@@ -414,6 +473,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "http://www.ap.gov",
       "Domain": "ap.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -421,6 +481,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "https://www.applicationmanager.gov",
       "Domain": "applicationmanager.gov",
       "HTTPS Enabled?": 2,
       "HTTPS Enforced?": 3,
@@ -428,6 +489,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "http://apps.gov",
       "Domain": "apps.gov",
       "HTTPS Enabled?": 1,
       "HTTPS Enforced?": 1,
@@ -435,6 +497,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "http://www.arc.gov",
       "Domain": "arc.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -442,6 +505,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://archives.gov",
       "Domain": "archives.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -449,6 +513,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://arctic.gov",
       "Domain": "arctic.gov",
       "HTTPS Enabled?": 1,
       "HTTPS Enforced?": 1,
@@ -456,6 +521,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "http://arcticgas.gov",
       "Domain": "arcticgas.gov",
       "HTTPS Enabled?": 1,
       "HTTPS Enforced?": 1,
@@ -463,6 +529,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "http://www.arm.gov",
       "Domain": "arm.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -470,6 +537,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.ars-grin.gov",
       "Domain": "ars-grin.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -477,6 +545,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://arts.gov",
       "Domain": "arts.gov",
       "HTTPS Enabled?": 1,
       "HTTPS Enforced?": 1,
@@ -484,6 +553,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "https://www.asap.gov",
       "Domain": "asap.gov",
       "HTTPS Enabled?": 1,
       "HTTPS Enforced?": 3,
@@ -491,6 +561,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "https://www.asc.gov",
       "Domain": "asc.gov",
       "HTTPS Enabled?": 2,
       "HTTPS Enforced?": 3,
@@ -498,6 +569,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "http://asianpacificheritage.gov",
       "Domain": "asianpacificheritage.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -505,6 +577,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.askkaren.gov",
       "Domain": "askkaren.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -512,6 +585,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.astrongmiddleclass.gov",
       "Domain": "astrongmiddleclass.gov",
       "HTTPS Enabled?": 2,
       "HTTPS Enforced?": 1,
@@ -519,6 +593,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "http://www.atf.gov",
       "Domain": "atf.gov",
       "HTTPS Enabled?": 2,
       "HTTPS Enforced?": 1,
@@ -526,6 +601,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "http://www.atvsafety.gov",
       "Domain": "atvsafety.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -533,6 +609,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.autocommunities.gov",
       "Domain": "autocommunities.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -540,6 +617,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://aviationweather.gov",
       "Domain": "aviationweather.gov",
       "HTTPS Enabled?": 2,
       "HTTPS Enforced?": 1,
@@ -547,6 +625,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "http://ayudaconmibanco.gov",
       "Domain": "ayudaconmibanco.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -554,6 +633,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.bam.gov",
       "Domain": "bam.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -561,6 +641,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://bankanswers.gov",
       "Domain": "bankanswers.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -568,6 +649,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://bankcustomer.gov",
       "Domain": "bankcustomer.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -575,6 +657,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://bankcustomerassistance.gov",
       "Domain": "bankcustomerassistance.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -582,6 +665,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://bankhelp.gov",
       "Domain": "bankhelp.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -589,6 +673,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://banknet.gov",
       "Domain": "banknet.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -596,6 +681,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.bankruptcy.gov",
       "Domain": "bankruptcy.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -603,6 +689,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.bbg.gov",
       "Domain": "bbg.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -610,6 +697,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.bcfp.gov",
       "Domain": "bcfp.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -617,6 +705,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://bea.gov",
       "Domain": "bea.gov",
       "HTTPS Enabled?": 2,
       "HTTPS Enforced?": 1,
@@ -624,6 +713,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "http://www.befoodsafe.gov",
       "Domain": "befoodsafe.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -631,6 +721,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.benefits.gov",
       "Domain": "benefits.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -638,6 +729,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://bep.gov",
       "Domain": "bep.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -645,6 +737,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.bestbonesforever.gov",
       "Domain": "bestbonesforever.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -652,6 +745,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.betobaccofree.gov",
       "Domain": "betobaccofree.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -659,6 +753,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.bfelob.gov",
       "Domain": "bfelob.gov",
       "HTTPS Enabled?": 2,
       "HTTPS Enforced?": 1,
@@ -666,6 +761,7 @@
       "Strict Transport Security (HSTS)": 3
     },
     {
+      "Canonical": "https://bfem.gov",
       "Domain": "bfem.gov",
       "HTTPS Enabled?": 2,
       "HTTPS Enforced?": 3,
@@ -673,6 +769,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "http://bia.gov",
       "Domain": "bia.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -680,6 +777,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.bioeco.gov",
       "Domain": "bioeco.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -687,6 +785,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://bioethics.gov",
       "Domain": "bioethics.gov",
       "HTTPS Enabled?": 1,
       "HTTPS Enforced?": 1,
@@ -694,6 +793,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "http://biomassboard.gov",
       "Domain": "biomassboard.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -701,6 +801,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.biometriccoe.gov",
       "Domain": "biometriccoe.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -708,6 +809,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://biometrics.gov",
       "Domain": "biometrics.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -715,6 +817,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://biopreferred.gov",
       "Domain": "biopreferred.gov",
       "HTTPS Enabled?": 1,
       "HTTPS Enforced?": 1,
@@ -722,6 +825,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "https://www.bja.gov",
       "Domain": "bja.gov",
       "HTTPS Enabled?": 2,
       "HTTPS Enforced?": 3,
@@ -729,6 +833,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "http://bjs.gov",
       "Domain": "bjs.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -736,6 +841,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.bldrdoc.gov",
       "Domain": "bldrdoc.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -743,6 +849,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.blm.gov",
       "Domain": "blm.gov",
       "HTTPS Enabled?": 2,
       "HTTPS Enforced?": 0,
@@ -750,6 +857,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "http://blmntl.gov",
       "Domain": "blmntl.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -757,6 +865,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.bls.gov",
       "Domain": "bls.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -764,6 +873,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.bnl.gov",
       "Domain": "bnl.gov",
       "HTTPS Enabled?": 2,
       "HTTPS Enforced?": 0,
@@ -771,6 +881,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "http://www.boem.gov",
       "Domain": "boem.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -778,6 +889,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://boemre.gov",
       "Domain": "boemre.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -785,6 +897,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://bondpro.gov",
       "Domain": "bondpro.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -792,6 +905,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.bop.gov",
       "Domain": "bop.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -799,6 +913,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.bpa.gov",
       "Domain": "bpa.gov",
       "HTTPS Enabled?": 2,
       "HTTPS Enforced?": 1,
@@ -806,6 +921,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "http://brac.gov",
       "Domain": "brac.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -813,6 +929,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.broadband.gov",
       "Domain": "broadband.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -820,6 +937,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://broadbandmap.gov",
       "Domain": "broadbandmap.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -827,6 +945,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.browsetopics.gov",
       "Domain": "browsetopics.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -834,6 +953,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.bsee.gov",
       "Domain": "bsee.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -841,6 +961,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.bts.gov",
       "Domain": "bts.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -848,6 +969,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.budget.gov",
       "Domain": "budget.gov",
       "HTTPS Enabled?": 2,
       "HTTPS Enforced?": 1,
@@ -855,6 +977,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "http://www.buildingamerica.gov",
       "Domain": "buildingamerica.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -862,6 +985,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.business.gov",
       "Domain": "business.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -869,6 +993,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.businessusa.gov",
       "Domain": "businessusa.gov",
       "HTTPS Enabled?": 2,
       "HTTPS Enforced?": 1,
@@ -876,6 +1001,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "http://buyaccessible.gov",
       "Domain": "buyaccessible.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -883,6 +1009,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://buyusa.gov",
       "Domain": "buyusa.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -890,6 +1017,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.c3.gov",
       "Domain": "c3.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -897,6 +1025,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.cancer.gov",
       "Domain": "cancer.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -904,6 +1033,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.cancernet.gov",
       "Domain": "cancernet.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -911,6 +1041,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "https://cao.gov",
       "Domain": "cao.gov",
       "HTTPS Enabled?": 2,
       "HTTPS Enforced?": 3,
@@ -918,6 +1049,7 @@
       "Strict Transport Security (HSTS)": 3
     },
     {
+      "Canonical": "http://capitol.gov",
       "Domain": "capitol.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -925,6 +1057,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.capitolflags.gov",
       "Domain": "capitolflags.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -932,6 +1065,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.capitolhill.gov",
       "Domain": "capitolhill.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -939,6 +1073,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.capnhq.gov",
       "Domain": "capnhq.gov",
       "HTTPS Enabled?": 2,
       "HTTPS Enforced?": 1,
@@ -946,6 +1081,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "http://www.carboncyclescience.gov",
       "Domain": "carboncyclescience.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -953,6 +1089,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.casl.gov",
       "Domain": "casl.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -960,6 +1097,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://cbca.gov",
       "Domain": "cbca.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -967,6 +1105,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.cbo.gov",
       "Domain": "cbo.gov",
       "HTTPS Enabled?": 2,
       "HTTPS Enforced?": 1,
@@ -974,6 +1113,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "http://cbonews.gov",
       "Domain": "cbonews.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -981,6 +1121,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.cbp.gov",
       "Domain": "cbp.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -988,6 +1129,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://ccac.gov",
       "Domain": "ccac.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -995,6 +1137,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.ccr.gov",
       "Domain": "ccr.gov",
       "HTTPS Enabled?": 1,
       "HTTPS Enforced?": 1,
@@ -1002,6 +1145,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "http://www.cdc.gov",
       "Domain": "cdc.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -1009,6 +1153,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.cdco.gov",
       "Domain": "cdco.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -1016,6 +1161,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://cdfifund.gov",
       "Domain": "cdfifund.gov",
       "HTTPS Enabled?": 1,
       "HTTPS Enforced?": 1,
@@ -1023,6 +1169,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "http://www.cebaf.gov",
       "Domain": "cebaf.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -1030,6 +1177,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.cecc.gov",
       "Domain": "cecc.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -1037,6 +1185,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://cendi.gov",
       "Domain": "cendi.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -1044,6 +1193,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://census.gov",
       "Domain": "census.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -1051,6 +1201,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://cfa.gov",
       "Domain": "cfa.gov",
       "HTTPS Enabled?": 2,
       "HTTPS Enforced?": 1,
@@ -1058,6 +1209,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "https://www.cfda.gov",
       "Domain": "cfda.gov",
       "HTTPS Enabled?": 1,
       "HTTPS Enforced?": 3,
@@ -1065,6 +1217,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "http://www.cflhd.gov",
       "Domain": "cflhd.gov",
       "HTTPS Enabled?": 1,
       "HTTPS Enforced?": 1,
@@ -1072,6 +1225,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "https://cfo.gov",
       "Domain": "cfo.gov",
       "HTTPS Enabled?": 2,
       "HTTPS Enforced?": 3,
@@ -1079,6 +1233,7 @@
       "Strict Transport Security (HSTS)": 3
     },
     {
+      "Canonical": "http://www.cfpa.gov",
       "Domain": "cfpa.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -1086,6 +1241,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.cfpb.gov",
       "Domain": "cfpb.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -1093,6 +1249,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.cftc.gov",
       "Domain": "cftc.gov",
       "HTTPS Enabled?": 1,
       "HTTPS Enforced?": 0,
@@ -1100,6 +1257,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "http://www.challenge.gov",
       "Domain": "challenge.gov",
       "HTTPS Enabled?": 2,
       "HTTPS Enforced?": 1,
@@ -1107,6 +1265,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "http://www.challenges.gov",
       "Domain": "challenges.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -1114,6 +1273,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://change.gov",
       "Domain": "change.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -1121,6 +1281,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://chcoc.gov",
       "Domain": "chcoc.gov",
       "HTTPS Enabled?": 2,
       "HTTPS Enforced?": 1,
@@ -1128,6 +1289,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "http://www.chemsafety.gov",
       "Domain": "chemsafety.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -1135,6 +1297,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.childreninadversity.gov",
       "Domain": "childreninadversity.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -1142,6 +1305,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.childstats.gov",
       "Domain": "childstats.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -1149,6 +1313,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "https://childwelfare.gov",
       "Domain": "childwelfare.gov",
       "HTTPS Enabled?": 2,
       "HTTPS Enforced?": 3,
@@ -1156,6 +1321,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "http://chinacommission.gov",
       "Domain": "chinacommission.gov",
       "HTTPS Enabled?": 1,
       "HTTPS Enforced?": 1,
@@ -1163,6 +1329,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "http://choosemyplate.gov",
       "Domain": "choosemyplate.gov",
       "HTTPS Enabled?": 1,
       "HTTPS Enforced?": 1,
@@ -1170,6 +1337,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "http://www.christophercolumbusfoundation.gov",
       "Domain": "christophercolumbusfoundation.gov",
       "HTTPS Enabled?": 2,
       "HTTPS Enforced?": 1,
@@ -1177,6 +1345,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "https://www.cia.gov",
       "Domain": "cia.gov",
       "HTTPS Enabled?": 2,
       "HTTPS Enforced?": 3,
@@ -1184,6 +1353,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "https://cio.gov",
       "Domain": "cio.gov",
       "HTTPS Enabled?": 2,
       "HTTPS Enforced?": 3,
@@ -1191,6 +1361,7 @@
       "Strict Transport Security (HSTS)": 3
     },
     {
+      "Canonical": "http://www.citizencorps.gov",
       "Domain": "citizencorps.gov",
       "HTTPS Enabled?": 2,
       "HTTPS Enforced?": 1,
@@ -1198,6 +1369,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "http://www.citizens.gov",
       "Domain": "citizens.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -1205,6 +1377,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://civilianresponsecorps.gov",
       "Domain": "civilianresponsecorps.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -1212,6 +1385,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://civilrightsusa.gov",
       "Domain": "civilrightsusa.gov",
       "HTTPS Enabled?": 1,
       "HTTPS Enforced?": 1,
@@ -1219,6 +1393,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "http://climate.gov",
       "Domain": "climate.gov",
       "HTTPS Enabled?": 2,
       "HTTPS Enforced?": 1,
@@ -1226,6 +1401,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "http://www.clinicaltrial.gov",
       "Domain": "clinicaltrial.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -1233,6 +1409,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "https://clinicaltrials.gov",
       "Domain": "clinicaltrials.gov",
       "HTTPS Enabled?": 2,
       "HTTPS Enforced?": 3,
@@ -1240,6 +1417,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "http://clintonlibrary.gov",
       "Domain": "clintonlibrary.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -1247,6 +1425,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.clubdrugs.gov",
       "Domain": "clubdrugs.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -1254,6 +1433,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://cms.gov",
       "Domain": "cms.gov",
       "HTTPS Enabled?": 2,
       "HTTPS Enforced?": 1,
@@ -1261,6 +1441,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "http://www.cmts.gov",
       "Domain": "cmts.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -1268,6 +1449,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.cncs.gov",
       "Domain": "cncs.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -1275,6 +1457,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://cncsoig.gov",
       "Domain": "cncsoig.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -1282,6 +1465,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.cns.gov",
       "Domain": "cns.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -1289,6 +1473,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "https://www.cnss.gov",
       "Domain": "cnss.gov",
       "HTTPS Enabled?": 1,
       "HTTPS Enforced?": 3,
@@ -1296,6 +1481,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "http://coast2050.gov",
       "Domain": "coast2050.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -1303,6 +1489,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://coastalamerica.gov",
       "Domain": "coastalamerica.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -1310,6 +1497,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.college.gov",
       "Domain": "college.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -1317,6 +1505,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://collegedrinkingprevention.gov",
       "Domain": "collegedrinkingprevention.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -1324,6 +1513,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.collegenavigator.gov",
       "Domain": "collegenavigator.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -1331,6 +1521,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.commerce.gov",
       "Domain": "commerce.gov",
       "HTTPS Enabled?": 2,
       "HTTPS Enforced?": 0,
@@ -1338,6 +1529,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "http://www.complaintreferralexpress.gov",
       "Domain": "complaintreferralexpress.gov",
       "HTTPS Enabled?": 2,
       "HTTPS Enforced?": 1,
@@ -1345,6 +1537,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "http://www.compliance.gov",
       "Domain": "compliance.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -1352,6 +1545,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://comptrollerofthecurrency.gov",
       "Domain": "comptrollerofthecurrency.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -1359,6 +1553,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.computers4learning.gov",
       "Domain": "computers4learning.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -1366,6 +1561,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://computersforlearning.gov",
       "Domain": "computersforlearning.gov",
       "HTTPS Enabled?": 2,
       "HTTPS Enforced?": 1,
@@ -1373,6 +1569,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "https://congress.gov",
       "Domain": "congress.gov",
       "HTTPS Enabled?": 2,
       "HTTPS Enforced?": 3,
@@ -1380,6 +1577,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "http://www.congressionaldirectory.gov",
       "Domain": "congressionaldirectory.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -1387,6 +1585,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.congressionalrecord.gov",
       "Domain": "congressionalrecord.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -1394,6 +1593,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.connect.gov",
       "Domain": "connect.gov",
       "HTTPS Enabled?": 2,
       "HTTPS Enforced?": 1,
@@ -1401,6 +1601,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "http://www.consumer.gov",
       "Domain": "consumer.gov",
       "HTTPS Enabled?": 2,
       "HTTPS Enforced?": 1,
@@ -1408,6 +1609,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "http://www.consumeraction.gov",
       "Domain": "consumeraction.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -1415,6 +1617,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.consumerbureau.gov",
       "Domain": "consumerbureau.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -1422,6 +1625,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.consumerfinance.gov",
       "Domain": "consumerfinance.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -1429,6 +1633,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.consumerfinancial.gov",
       "Domain": "consumerfinancial.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -1436,6 +1641,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.consumerfinancialbureau.gov",
       "Domain": "consumerfinancialbureau.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -1443,6 +1649,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.consumerfinancialprotectionbureau.gov",
       "Domain": "consumerfinancialprotectionbureau.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -1450,6 +1657,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.consumerprotection.gov",
       "Domain": "consumerprotection.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -1457,6 +1665,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.consumerprotectionbureau.gov",
       "Domain": "consumerprotectionbureau.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -1464,6 +1673,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "https://consumersentinel.gov",
       "Domain": "consumersentinel.gov",
       "HTTPS Enabled?": 2,
       "HTTPS Enforced?": 3,
@@ -1471,6 +1681,7 @@
       "Strict Transport Security (HSTS)": 3
     },
     {
+      "Canonical": "http://www.consumidor.gov",
       "Domain": "consumidor.gov",
       "HTTPS Enabled?": 2,
       "HTTPS Enforced?": 1,
@@ -1478,6 +1689,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "http://continentalshelf.gov",
       "Domain": "continentalshelf.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -1485,6 +1697,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "https://www.contractdirectory.gov",
       "Domain": "contractdirectory.gov",
       "HTTPS Enabled?": 1,
       "HTTPS Enforced?": 3,
@@ -1492,6 +1705,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "http://www.coop-uspto.gov",
       "Domain": "coop-uspto.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -1499,6 +1713,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://copyright.gov",
       "Domain": "copyright.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -1506,6 +1721,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.coralreef.gov",
       "Domain": "coralreef.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -1513,6 +1729,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.cosponsor.gov",
       "Domain": "cosponsor.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -1520,6 +1737,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.counterwmd.gov",
       "Domain": "counterwmd.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -1527,6 +1745,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "https://www.cpars.gov",
       "Domain": "cpars.gov",
       "HTTPS Enabled?": 1,
       "HTTPS Enforced?": 3,
@@ -1534,6 +1753,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "https://www.cpnireporting.gov",
       "Domain": "cpnireporting.gov",
       "HTTPS Enabled?": 1,
       "HTTPS Enforced?": 3,
@@ -1541,6 +1761,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "http://www.cpsc.gov",
       "Domain": "cpsc.gov",
       "HTTPS Enabled?": 2,
       "HTTPS Enforced?": 1,
@@ -1548,6 +1769,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "http://www.crimesolutions.gov",
       "Domain": "crimesolutions.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -1555,6 +1777,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://crimevictims.gov",
       "Domain": "crimevictims.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -1562,6 +1785,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.crt2014-2024review.gov",
       "Domain": "crt2014-2024review.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -1569,6 +1793,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.csb.gov",
       "Domain": "csb.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -1576,6 +1801,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://csce.gov",
       "Domain": "csce.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -1583,6 +1809,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.csosa.fed.us",
       "Domain": "csosa.fed.us",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -1590,6 +1817,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://csosa.gov",
       "Domain": "csosa.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -1597,6 +1825,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://cttso.gov",
       "Domain": "cttso.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -1604,6 +1833,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "https://www.cuidadodesalud.gov",
       "Domain": "cuidadodesalud.gov",
       "HTTPS Enabled?": 2,
       "HTTPS Enforced?": 3,
@@ -1611,6 +1841,7 @@
       "Strict Transport Security (HSTS)": 1
     },
     {
+      "Canonical": "http://www.cupcao.gov",
       "Domain": "cupcao.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -1618,6 +1849,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://cwc.gov",
       "Domain": "cwc.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -1625,6 +1857,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.cybercrime.gov",
       "Domain": "cybercrime.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -1632,6 +1865,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.data.gov",
       "Domain": "data.gov",
       "HTTPS Enabled?": 2,
       "HTTPS Enforced?": 1,
@@ -1639,6 +1873,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "http://www.dcsc.gov",
       "Domain": "dcsc.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -1646,6 +1881,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.dea.gov",
       "Domain": "dea.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -1653,6 +1889,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://deadiversion.gov",
       "Domain": "deadiversion.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -1660,6 +1897,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.defense.gov",
       "Domain": "defense.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -1667,6 +1905,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.democraticleader.gov",
       "Domain": "democraticleader.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -1674,6 +1913,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.democraticwhip.gov",
       "Domain": "democraticwhip.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -1681,6 +1921,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.dems.gov",
       "Domain": "dems.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -1688,6 +1929,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://denali.gov",
       "Domain": "denali.gov",
       "HTTPS Enabled?": 1,
       "HTTPS Enforced?": 1,
@@ -1695,6 +1937,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "http://dfafacts.gov",
       "Domain": "dfafacts.gov",
       "HTTPS Enabled?": 2,
       "HTTPS Enforced?": 1,
@@ -1702,6 +1945,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "http://www.dhhs.gov",
       "Domain": "dhhs.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -1709,6 +1953,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.dhs.gov",
       "Domain": "dhs.gov",
       "HTTPS Enabled?": 2,
       "HTTPS Enforced?": 0,
@@ -1716,6 +1961,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "http://www.diabetescommittee.gov",
       "Domain": "diabetescommittee.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -1723,6 +1969,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.dietaryguidelines.gov",
       "Domain": "dietaryguidelines.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -1730,6 +1977,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.digitalgov.gov",
       "Domain": "digitalgov.gov",
       "HTTPS Enabled?": 2,
       "HTTPS Enforced?": 1,
@@ -1737,6 +1985,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "http://www.digitalliteracy.gov",
       "Domain": "digitalliteracy.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -1744,6 +1993,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://digitalpreservation.gov",
       "Domain": "digitalpreservation.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -1751,6 +2001,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.digitalstewardship.gov",
       "Domain": "digitalstewardship.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -1758,6 +2009,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://digitizationguidelines.gov",
       "Domain": "digitizationguidelines.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -1765,6 +2017,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "https://www.directoasucuenta.gov",
       "Domain": "directoasucuenta.gov",
       "HTTPS Enabled?": 2,
       "HTTPS Enforced?": 3,
@@ -1772,6 +2025,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "https://www.disability.gov",
       "Domain": "disability.gov",
       "HTTPS Enabled?": 2,
       "HTTPS Enforced?": 3,
@@ -1779,6 +2033,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "http://www.disasterassistance.gov",
       "Domain": "disasterassistance.gov",
       "HTTPS Enabled?": 2,
       "HTTPS Enforced?": 0,
@@ -1786,6 +2041,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "http://disasterhousing.gov",
       "Domain": "disasterhousing.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -1793,6 +2049,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://distracteddriving.gov",
       "Domain": "distracteddriving.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -1800,6 +2057,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.distraction.gov",
       "Domain": "distraction.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -1807,6 +2065,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.dna.gov",
       "Domain": "dna.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -1814,6 +2073,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.dnfsb.gov",
       "Domain": "dnfsb.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -1821,6 +2081,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.dni.gov",
       "Domain": "dni.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -1828,6 +2089,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.dnsops.gov",
       "Domain": "dnsops.gov",
       "HTTPS Enabled?": 1,
       "HTTPS Enforced?": 1,
@@ -1835,6 +2097,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "http://www.doc.gov",
       "Domain": "doc.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -1842,6 +2105,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "https://www.docline.gov",
       "Domain": "docline.gov",
       "HTTPS Enabled?": 2,
       "HTTPS Enforced?": 0,
@@ -1849,6 +2113,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "http://www.dod.gov",
       "Domain": "dod.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -1856,6 +2121,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.doe.gov",
       "Domain": "doe.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -1863,6 +2129,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.doeal.gov",
       "Domain": "doeal.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -1870,6 +2137,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.doi.gov",
       "Domain": "doi.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -1877,6 +2145,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.doioig.gov",
       "Domain": "doioig.gov",
       "HTTPS Enabled?": 2,
       "HTTPS Enforced?": 1,
@@ -1884,6 +2153,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "http://dol-esa.gov",
       "Domain": "dol-esa.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -1891,6 +2161,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://dol.gov",
       "Domain": "dol.gov",
       "HTTPS Enabled?": 2,
       "HTTPS Enforced?": 1,
@@ -1898,6 +2169,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "http://doleta.gov",
       "Domain": "doleta.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -1905,6 +2177,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "https://donotcall.gov",
       "Domain": "donotcall.gov",
       "HTTPS Enabled?": 2,
       "HTTPS Enforced?": 3,
@@ -1912,6 +2185,7 @@
       "Strict Transport Security (HSTS)": 3
     },
     {
+      "Canonical": "http://www.dontserveteens.gov",
       "Domain": "dontserveteens.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -1919,6 +2193,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.dot.gov",
       "Domain": "dot.gov",
       "HTTPS Enabled?": 2,
       "HTTPS Enforced?": 0,
@@ -1926,6 +2201,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "https://www.dotgov.gov",
       "Domain": "dotgov.gov",
       "HTTPS Enabled?": 2,
       "HTTPS Enforced?": 3,
@@ -1933,6 +2209,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "https://www.dotideahub.gov",
       "Domain": "dotideahub.gov",
       "HTTPS Enabled?": 2,
       "HTTPS Enforced?": 3,
@@ -1940,6 +2217,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "http://dottrafficrecords.gov",
       "Domain": "dottrafficrecords.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -1947,6 +2225,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://dottrcc.gov",
       "Domain": "dottrcc.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -1954,6 +2233,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://dra.gov",
       "Domain": "dra.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -1961,6 +2241,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.drought.gov",
       "Domain": "drought.gov",
       "HTTPS Enabled?": 2,
       "HTTPS Enforced?": 1,
@@ -1968,6 +2249,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "http://www.drugabuse.gov",
       "Domain": "drugabuse.gov",
       "HTTPS Enabled?": 2,
       "HTTPS Enforced?": 1,
@@ -1975,6 +2257,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "http://www.drugfreeworkplace.gov",
       "Domain": "drugfreeworkplace.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -1982,6 +2265,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.drywallresponse.gov",
       "Domain": "drywallresponse.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -1989,6 +2273,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "https://www.dsac.gov",
       "Domain": "dsac.gov",
       "HTTPS Enabled?": 2,
       "HTTPS Enforced?": 2,
@@ -1996,6 +2281,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "http://www.dtv.gov",
       "Domain": "dtv.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -2003,6 +2289,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.e-qip.gov",
       "Domain": "e-qip.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -2010,6 +2297,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://e3.gov",
       "Domain": "e3.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -2017,6 +2305,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.eac.gov",
       "Domain": "eac.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -2024,6 +2313,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.earmarks.gov",
       "Domain": "earmarks.gov",
       "HTTPS Enabled?": 2,
       "HTTPS Enforced?": 1,
@@ -2031,6 +2321,7 @@
       "Strict Transport Security (HSTS)": 3
     },
     {
+      "Canonical": "http://www.earthquake.gov",
       "Domain": "earthquake.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -2038,6 +2329,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.ecfr.gov",
       "Domain": "ecfr.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -2045,6 +2337,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "https://economicinclusion.gov",
       "Domain": "economicinclusion.gov",
       "HTTPS Enabled?": 2,
       "HTTPS Enforced?": 3,
@@ -2052,6 +2345,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "http://econsumer.gov",
       "Domain": "econsumer.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -2059,6 +2353,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://ecopartnerships.gov",
       "Domain": "ecopartnerships.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -2066,6 +2361,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "https://www.ecpic.gov",
       "Domain": "ecpic.gov",
       "HTTPS Enabled?": 2,
       "HTTPS Enforced?": 2,
@@ -2073,6 +2369,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "http://www.ecr.gov",
       "Domain": "ecr.gov",
       "HTTPS Enabled?": 2,
       "HTTPS Enforced?": 1,
@@ -2080,6 +2377,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "http://www.ed.gov",
       "Domain": "ed.gov",
       "HTTPS Enabled?": 2,
       "HTTPS Enforced?": 1,
@@ -2087,6 +2385,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "http://eda.gov",
       "Domain": "eda.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -2094,6 +2393,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.edison.gov",
       "Domain": "edison.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -2101,6 +2401,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.edpubs.gov",
       "Domain": "edpubs.gov",
       "HTTPS Enabled?": 2,
       "HTTPS Enforced?": 0,
@@ -2108,6 +2409,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "http://www.education.gov",
       "Domain": "education.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -2115,6 +2417,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.educationjobsfund.gov",
       "Domain": "educationjobsfund.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -2122,6 +2425,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://eeoc.gov",
       "Domain": "eeoc.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -2129,6 +2433,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.eforms.gov",
       "Domain": "eforms.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -2136,6 +2441,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "https://www.eftps.gov",
       "Domain": "eftps.gov",
       "HTTPS Enabled?": 2,
       "HTTPS Enforced?": 3,
@@ -2143,6 +2449,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "http://www.egov.gov",
       "Domain": "egov.gov",
       "HTTPS Enabled?": 2,
       "HTTPS Enforced?": 1,
@@ -2150,6 +2457,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "http://www.eia.gov",
       "Domain": "eia.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -2157,6 +2465,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://eisenhowermemorial.gov",
       "Domain": "eisenhowermemorial.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -2164,6 +2473,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.eldercare.gov",
       "Domain": "eldercare.gov",
       "HTTPS Enabled?": 2,
       "HTTPS Enforced?": 1,
@@ -2171,6 +2481,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "http://www.emergency-federal-register.gov",
       "Domain": "emergency-federal-register.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -2178,6 +2489,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "https://www.employeeexpress.gov",
       "Domain": "employeeexpress.gov",
       "HTTPS Enabled?": 2,
       "HTTPS Enforced?": 3,
@@ -2185,6 +2497,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "https://empowhr.gov",
       "Domain": "empowhr.gov",
       "HTTPS Enabled?": 1,
       "HTTPS Enforced?": 3,
@@ -2192,6 +2505,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "http://ems.gov",
       "Domain": "ems.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -2199,6 +2513,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://endingthedocumentgame.gov",
       "Domain": "endingthedocumentgame.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -2206,6 +2521,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://energy.gov",
       "Domain": "energy.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -2213,6 +2529,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.energycodes.gov",
       "Domain": "energycodes.gov",
       "HTTPS Enabled?": 2,
       "HTTPS Enforced?": 1,
@@ -2220,6 +2537,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "http://www.energyplus.gov",
       "Domain": "energyplus.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -2227,6 +2545,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.energysaver.gov",
       "Domain": "energysaver.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -2234,6 +2553,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.energysavers.gov",
       "Domain": "energysavers.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -2241,6 +2561,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.energystar.gov",
       "Domain": "energystar.gov",
       "HTTPS Enabled?": 2,
       "HTTPS Enforced?": 1,
@@ -2248,6 +2569,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "http://www.eop.gov",
       "Domain": "eop.gov",
       "HTTPS Enabled?": 2,
       "HTTPS Enforced?": 1,
@@ -2255,6 +2577,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "http://www.epa-echo.gov",
       "Domain": "epa-echo.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -2262,6 +2585,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.epa-otis.gov",
       "Domain": "epa-otis.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -2269,6 +2593,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://epa.gov",
       "Domain": "epa.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -2276,6 +2601,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.epls.gov",
       "Domain": "epls.gov",
       "HTTPS Enabled?": 1,
       "HTTPS Enforced?": 1,
@@ -2283,6 +2609,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "http://www.errp.gov",
       "Domain": "errp.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -2290,6 +2617,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://esa.gov",
       "Domain": "esa.gov",
       "HTTPS Enabled?": 1,
       "HTTPS Enforced?": 1,
@@ -2297,6 +2625,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "http://www.esc.gov",
       "Domain": "esc.gov",
       "HTTPS Enabled?": 2,
       "HTTPS Enforced?": 1,
@@ -2304,6 +2633,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "http://www.espanol.gov",
       "Domain": "espanol.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -2311,6 +2641,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://espanolforlawenforcement.gov",
       "Domain": "espanolforlawenforcement.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -2318,6 +2649,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "https://www.esrs.gov",
       "Domain": "esrs.gov",
       "HTTPS Enabled?": 2,
       "HTTPS Enforced?": 3,
@@ -2325,6 +2657,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "https://www.eta-find.gov",
       "Domain": "eta-find.gov",
       "HTTPS Enabled?": 2,
       "HTTPS Enforced?": 3,
@@ -2332,6 +2665,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "http://www.ethics.gov",
       "Domain": "ethics.gov",
       "HTTPS Enabled?": 2,
       "HTTPS Enforced?": 1,
@@ -2339,6 +2673,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "http://www.ethicsburg.gov",
       "Domain": "ethicsburg.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -2346,6 +2681,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.evergladesrestoration.gov",
       "Domain": "evergladesrestoration.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -2353,6 +2689,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.execsec.gov",
       "Domain": "execsec.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -2360,6 +2697,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.exim.gov",
       "Domain": "exim.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -2367,6 +2705,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.exploretsp.gov",
       "Domain": "exploretsp.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -2374,6 +2713,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://export.gov",
       "Domain": "export.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -2381,6 +2721,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://eyenote.gov",
       "Domain": "eyenote.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -2388,6 +2729,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.faa.gov",
       "Domain": "faa.gov",
       "HTTPS Enabled?": 2,
       "HTTPS Enforced?": 1,
@@ -2395,6 +2737,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "http://www.faasafety.gov",
       "Domain": "faasafety.gov",
       "HTTPS Enabled?": 2,
       "HTTPS Enforced?": 0,
@@ -2402,6 +2745,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "http://faca.gov",
       "Domain": "faca.gov",
       "HTTPS Enabled?": 2,
       "HTTPS Enforced?": 1,
@@ -2409,6 +2753,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "http://facadatabase.gov",
       "Domain": "facadatabase.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -2416,6 +2761,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://fafsa.gov",
       "Domain": "fafsa.gov",
       "HTTPS Enabled?": 2,
       "HTTPS Enforced?": 1,
@@ -2423,6 +2769,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "http://www.fai.gov",
       "Domain": "fai.gov",
       "HTTPS Enabled?": 1,
       "HTTPS Enforced?": 0,
@@ -2430,6 +2777,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "https://www.fan.gov",
       "Domain": "fan.gov",
       "HTTPS Enabled?": 2,
       "HTTPS Enforced?": 2,
@@ -2437,6 +2785,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "https://fapiis.gov",
       "Domain": "fapiis.gov",
       "HTTPS Enabled?": 1,
       "HTTPS Enforced?": 3,
@@ -2444,6 +2793,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "http://www.faq.gov",
       "Domain": "faq.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -2451,6 +2801,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.fara.gov",
       "Domain": "fara.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -2458,6 +2809,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "https://www.farmerclaims.gov",
       "Domain": "farmerclaims.gov",
       "HTTPS Enabled?": 1,
       "HTTPS Enforced?": 3,
@@ -2465,6 +2817,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "http://fasab.gov",
       "Domain": "fasab.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -2472,6 +2825,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "https://fatherhood.gov",
       "Domain": "fatherhood.gov",
       "HTTPS Enabled?": 2,
       "HTTPS Enforced?": 3,
@@ -2479,6 +2833,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "http://www.fbi.gov",
       "Domain": "fbi.gov",
       "HTTPS Enabled?": 2,
       "HTTPS Enforced?": 0,
@@ -2486,6 +2841,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "http://www.fbiic.gov",
       "Domain": "fbiic.gov",
       "HTTPS Enabled?": 2,
       "HTTPS Enforced?": 1,
@@ -2493,6 +2849,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "https://www.fbijobs.gov",
       "Domain": "fbijobs.gov",
       "HTTPS Enabled?": 2,
       "HTTPS Enforced?": 2,
@@ -2500,6 +2857,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "https://www.fbo.gov",
       "Domain": "fbo.gov",
       "HTTPS Enabled?": 1,
       "HTTPS Enforced?": 3,
@@ -2507,6 +2865,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "http://fca.gov",
       "Domain": "fca.gov",
       "HTTPS Enabled?": 1,
       "HTTPS Enforced?": 1,
@@ -2514,6 +2873,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "http://www.fcc.gov",
       "Domain": "fcc.gov",
       "HTTPS Enabled?": 2,
       "HTTPS Enforced?": 1,
@@ -2521,6 +2881,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "http://www.fccuniversity.gov",
       "Domain": "fccuniversity.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -2528,6 +2889,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.fcg.gov",
       "Domain": "fcg.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -2535,6 +2897,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.fcic.gov",
       "Domain": "fcic.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -2542,6 +2905,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://fcsic.gov",
       "Domain": "fcsic.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -2549,6 +2913,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://fcsm.gov",
       "Domain": "fcsm.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -2556,6 +2921,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.fda.gov",
       "Domain": "fda.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -2563,6 +2929,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "https://fdic.gov",
       "Domain": "fdic.gov",
       "HTTPS Enabled?": 2,
       "HTTPS Enforced?": 3,
@@ -2570,6 +2937,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "http://fdicbets.gov",
       "Domain": "fdicbets.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -2577,6 +2945,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.fdicconnect.gov",
       "Domain": "fdicconnect.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -2584,6 +2953,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://fdicig.gov",
       "Domain": "fdicig.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -2591,6 +2961,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://fdicoig.gov",
       "Domain": "fdicoig.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -2598,6 +2969,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://fdicseguro.gov",
       "Domain": "fdicseguro.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -2605,6 +2977,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.fdlp.gov",
       "Domain": "fdlp.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -2612,6 +2985,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.fdms.gov",
       "Domain": "fdms.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -2619,6 +2993,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "https://www.fdr.gov",
       "Domain": "fdr.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -2626,6 +3001,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.fdsys.gov",
       "Domain": "fdsys.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -2633,6 +3009,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://feb.gov",
       "Domain": "feb.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -2640,6 +3017,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://fec.gov",
       "Domain": "fec.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -2647,6 +3025,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.fedbizopps.gov",
       "Domain": "fedbizopps.gov",
       "HTTPS Enabled?": 1,
       "HTTPS Enforced?": 1,
@@ -2654,6 +3033,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "https://www.fedcenter.gov",
       "Domain": "fedcenter.gov",
       "HTTPS Enabled?": 2,
       "HTTPS Enforced?": 3,
@@ -2661,6 +3041,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "http://www.federalaccountability.gov",
       "Domain": "federalaccountability.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -2668,6 +3049,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.federalcourts.gov",
       "Domain": "federalcourts.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -2675,6 +3057,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://federalinvestments.gov",
       "Domain": "federalinvestments.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -2682,6 +3065,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.federaljobs.gov",
       "Domain": "federaljobs.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -2689,6 +3073,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.federalprobation.gov",
       "Domain": "federalprobation.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -2696,6 +3081,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "https://www.federalregister.gov",
       "Domain": "federalregister.gov",
       "HTTPS Enabled?": 2,
       "HTTPS Enforced?": 2,
@@ -2703,6 +3089,7 @@
       "Strict Transport Security (HSTS)": 3
     },
     {
+      "Canonical": "http://www.federalreporting.gov",
       "Domain": "federalreporting.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -2710,6 +3097,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://federalreserve.gov",
       "Domain": "federalreserve.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -2717,6 +3105,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://federalreserveconsumerhelp.gov",
       "Domain": "federalreserveconsumerhelp.gov",
       "HTTPS Enabled?": 2,
       "HTTPS Enforced?": 1,
@@ -2724,6 +3113,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "http://www.federalrules.gov",
       "Domain": "federalrules.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -2731,6 +3121,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.federaltransparency.gov",
       "Domain": "federaltransparency.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -2738,6 +3129,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.fedforms.gov",
       "Domain": "fedforms.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -2745,6 +3137,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://fedidcard.gov",
       "Domain": "fedidcard.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -2752,6 +3145,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://fedinvest.gov",
       "Domain": "fedinvest.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -2759,6 +3153,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.fedjobs.gov",
       "Domain": "fedjobs.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -2766,6 +3161,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "https://fedpartnership.gov",
       "Domain": "fedpartnership.gov",
       "HTTPS Enabled?": 2,
       "HTTPS Enforced?": 3,
@@ -2773,6 +3169,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "http://www.fedramp.gov",
       "Domain": "fedramp.gov",
       "HTTPS Enabled?": 2,
       "HTTPS Enforced?": 1,
@@ -2780,6 +3177,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "http://fedrealestate.gov",
       "Domain": "fedrealestate.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -2787,6 +3185,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.fedreg.gov",
       "Domain": "fedreg.gov",
       "HTTPS Enabled?": 2,
       "HTTPS Enforced?": 1,
@@ -2794,6 +3193,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "http://fedrooms.gov",
       "Domain": "fedrooms.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -2801,6 +3201,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://fedshirevets.gov",
       "Domain": "fedshirevets.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -2808,6 +3209,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://fedstats.gov",
       "Domain": "fedstats.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -2815,6 +3217,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://feedthefuture.gov",
       "Domain": "feedthefuture.gov",
       "HTTPS Enabled?": 2,
       "HTTPS Enforced?": 0,
@@ -2822,6 +3225,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "http://www.fegli.gov",
       "Domain": "fegli.gov",
       "HTTPS Enabled?": 2,
       "HTTPS Enforced?": 1,
@@ -2829,6 +3233,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "http://www.fema.gov",
       "Domain": "fema.gov",
       "HTTPS Enabled?": 2,
       "HTTPS Enforced?": 1,
@@ -2836,6 +3241,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "https://www.femalefarmerclaims.gov",
       "Domain": "femalefarmerclaims.gov",
       "HTTPS Enabled?": 1,
       "HTTPS Enforced?": 3,
@@ -2843,6 +3249,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "http://ferc.gov",
       "Domain": "ferc.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -2850,6 +3257,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://fercalt.gov",
       "Domain": "fercalt.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -2857,6 +3265,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.ffiec.gov",
       "Domain": "ffiec.gov",
       "HTTPS Enabled?": 2,
       "HTTPS Enforced?": 1,
@@ -2864,6 +3273,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "http://fgdc.gov",
       "Domain": "fgdc.gov",
       "HTTPS Enabled?": 2,
       "HTTPS Enforced?": 1,
@@ -2871,6 +3281,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "http://www.fha.gov",
       "Domain": "fha.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -2878,6 +3289,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.fhfa.gov",
       "Domain": "fhfa.gov",
       "HTTPS Enabled?": 1,
       "HTTPS Enforced?": 0,
@@ -2885,6 +3297,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "http://www.fhfaoig.gov",
       "Domain": "fhfaoig.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -2892,6 +3305,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://fido.gov",
       "Domain": "fido.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -2899,6 +3313,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://fightingmalaria.gov",
       "Domain": "fightingmalaria.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -2906,6 +3321,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://financialresearch.gov",
       "Domain": "financialresearch.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -2913,6 +3329,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.financialstability.gov",
       "Domain": "financialstability.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -2920,6 +3337,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://fincen.gov",
       "Domain": "fincen.gov",
       "HTTPS Enabled?": 1,
       "HTTPS Enforced?": 1,
@@ -2927,6 +3345,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "http://findyouthinfo.gov",
       "Domain": "findyouthinfo.gov",
       "HTTPS Enabled?": 1,
       "HTTPS Enforced?": 1,
@@ -2934,6 +3353,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "http://www.firecode.gov",
       "Domain": "firecode.gov",
       "HTTPS Enabled?": 2,
       "HTTPS Enforced?": 1,
@@ -2941,6 +3361,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "http://www.fireleadership.gov",
       "Domain": "fireleadership.gov",
       "HTTPS Enabled?": 1,
       "HTTPS Enforced?": 1,
@@ -2948,6 +3369,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "http://www.firenet.gov",
       "Domain": "firenet.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -2955,6 +3377,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.firescience.gov",
       "Domain": "firescience.gov",
       "HTTPS Enabled?": 2,
       "HTTPS Enforced?": 1,
@@ -2962,6 +3385,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "http://www.firstfreedom.gov",
       "Domain": "firstfreedom.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -2969,6 +3393,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.firstgov.gov",
       "Domain": "firstgov.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -2976,6 +3401,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://firstnet.gov",
       "Domain": "firstnet.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -2983,6 +3409,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.firstresponder.gov",
       "Domain": "firstresponder.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -2990,6 +3417,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "https://www.firstrespondertraining.gov",
       "Domain": "firstrespondertraining.gov",
       "HTTPS Enabled?": 2,
       "HTTPS Enforced?": 0,
@@ -2997,6 +3425,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "http://www.fiscalcommission.gov",
       "Domain": "fiscalcommission.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -3004,6 +3433,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.fishwatch.gov",
       "Domain": "fishwatch.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -3011,6 +3441,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://fitness.gov",
       "Domain": "fitness.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -3018,6 +3449,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.fjc.gov",
       "Domain": "fjc.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -3025,6 +3457,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "https://www.fleta.gov",
       "Domain": "fleta.gov",
       "HTTPS Enabled?": 2,
       "HTTPS Enforced?": 3,
@@ -3032,6 +3465,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "https://www.fletc.gov",
       "Domain": "fletc.gov",
       "HTTPS Enabled?": 2,
       "HTTPS Enforced?": 3,
@@ -3039,6 +3473,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "https://www.flightschoolcandidates.gov",
       "Domain": "flightschoolcandidates.gov",
       "HTTPS Enabled?": 2,
       "HTTPS Enforced?": 3,
@@ -3046,6 +3481,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "https://www.floodsmart.gov",
       "Domain": "floodsmart.gov",
       "HTTPS Enabled?": 2,
       "HTTPS Enforced?": 0,
@@ -3053,6 +3489,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "http://flra.gov",
       "Domain": "flra.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -3060,6 +3497,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.flu.gov",
       "Domain": "flu.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -3067,6 +3505,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.fmc.gov",
       "Domain": "fmc.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -3074,6 +3513,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.fmcs.gov",
       "Domain": "fmcs.gov",
       "HTTPS Enabled?": 2,
       "HTTPS Enforced?": 0,
@@ -3081,6 +3521,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "http://fmi.gov",
       "Domain": "fmi.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -3088,6 +3529,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.fmip.gov",
       "Domain": "fmip.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -3095,6 +3537,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://fmshrc.gov",
       "Domain": "fmshrc.gov",
       "HTTPS Enabled?": 2,
       "HTTPS Enforced?": 1,
@@ -3102,6 +3545,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "http://fnal.gov",
       "Domain": "fnal.gov",
       "HTTPS Enabled?": 2,
       "HTTPS Enforced?": 1,
@@ -3109,6 +3553,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "http://www.foia.gov",
       "Domain": "foia.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -3116,6 +3561,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.foodsafety.gov",
       "Domain": "foodsafety.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -3123,6 +3569,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.foodsafetyjobs.gov",
       "Domain": "foodsafetyjobs.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -3130,6 +3577,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.foodsafetyworkinggroup.gov",
       "Domain": "foodsafetyworkinggroup.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -3137,6 +3585,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://fordlibrarymuseum.gov",
       "Domain": "fordlibrarymuseum.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -3144,6 +3593,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://foreignassistance.gov",
       "Domain": "foreignassistance.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -3151,6 +3601,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://forestsandrangelands.gov",
       "Domain": "forestsandrangelands.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -3158,6 +3609,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.forfeiture.gov",
       "Domain": "forfeiture.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -3165,6 +3617,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.forms.gov",
       "Domain": "forms.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -3172,6 +3625,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.fpds.gov",
       "Domain": "fpds.gov",
       "HTTPS Enabled?": 2,
       "HTTPS Enforced?": 1,
@@ -3179,6 +3633,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "http://frcc.gov",
       "Domain": "frcc.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -3186,6 +3641,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.freecreditreport.gov",
       "Domain": "freecreditreport.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -3193,6 +3649,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://frtib.gov",
       "Domain": "frtib.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -3200,6 +3657,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://frtr.gov",
       "Domain": "frtr.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -3207,6 +3665,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.fruitsandveggiesmatter.gov",
       "Domain": "fruitsandveggiesmatter.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -3214,6 +3673,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.fs.fed.us",
       "Domain": "fs.fed.us",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -3221,6 +3681,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.fsafeds.gov",
       "Domain": "fsafeds.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -3228,6 +3689,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.fsapubs.gov",
       "Domain": "fsapubs.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -3235,6 +3697,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "https://www.fsd.gov",
       "Domain": "fsd.gov",
       "HTTPS Enabled?": 1,
       "HTTPS Enforced?": 3,
@@ -3242,6 +3705,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "http://www.fsgb.gov",
       "Domain": "fsgb.gov",
       "HTTPS Enabled?": 2,
       "HTTPS Enforced?": 1,
@@ -3249,6 +3713,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "http://www.fsoc.gov",
       "Domain": "fsoc.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -3256,6 +3721,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "https://www.fsrs.gov",
       "Domain": "fsrs.gov",
       "HTTPS Enabled?": 2,
       "HTTPS Enforced?": 3,
@@ -3263,6 +3729,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "http://www.fswg.gov",
       "Domain": "fswg.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -3270,6 +3737,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "https://www.ftc.gov",
       "Domain": "ftc.gov",
       "HTTPS Enabled?": 2,
       "HTTPS Enforced?": 3,
@@ -3277,6 +3745,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "https://ftccomplaintassistant.gov",
       "Domain": "ftccomplaintassistant.gov",
       "HTTPS Enabled?": 2,
       "HTTPS Enforced?": 3,
@@ -3284,6 +3753,7 @@
       "Strict Transport Security (HSTS)": 3
     },
     {
+      "Canonical": "https://ftcefile.gov",
       "Domain": "ftcefile.gov",
       "HTTPS Enabled?": 2,
       "HTTPS Enforced?": 3,
@@ -3291,6 +3761,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "https://www.fttesttwai.gov",
       "Domain": "fttesttwai.gov",
       "HTTPS Enabled?": 1,
       "HTTPS Enforced?": 3,
@@ -3298,6 +3769,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "http://fueleconomy.gov",
       "Domain": "fueleconomy.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -3305,6 +3777,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.fvap.gov",
       "Domain": "fvap.gov",
       "HTTPS Enabled?": 2,
       "HTTPS Enforced?": 0,
@@ -3312,6 +3785,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "http://www.fws.gov",
       "Domain": "fws.gov",
       "HTTPS Enabled?": 2,
       "HTTPS Enforced?": 1,
@@ -3319,6 +3793,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "https://www.g5.gov",
       "Domain": "g5.gov",
       "HTTPS Enabled?": 2,
       "HTTPS Enforced?": 3,
@@ -3326,6 +3801,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "http://gao.gov",
       "Domain": "gao.gov",
       "HTTPS Enabled?": 1,
       "HTTPS Enforced?": 1,
@@ -3333,6 +3809,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "http://gaonet.gov",
       "Domain": "gaonet.gov",
       "HTTPS Enabled?": 1,
       "HTTPS Enforced?": 1,
@@ -3340,6 +3817,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "http://www.gcdamp.gov",
       "Domain": "gcdamp.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -3347,6 +3825,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.gcmrc.gov",
       "Domain": "gcmrc.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -3354,6 +3833,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.genbank.gov",
       "Domain": "genbank.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -3361,6 +3841,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.genome.gov",
       "Domain": "genome.gov",
       "HTTPS Enabled?": 2,
       "HTTPS Enforced?": 1,
@@ -3368,6 +3849,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "http://www.geocommunicator.gov",
       "Domain": "geocommunicator.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -3375,6 +3857,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.geomac.gov",
       "Domain": "geomac.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -3382,6 +3865,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://geoplatform.gov",
       "Domain": "geoplatform.gov",
       "HTTPS Enabled?": 2,
       "HTTPS Enforced?": 1,
@@ -3389,6 +3873,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "http://www.georgewbushlibrary.gov",
       "Domain": "georgewbushlibrary.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -3396,6 +3881,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.getinvolved.gov",
       "Domain": "getinvolved.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -3403,6 +3889,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://getsmartaboutdrugs.gov",
       "Domain": "getsmartaboutdrugs.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -3410,6 +3897,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.getyouhome.gov",
       "Domain": "getyouhome.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -3417,6 +3905,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://ghi.gov",
       "Domain": "ghi.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -3424,6 +3913,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.ginniemae.gov",
       "Domain": "ginniemae.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -3431,6 +3921,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://girlshealth.gov",
       "Domain": "girlshealth.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -3438,6 +3929,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.globalchange.gov",
       "Domain": "globalchange.gov",
       "HTTPS Enabled?": 2,
       "HTTPS Enforced?": 0,
@@ -3445,6 +3937,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "http://www.globalentry.gov",
       "Domain": "globalentry.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -3452,6 +3945,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.globalhealth.gov",
       "Domain": "globalhealth.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -3459,6 +3953,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.globe.gov",
       "Domain": "globe.gov",
       "HTTPS Enabled?": 2,
       "HTTPS Enforced?": 1,
@@ -3466,6 +3961,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "http://www.gobierno.gov",
       "Domain": "gobierno.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -3473,6 +3969,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.gobiernousa.gov",
       "Domain": "gobiernousa.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -3480,6 +3977,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "https://www.godirect.gov",
       "Domain": "godirect.gov",
       "HTTPS Enabled?": 2,
       "HTTPS Enforced?": 3,
@@ -3487,6 +3985,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "http://www.goes-r.gov",
       "Domain": "goes-r.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -3494,6 +3993,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://golearn.gov",
       "Domain": "golearn.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -3501,6 +4001,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.gop.gov",
       "Domain": "gop.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -3508,6 +4009,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.gopconference.gov",
       "Domain": "gopconference.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -3515,6 +4017,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.gopleader.gov",
       "Domain": "gopleader.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -3522,6 +4025,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.govbenefits.gov",
       "Domain": "govbenefits.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -3529,6 +4033,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.governmentjobs.gov",
       "Domain": "governmentjobs.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -3536,6 +4041,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.govloans.gov",
       "Domain": "govloans.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -3543,6 +4049,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.govsales.gov",
       "Domain": "govsales.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -3550,6 +4057,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://gpo.gov",
       "Domain": "gpo.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -3557,6 +4065,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.gpoaccess.gov",
       "Domain": "gpoaccess.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -3564,6 +4073,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.gps.gov",
       "Domain": "gps.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -3571,6 +4081,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.grants.gov",
       "Domain": "grants.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -3578,6 +4089,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "https://grantsolutions.gov",
       "Domain": "grantsolutions.gov",
       "HTTPS Enabled?": 2,
       "HTTPS Enforced?": 3,
@@ -3585,6 +4097,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "http://www.green.gov",
       "Domain": "green.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -3592,6 +4105,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://greengov.gov",
       "Domain": "greengov.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -3599,6 +4113,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.gsa.gov",
       "Domain": "gsa.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -3606,6 +4121,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "https://gsaadvantage.gov",
       "Domain": "gsaadvantage.gov",
       "HTTPS Enabled?": 2,
       "HTTPS Enforced?": 3,
@@ -3613,6 +4129,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "http://www.gsaauctions.gov",
       "Domain": "gsaauctions.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -3620,6 +4137,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.gsadvantage.gov",
       "Domain": "gsadvantage.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -3627,6 +4145,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "https://www.gsaig.gov",
       "Domain": "gsaig.gov",
       "HTTPS Enabled?": 2,
       "HTTPS Enforced?": 2,
@@ -3634,6 +4153,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "http://gsaxcess.gov",
       "Domain": "gsaxcess.gov",
       "HTTPS Enabled?": 2,
       "HTTPS Enforced?": 1,
@@ -3641,6 +4161,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "http://www.guideline.gov",
       "Domain": "guideline.gov",
       "HTTPS Enabled?": 2,
       "HTTPS Enforced?": 1,
@@ -3648,6 +4169,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "http://www.guidelines.gov",
       "Domain": "guidelines.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -3655,6 +4177,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "https://www.gwa.gov",
       "Domain": "gwa.gov",
       "HTTPS Enabled?": 1,
       "HTTPS Enforced?": 3,
@@ -3662,6 +4185,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "http://www.hanford.gov",
       "Domain": "hanford.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -3669,6 +4193,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://harp.gov",
       "Domain": "harp.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -3676,6 +4201,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://hc.gov",
       "Domain": "hc.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -3683,6 +4209,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.hcqualitycommission.gov",
       "Domain": "hcqualitycommission.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -3690,6 +4217,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://health.gov",
       "Domain": "health.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -3697,6 +4225,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "https://www.healthcare.gov",
       "Domain": "healthcare.gov",
       "HTTPS Enabled?": 2,
       "HTTPS Enforced?": 3,
@@ -3704,6 +4233,7 @@
       "Strict Transport Security (HSTS)": 1
     },
     {
+      "Canonical": "http://www.healthdata.gov",
       "Domain": "healthdata.gov",
       "HTTPS Enabled?": 2,
       "HTTPS Enforced?": 1,
@@ -3711,6 +4241,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "http://healthfinder.gov",
       "Domain": "healthfinder.gov",
       "HTTPS Enabled?": 2,
       "HTTPS Enforced?": 1,
@@ -3718,6 +4249,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "http://www.healthindicators.gov",
       "Domain": "healthindicators.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -3725,6 +4257,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://healthit.gov",
       "Domain": "healthit.gov",
       "HTTPS Enabled?": 1,
       "HTTPS Enforced?": 1,
@@ -3732,6 +4265,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "http://healthreform.gov",
       "Domain": "healthreform.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -3739,6 +4273,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.healthypeople.gov",
       "Domain": "healthypeople.gov",
       "HTTPS Enabled?": 2,
       "HTTPS Enforced?": 1,
@@ -3746,6 +4281,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "http://www.hearttruth.gov",
       "Domain": "hearttruth.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -3753,6 +4289,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.helpingamericasyouth.gov",
       "Domain": "helpingamericasyouth.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -3760,6 +4297,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://helpwithmybank.gov",
       "Domain": "helpwithmybank.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -3767,6 +4305,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://helpwithmycheckingaccount.gov",
       "Domain": "helpwithmycheckingaccount.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -3774,6 +4313,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://helpwithmycreditcard.gov",
       "Domain": "helpwithmycreditcard.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -3781,6 +4321,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://helpwithmycreditcardbank.gov",
       "Domain": "helpwithmycreditcardbank.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -3788,6 +4329,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://helpwithmymortgage.gov",
       "Domain": "helpwithmymortgage.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -3795,6 +4337,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://helpwithmymortgagebank.gov",
       "Domain": "helpwithmymortgagebank.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -3802,6 +4345,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.hhs.gov",
       "Domain": "hhs.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -3809,6 +4353,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.hhsoig.gov",
       "Domain": "hhsoig.gov",
       "HTTPS Enabled?": 1,
       "HTTPS Enforced?": 1,
@@ -3816,6 +4361,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "http://www.highperformancebuildings.gov",
       "Domain": "highperformancebuildings.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -3823,6 +4369,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.hill.gov",
       "Domain": "hill.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -3830,6 +4377,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "https://www.hispanicfarmerclaims.gov",
       "Domain": "hispanicfarmerclaims.gov",
       "HTTPS Enabled?": 1,
       "HTTPS Enforced?": 3,
@@ -3837,6 +4385,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "http://hispanicheritagemonth.gov",
       "Domain": "hispanicheritagemonth.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -3844,6 +4393,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.hiv.gov",
       "Domain": "hiv.gov",
       "HTTPS Enabled?": 1,
       "HTTPS Enforced?": 1,
@@ -3851,6 +4401,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "http://www.homeenergyscore.gov",
       "Domain": "homeenergyscore.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -3858,6 +4409,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.homelandsecurity.gov",
       "Domain": "homelandsecurity.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -3865,6 +4417,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://homesales.gov",
       "Domain": "homesales.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -3872,6 +4425,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.house.gov",
       "Domain": "house.gov",
       "HTTPS Enabled?": 2,
       "HTTPS Enforced?": 1,
@@ -3879,6 +4433,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "http://www.housecalendar.gov",
       "Domain": "housecalendar.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -3886,6 +4441,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.housecommunications.gov",
       "Domain": "housecommunications.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -3893,6 +4449,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.housedemocrats.gov",
       "Domain": "housedemocrats.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -3900,6 +4457,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.housedems.gov",
       "Domain": "housedems.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -3907,6 +4465,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://houselive.gov",
       "Domain": "houselive.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -3914,6 +4473,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.howto.gov",
       "Domain": "howto.gov",
       "HTTPS Enabled?": 2,
       "HTTPS Enforced?": 1,
@@ -3921,6 +4481,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "http://hrsa.gov",
       "Domain": "hrsa.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -3928,6 +4489,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "https://hru.gov",
       "Domain": "hru.gov",
       "HTTPS Enabled?": 2,
       "HTTPS Enforced?": 3,
@@ -3935,6 +4497,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "http://hsa.gov",
       "Domain": "hsa.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -3942,6 +4505,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "https://hsr.gov",
       "Domain": "hsr.gov",
       "HTTPS Enabled?": 2,
       "HTTPS Enforced?": 3,
@@ -3949,6 +4513,7 @@
       "Strict Transport Security (HSTS)": 3
     },
     {
+      "Canonical": "http://hud.gov",
       "Domain": "hud.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -3956,6 +4521,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.hudoig.gov",
       "Domain": "hudoig.gov",
       "HTTPS Enabled?": 2,
       "HTTPS Enforced?": 1,
@@ -3963,6 +4529,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "http://www.humanities.gov",
       "Domain": "humanities.gov",
       "HTTPS Enabled?": 1,
       "HTTPS Enforced?": 1,
@@ -3970,6 +4537,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "http://www.humanrights.gov",
       "Domain": "humanrights.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -3977,6 +4545,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.hurricanes.gov",
       "Domain": "hurricanes.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -3984,6 +4553,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://hydrogen.gov",
       "Domain": "hydrogen.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -3991,6 +4561,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "https://www.iad.gov",
       "Domain": "iad.gov",
       "HTTPS Enabled?": 1,
       "HTTPS Enforced?": 3,
@@ -3998,6 +4569,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "http://www.iaf.gov",
       "Domain": "iaf.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -4005,6 +4577,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://iarpa-ideas.gov",
       "Domain": "iarpa-ideas.gov",
       "HTTPS Enabled?": 2,
       "HTTPS Enforced?": 1,
@@ -4012,6 +4585,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "http://www.iarpa.gov",
       "Domain": "iarpa.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -4019,6 +4593,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.iat.gov",
       "Domain": "iat.gov",
       "HTTPS Enabled?": 2,
       "HTTPS Enforced?": 1,
@@ -4026,6 +4601,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "https://www.iawg.gov",
       "Domain": "iawg.gov",
       "HTTPS Enabled?": 2,
       "HTTPS Enforced?": 3,
@@ -4033,6 +4609,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "http://www.ibb.gov",
       "Domain": "ibb.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -4040,6 +4617,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://ibwc.gov",
       "Domain": "ibwc.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -4047,6 +4625,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.ic3.gov",
       "Domain": "ic3.gov",
       "HTTPS Enabled?": 2,
       "HTTPS Enforced?": 1,
@@ -4054,6 +4633,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "https://www.icass.gov",
       "Domain": "icass.gov",
       "HTTPS Enabled?": 2,
       "HTTPS Enforced?": 2,
@@ -4061,6 +4641,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "http://icbemp.gov",
       "Domain": "icbemp.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -4068,6 +4649,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.ice.gov",
       "Domain": "ice.gov",
       "HTTPS Enabled?": 2,
       "HTTPS Enforced?": 1,
@@ -4075,6 +4657,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "http://www.ich.gov",
       "Domain": "ich.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -4082,6 +4665,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://icjointduty.gov",
       "Domain": "icjointduty.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -4089,6 +4673,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.identitytheft.gov",
       "Domain": "identitytheft.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -4096,6 +4681,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://idmanagement.gov",
       "Domain": "idmanagement.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -4103,6 +4689,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.idtheft.gov",
       "Domain": "idtheft.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -4110,6 +4697,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.iedison.gov",
       "Domain": "iedison.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -4117,6 +4705,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "https://www.ignet.gov",
       "Domain": "ignet.gov",
       "HTTPS Enabled?": 1,
       "HTTPS Enforced?": 3,
@@ -4124,6 +4713,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "http://www.ihs.gov",
       "Domain": "ihs.gov",
       "HTTPS Enabled?": 2,
       "HTTPS Enforced?": 1,
@@ -4131,6 +4721,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "http://iiog.gov",
       "Domain": "iiog.gov",
       "HTTPS Enabled?": 1,
       "HTTPS Enforced?": 1,
@@ -4138,6 +4729,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "http://www.imls.gov",
       "Domain": "imls.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -4145,6 +4737,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://indianaffairs.gov",
       "Domain": "indianaffairs.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -4152,6 +4745,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.inel.gov",
       "Domain": "inel.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -4159,6 +4753,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.info.gov",
       "Domain": "info.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -4166,6 +4761,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "https://inl.gov",
       "Domain": "inl.gov",
       "HTTPS Enabled?": 2,
       "HTTPS Enforced?": 3,
@@ -4173,6 +4769,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "http://insurekidsnow.gov",
       "Domain": "insurekidsnow.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -4180,6 +4777,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "https://www.integrity.gov",
       "Domain": "integrity.gov",
       "HTTPS Enabled?": 2,
       "HTTPS Enforced?": 3,
@@ -4187,6 +4785,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "http://www.intelink.gov",
       "Domain": "intelink.gov",
       "HTTPS Enabled?": 2,
       "HTTPS Enforced?": 1,
@@ -4194,6 +4793,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "http://intelligence.gov",
       "Domain": "intelligence.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -4201,6 +4801,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.interior.gov",
       "Domain": "interior.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -4208,6 +4809,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.interpol.gov",
       "Domain": "interpol.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -4215,6 +4817,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://invasivespecies.gov",
       "Domain": "invasivespecies.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -4222,6 +4825,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.invasivespeciesinfo.gov",
       "Domain": "invasivespeciesinfo.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -4229,6 +4833,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://investor.gov",
       "Domain": "investor.gov",
       "HTTPS Enabled?": 2,
       "HTTPS Enforced?": 0,
@@ -4236,6 +4841,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "https://www.ioss.gov",
       "Domain": "ioss.gov",
       "HTTPS Enabled?": 1,
       "HTTPS Enforced?": 3,
@@ -4243,6 +4849,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "https://www.ipac.gov",
       "Domain": "ipac.gov",
       "HTTPS Enabled?": 1,
       "HTTPS Enforced?": 3,
@@ -4250,6 +4857,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "http://ipcc-wg2.gov",
       "Domain": "ipcc-wg2.gov",
       "HTTPS Enabled?": 2,
       "HTTPS Enforced?": 1,
@@ -4257,6 +4865,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "http://www.ipm.gov",
       "Domain": "ipm.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -4264,6 +4873,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.ipp.gov",
       "Domain": "ipp.gov",
       "HTTPS Enabled?": 2,
       "HTTPS Enforced?": 1,
@@ -4271,6 +4881,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "http://www.iprcenter.gov",
       "Domain": "iprcenter.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -4278,6 +4889,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.irs.gov",
       "Domain": "irs.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -4285,6 +4897,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.irsauctions.gov",
       "Domain": "irsauctions.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -4292,6 +4905,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.irssales.gov",
       "Domain": "irssales.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -4299,6 +4913,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.irsvideos.gov",
       "Domain": "irsvideos.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -4306,6 +4921,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://ise.gov",
       "Domain": "ise.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -4313,6 +4929,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.isitdoneyet.gov",
       "Domain": "isitdoneyet.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -4320,6 +4937,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "https://isotope.gov",
       "Domain": "isotope.gov",
       "HTTPS Enabled?": 2,
       "HTTPS Enforced?": 3,
@@ -4327,6 +4945,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "https://isotopes.gov",
       "Domain": "isotopes.gov",
       "HTTPS Enabled?": 2,
       "HTTPS Enforced?": 3,
@@ -4334,6 +4953,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "http://www.italladdsup.gov",
       "Domain": "italladdsup.gov",
       "HTTPS Enabled?": 1,
       "HTTPS Enforced?": 1,
@@ -4341,6 +4961,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "http://www.itap.gov",
       "Domain": "itap.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -4348,6 +4969,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "https://itdashboard.gov",
       "Domain": "itdashboard.gov",
       "HTTPS Enabled?": 2,
       "HTTPS Enforced?": 3,
@@ -4355,6 +4977,7 @@
       "Strict Transport Security (HSTS)": 3
     },
     {
+      "Canonical": "http://itds.gov",
       "Domain": "itds.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -4362,6 +4985,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.itis.gov",
       "Domain": "itis.gov",
       "HTTPS Enabled?": 2,
       "HTTPS Enforced?": 0,
@@ -4369,6 +4993,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "http://www.itrd.gov",
       "Domain": "itrd.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -4376,6 +5001,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "https://www.its.gov",
       "Domain": "its.gov",
       "HTTPS Enabled?": 1,
       "HTTPS Enforced?": 3,
@@ -4383,6 +5009,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "http://www.jamesmadison.gov",
       "Domain": "jamesmadison.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -4390,6 +5017,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.jccs.gov",
       "Domain": "jccs.gov",
       "HTTPS Enabled?": 1,
       "HTTPS Enforced?": 1,
@@ -4397,6 +5025,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "https://www.jct.gov",
       "Domain": "jct.gov",
       "HTTPS Enabled?": 2,
       "HTTPS Enforced?": 2,
@@ -4404,6 +5033,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "http://jem.gov",
       "Domain": "jem.gov",
       "HTTPS Enabled?": 2,
       "HTTPS Enforced?": 1,
@@ -4411,6 +5041,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "http://jewishheritage.gov",
       "Domain": "jewishheritage.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -4418,6 +5049,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://jewishheritagemonth.gov",
       "Domain": "jewishheritagemonth.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -4425,6 +5057,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.jimmycarterlibrary.gov",
       "Domain": "jimmycarterlibrary.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -4432,6 +5065,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.jmc.gov",
       "Domain": "jmc.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -4439,6 +5073,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.jobcenter.gov",
       "Domain": "jobcenter.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -4446,6 +5081,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.jobcorps.gov",
       "Domain": "jobcorps.gov",
       "HTTPS Enabled?": 2,
       "HTTPS Enforced?": 1,
@@ -4453,6 +5089,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "http://www.joiningforces.gov",
       "Domain": "joiningforces.gov",
       "HTTPS Enabled?": 2,
       "HTTPS Enforced?": 1,
@@ -4460,6 +5097,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "http://www.judicialconference.gov",
       "Domain": "judicialconference.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -4467,6 +5105,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.justice.gov",
       "Domain": "justice.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -4474,6 +5113,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://justthinktwice.gov",
       "Domain": "justthinktwice.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -4481,6 +5121,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://juvenilecouncil.gov",
       "Domain": "juvenilecouncil.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -4488,6 +5129,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://jwod.gov",
       "Domain": "jwod.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -4495,6 +5137,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.kids.gov",
       "Domain": "kids.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -4502,6 +5145,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://klamathrestoration.gov",
       "Domain": "klamathrestoration.gov",
       "HTTPS Enabled?": 1,
       "HTTPS Enforced?": 1,
@@ -4509,6 +5153,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "http://www.labor.gov",
       "Domain": "labor.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -4516,6 +5161,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.lacoast.gov",
       "Domain": "lacoast.gov",
       "HTTPS Enabled?": 2,
       "HTTPS Enforced?": 1,
@@ -4523,6 +5169,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "http://landfire.gov",
       "Domain": "landfire.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -4530,6 +5177,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.landimaging.gov",
       "Domain": "landimaging.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -4537,6 +5185,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://lanl.gov",
       "Domain": "lanl.gov",
       "HTTPS Enabled?": 2,
       "HTTPS Enforced?": 1,
@@ -4544,6 +5193,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "https://www.latinofarmerclaims.gov",
       "Domain": "latinofarmerclaims.gov",
       "HTTPS Enabled?": 1,
       "HTTPS Enforced?": 3,
@@ -4551,6 +5201,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "http://www.law.gov",
       "Domain": "law.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -4558,6 +5209,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.lbl.gov",
       "Domain": "lbl.gov",
       "HTTPS Enabled?": 2,
       "HTTPS Enforced?": 1,
@@ -4565,6 +5217,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "http://lca.gov",
       "Domain": "lca.gov",
       "HTTPS Enabled?": 2,
       "HTTPS Enforced?": 0,
@@ -4572,6 +5225,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "http://www.lcacommons.gov",
       "Domain": "lcacommons.gov",
       "HTTPS Enabled?": 2,
       "HTTPS Enforced?": 0,
@@ -4579,6 +5233,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "http://www.lcrmscp.gov",
       "Domain": "lcrmscp.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -4586,6 +5241,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.learnandserve.gov",
       "Domain": "learnandserve.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -4593,6 +5249,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "https://www.learnperformance.gov",
       "Domain": "learnperformance.gov",
       "HTTPS Enabled?": 2,
       "HTTPS Enforced?": 2,
@@ -4600,6 +5257,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "http://www.legislative.gov",
       "Domain": "legislative.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -4607,6 +5265,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.legislativebranch.gov",
       "Domain": "legislativebranch.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -4614,6 +5273,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.lep.gov",
       "Domain": "lep.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -4621,6 +5281,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.letsmove.gov",
       "Domain": "letsmove.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -4628,6 +5289,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.library-of-congress.gov",
       "Domain": "library-of-congress.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -4635,6 +5297,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.libraryofcongress.gov",
       "Domain": "libraryofcongress.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -4642,6 +5305,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.lifeline.gov",
       "Domain": "lifeline.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -4649,6 +5313,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.lis.gov",
       "Domain": "lis.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -4656,6 +5321,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.listo.gov",
       "Domain": "listo.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -4663,6 +5329,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.literacy.gov",
       "Domain": "literacy.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -4670,6 +5337,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.llis.gov",
       "Domain": "llis.gov",
       "HTTPS Enabled?": 2,
       "HTTPS Enforced?": 1,
@@ -4677,6 +5345,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "https://www.llnl.gov",
       "Domain": "llnl.gov",
       "HTTPS Enabled?": 2,
       "HTTPS Enforced?": 3,
@@ -4684,6 +5353,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "http://lmrcouncil.gov",
       "Domain": "lmrcouncil.gov",
       "HTTPS Enabled?": 2,
       "HTTPS Enforced?": 1,
@@ -4691,6 +5361,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "http://lmvsci.gov",
       "Domain": "lmvsci.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -4698,6 +5369,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://loc.gov",
       "Domain": "loc.gov",
       "HTTPS Enabled?": 2,
       "HTTPS Enforced?": 1,
@@ -4705,6 +5377,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "http://locatorplus.gov",
       "Domain": "locatorplus.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -4712,6 +5385,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.locimages.gov",
       "Domain": "locimages.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -4719,6 +5393,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.locstore.gov",
       "Domain": "locstore.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -4726,6 +5401,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.loctps.gov",
       "Domain": "loctps.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -4733,6 +5409,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://longtermcare.gov",
       "Domain": "longtermcare.gov",
       "HTTPS Enabled?": 1,
       "HTTPS Enforced?": 1,
@@ -4740,6 +5417,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "http://www.lookstoogoodtobetrue.gov",
       "Domain": "lookstoogoodtobetrue.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -4747,6 +5425,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.lowermississippivalleyscience.gov",
       "Domain": "lowermississippivalleyscience.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -4754,6 +5433,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.lps.gov",
       "Domain": "lps.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -4761,6 +5441,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.lsc.gov",
       "Domain": "lsc.gov",
       "HTTPS Enabled?": 1,
       "HTTPS Enforced?": 1,
@@ -4768,6 +5449,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "https://www.macpac.gov",
       "Domain": "macpac.gov",
       "HTTPS Enabled?": 2,
       "HTTPS Enforced?": 3,
@@ -4775,6 +5457,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "http://www.mail.gov",
       "Domain": "mail.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -4782,6 +5465,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.majorityleader.gov",
       "Domain": "majorityleader.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -4789,6 +5473,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.majoritywhip.gov",
       "Domain": "majoritywhip.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -4796,6 +5481,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.makinghomeaffordable.gov",
       "Domain": "makinghomeaffordable.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -4803,6 +5489,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://malwareinvestigator.gov",
       "Domain": "malwareinvestigator.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -4810,6 +5497,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://manufacturing.gov",
       "Domain": "manufacturing.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -4817,6 +5505,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.mapaplanet.gov",
       "Domain": "mapaplanet.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -4824,6 +5513,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.mapstats.gov",
       "Domain": "mapstats.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -4831,6 +5521,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://marine.gov",
       "Domain": "marine.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -4838,6 +5529,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://marinecadastre.gov",
       "Domain": "marinecadastre.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -4845,6 +5537,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.marview.gov",
       "Domain": "marview.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -4852,6 +5545,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "https://www.max.gov",
       "Domain": "max.gov",
       "HTTPS Enabled?": 2,
       "HTTPS Enforced?": 3,
@@ -4859,6 +5553,7 @@
       "Strict Transport Security (HSTS)": 3
     },
     {
+      "Canonical": "http://www.mbda.gov",
       "Domain": "mbda.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -4866,6 +5561,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "https://mcc.gov",
       "Domain": "mcc.gov",
       "HTTPS Enabled?": 1,
       "HTTPS Enforced?": 3,
@@ -4873,6 +5569,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "http://www.mcrmc.gov",
       "Domain": "mcrmc.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -4880,6 +5577,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://mda.gov",
       "Domain": "mda.gov",
       "HTTPS Enabled?": 1,
       "HTTPS Enforced?": 1,
@@ -4887,6 +5585,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "https://www.medalofvalor.gov",
       "Domain": "medalofvalor.gov",
       "HTTPS Enabled?": 2,
       "HTTPS Enforced?": 3,
@@ -4894,6 +5593,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "http://medicaid.gov",
       "Domain": "medicaid.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -4901,6 +5601,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.medicalcountermeasures.gov",
       "Domain": "medicalcountermeasures.gov",
       "HTTPS Enabled?": 1,
       "HTTPS Enforced?": 1,
@@ -4908,6 +5609,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "https://www.medicalreservecorps.gov",
       "Domain": "medicalreservecorps.gov",
       "HTTPS Enabled?": 2,
       "HTTPS Enforced?": 3,
@@ -4915,6 +5617,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "http://medicare.gov",
       "Domain": "medicare.gov",
       "HTTPS Enabled?": 2,
       "HTTPS Enforced?": 1,
@@ -4922,6 +5625,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "http://www.medline.gov",
       "Domain": "medline.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -4929,6 +5633,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.medlineplus.gov",
       "Domain": "medlineplus.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -4936,6 +5641,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://medpac.gov",
       "Domain": "medpac.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -4943,6 +5649,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.mentalhealth.gov",
       "Domain": "mentalhealth.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -4950,6 +5657,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.mesh.gov",
       "Domain": "mesh.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -4957,6 +5665,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.mha.gov",
       "Domain": "mha.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -4964,6 +5673,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "https://www.mimedicare.gov",
       "Domain": "mimedicare.gov",
       "HTTPS Enabled?": 2,
       "HTTPS Enforced?": 3,
@@ -4971,6 +5681,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "http://www.mitigationcommission.gov",
       "Domain": "mitigationcommission.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -4978,6 +5689,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.mlkday.gov",
       "Domain": "mlkday.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -4985,6 +5697,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://mmc.gov",
       "Domain": "mmc.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -4992,6 +5705,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://mms.gov",
       "Domain": "mms.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -4999,6 +5713,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://moneyfactory.gov",
       "Domain": "moneyfactory.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -5006,6 +5721,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.moneyfactorystore.gov",
       "Domain": "moneyfactorystore.gov",
       "HTTPS Enabled?": 2,
       "HTTPS Enforced?": 0,
@@ -5013,6 +5729,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "http://www.mrgo.gov",
       "Domain": "mrgo.gov",
       "HTTPS Enabled?": 2,
       "HTTPS Enforced?": 1,
@@ -5020,6 +5737,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "http://www.mrlc.gov",
       "Domain": "mrlc.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -5027,6 +5745,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://msb.gov",
       "Domain": "msb.gov",
       "HTTPS Enabled?": 1,
       "HTTPS Enforced?": 1,
@@ -5034,6 +5753,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "http://www.msha.gov",
       "Domain": "msha.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -5041,6 +5761,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://mspb.gov",
       "Domain": "mspb.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -5048,6 +5769,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://mtbs.gov",
       "Domain": "mtbs.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -5055,6 +5777,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.mycreditunion.gov",
       "Domain": "mycreditunion.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -5062,6 +5785,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.myfdic.gov",
       "Domain": "myfdic.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -5069,6 +5793,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://myfdicinsurance.gov",
       "Domain": "myfdicinsurance.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -5076,6 +5801,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.myloc.gov",
       "Domain": "myloc.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -5083,6 +5809,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "https://mymedicare.gov",
       "Domain": "mymedicare.gov",
       "HTTPS Enabled?": 2,
       "HTTPS Enforced?": 3,
@@ -5090,6 +5817,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "http://www.mymoney.gov",
       "Domain": "mymoney.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -5097,6 +5825,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.mynextmove.gov",
       "Domain": "mynextmove.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -5104,6 +5833,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.myra.gov",
       "Domain": "myra.gov",
       "HTTPS Enabled?": 1,
       "HTTPS Enforced?": 1,
@@ -5111,6 +5841,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "http://myusa.gov",
       "Domain": "myusa.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -5118,6 +5849,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://nafri.gov",
       "Domain": "nafri.gov",
       "HTTPS Enabled?": 1,
       "HTTPS Enforced?": 1,
@@ -5125,6 +5857,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "http://nagb.gov",
       "Domain": "nagb.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -5132,6 +5865,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://namus.gov",
       "Domain": "namus.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -5139,6 +5873,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://nano.gov",
       "Domain": "nano.gov",
       "HTTPS Enabled?": 1,
       "HTTPS Enforced?": 0,
@@ -5146,6 +5881,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "http://www.nara.gov",
       "Domain": "nara.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -5153,6 +5889,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.nasa.gov",
       "Domain": "nasa.gov",
       "HTTPS Enabled?": 2,
       "HTTPS Enforced?": 1,
@@ -5160,6 +5897,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "http://www.nationalatlas.gov",
       "Domain": "nationalatlas.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -5167,6 +5905,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.nationalbank.gov",
       "Domain": "nationalbank.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -5174,6 +5913,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://nationalbankhelp.gov",
       "Domain": "nationalbankhelp.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -5181,6 +5921,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.nationalbanknet.gov",
       "Domain": "nationalbanknet.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -5188,6 +5929,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.nationalchildrensstudy.gov",
       "Domain": "nationalchildrensstudy.gov",
       "HTTPS Enabled?": 2,
       "HTTPS Enforced?": 1,
@@ -5195,6 +5937,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "http://www.nationalgangcenter.gov",
       "Domain": "nationalgangcenter.gov",
       "HTTPS Enabled?": 1,
       "HTTPS Enforced?": 1,
@@ -5202,6 +5945,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "http://nationalhousing.gov",
       "Domain": "nationalhousing.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -5209,6 +5953,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://nationalhousinglocator.gov",
       "Domain": "nationalhousinglocator.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -5216,6 +5961,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://nationalmap.gov",
       "Domain": "nationalmap.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -5223,6 +5969,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.nationalresourcedirectory.gov",
       "Domain": "nationalresourcedirectory.gov",
       "HTTPS Enabled?": 2,
       "HTTPS Enforced?": 1,
@@ -5230,6 +5977,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "http://www.nationalservice.gov",
       "Domain": "nationalservice.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -5237,6 +5985,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "https://www.nationalserviceresources.gov",
       "Domain": "nationalserviceresources.gov",
       "HTTPS Enabled?": 2,
       "HTTPS Enforced?": 3,
@@ -5244,6 +5993,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "http://www.nationsreportcard.gov",
       "Domain": "nationsreportcard.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -5251,6 +6001,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://nativeamericanheritagemonth.gov",
       "Domain": "nativeamericanheritagemonth.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -5258,6 +6009,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.navycash.gov",
       "Domain": "navycash.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -5265,6 +6017,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.nbc.gov",
       "Domain": "nbc.gov",
       "HTTPS Enabled?": 2,
       "HTTPS Enforced?": 1,
@@ -5272,6 +6025,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "http://www.nbm.gov",
       "Domain": "nbm.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -5279,6 +6033,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://nccrc.gov",
       "Domain": "nccrc.gov",
       "HTTPS Enabled?": 1,
       "HTTPS Enforced?": 1,
@@ -5286,6 +6041,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "http://www.nccs.gov",
       "Domain": "nccs.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -5293,6 +6049,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.ncd.gov",
       "Domain": "ncd.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -5300,6 +6057,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.ncifcrf.gov",
       "Domain": "ncifcrf.gov",
       "HTTPS Enabled?": 2,
       "HTTPS Enforced?": 1,
@@ -5307,6 +6065,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "https://ncirc.gov",
       "Domain": "ncirc.gov",
       "HTTPS Enabled?": 2,
       "HTTPS Enforced?": 3,
@@ -5314,6 +6073,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "http://ncix.gov",
       "Domain": "ncix.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -5321,6 +6081,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "https://ncjrs.gov",
       "Domain": "ncjrs.gov",
       "HTTPS Enabled?": 2,
       "HTTPS Enforced?": 3,
@@ -5328,6 +6089,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "http://www.ncpc.gov",
       "Domain": "ncpc.gov",
       "HTTPS Enabled?": 2,
       "HTTPS Enforced?": 1,
@@ -5335,6 +6097,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "http://www.ncpw.gov",
       "Domain": "ncpw.gov",
       "HTTPS Enabled?": 2,
       "HTTPS Enforced?": 1,
@@ -5342,6 +6105,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "http://www.ncrc.gov",
       "Domain": "ncrc.gov",
       "HTTPS Enabled?": 2,
       "HTTPS Enforced?": 1,
@@ -5349,6 +6113,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "http://www.nctc.gov",
       "Domain": "nctc.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -5356,6 +6121,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.ncua.gov",
       "Domain": "ncua.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -5363,6 +6129,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.ndep.gov",
       "Domain": "ndep.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -5370,6 +6137,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.ndop.gov",
       "Domain": "ndop.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -5377,6 +6145,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.ndsa.gov",
       "Domain": "ndsa.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -5384,6 +6153,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.nea.gov",
       "Domain": "nea.gov",
       "HTTPS Enabled?": 1,
       "HTTPS Enforced?": 1,
@@ -5391,6 +6161,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "http://neglecteddiseases.gov",
       "Domain": "neglecteddiseases.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -5398,6 +6169,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.neh.gov",
       "Domain": "neh.gov",
       "HTTPS Enabled?": 1,
       "HTTPS Enforced?": 1,
@@ -5405,6 +6177,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "http://nehrp.gov",
       "Domain": "nehrp.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -5412,6 +6185,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.nel.gov",
       "Domain": "nel.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -5419,6 +6193,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.nemi.gov",
       "Domain": "nemi.gov",
       "HTTPS Enabled?": 2,
       "HTTPS Enforced?": 1,
@@ -5426,6 +6201,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "http://www.nepa.gov",
       "Domain": "nepa.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -5433,6 +6209,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.nersc.gov",
       "Domain": "nersc.gov",
       "HTTPS Enabled?": 2,
       "HTTPS Enforced?": 1,
@@ -5440,6 +6217,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "http://www.neup.gov",
       "Domain": "neup.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -5447,6 +6225,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.newmoney.gov",
       "Domain": "newmoney.gov",
       "HTTPS Enabled?": 2,
       "HTTPS Enforced?": 0,
@@ -5454,6 +6233,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "https://nfpors.gov",
       "Domain": "nfpors.gov",
       "HTTPS Enabled?": 2,
       "HTTPS Enforced?": 2,
@@ -5461,6 +6241,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "http://www.nga.gov",
       "Domain": "nga.gov",
       "HTTPS Enabled?": 2,
       "HTTPS Enforced?": 1,
@@ -5468,6 +6249,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "http://www.ngc.gov",
       "Domain": "ngc.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -5475,6 +6257,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://nhl.gov",
       "Domain": "nhl.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -5482,6 +6265,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.nhtsa.gov",
       "Domain": "nhtsa.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -5489,6 +6273,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.nibin.gov",
       "Domain": "nibin.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -5496,6 +6281,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.nic.gov",
       "Domain": "nic.gov",
       "HTTPS Enabled?": 2,
       "HTTPS Enforced?": 1,
@@ -5503,6 +6289,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "http://nicic.gov",
       "Domain": "nicic.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -5510,6 +6297,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "https://www.niem.gov",
       "Domain": "niem.gov",
       "HTTPS Enabled?": 2,
       "HTTPS Enforced?": 3,
@@ -5517,6 +6305,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "http://www.nifc.gov",
       "Domain": "nifc.gov",
       "HTTPS Enabled?": 1,
       "HTTPS Enforced?": 1,
@@ -5524,6 +6313,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "http://niftt.gov",
       "Domain": "niftt.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -5531,6 +6321,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://nigc.gov",
       "Domain": "nigc.gov",
       "HTTPS Enabled?": 1,
       "HTTPS Enforced?": 1,
@@ -5538,6 +6329,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "http://nih.gov",
       "Domain": "nih.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -5545,6 +6337,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://nihseniorhealth.gov",
       "Domain": "nihseniorhealth.gov",
       "HTTPS Enabled?": 2,
       "HTTPS Enforced?": 1,
@@ -5552,6 +6345,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "http://www.nij.gov",
       "Domain": "nij.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -5559,6 +6353,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.niosh.gov",
       "Domain": "niosh.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -5566,6 +6361,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://nist.gov",
       "Domain": "nist.gov",
       "HTTPS Enabled?": 2,
       "HTTPS Enforced?": 1,
@@ -5573,6 +6369,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "https://www.nitrd.gov",
       "Domain": "nitrd.gov",
       "HTTPS Enabled?": 2,
       "HTTPS Enforced?": 3,
@@ -5580,6 +6377,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "http://nixonlibrary.gov",
       "Domain": "nixonlibrary.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -5587,6 +6385,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.nlm.gov",
       "Domain": "nlm.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -5594,6 +6393,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://nlrb.gov",
       "Domain": "nlrb.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -5601,6 +6401,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://nls.gov",
       "Domain": "nls.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -5608,6 +6409,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.nmb.gov",
       "Domain": "nmb.gov",
       "HTTPS Enabled?": 1,
       "HTTPS Enforced?": 0,
@@ -5615,6 +6417,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "http://nmcourt.fed.us",
       "Domain": "nmcourt.fed.us",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -5622,6 +6425,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.nmic.gov",
       "Domain": "nmic.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -5629,6 +6433,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.nmvtis.gov",
       "Domain": "nmvtis.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -5636,6 +6441,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://nnlm.gov",
       "Domain": "nnlm.gov",
       "HTTPS Enabled?": 1,
       "HTTPS Enforced?": 1,
@@ -5643,6 +6449,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "http://www.noaa.gov",
       "Domain": "noaa.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -5650,6 +6457,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.noaawatch.gov",
       "Domain": "noaawatch.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -5657,6 +6465,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.nolaenvironmental.gov",
       "Domain": "nolaenvironmental.gov",
       "HTTPS Enabled?": 2,
       "HTTPS Enforced?": 1,
@@ -5664,6 +6473,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "http://www.nonprofit.gov",
       "Domain": "nonprofit.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -5671,6 +6481,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "https://www.notalone.gov",
       "Domain": "notalone.gov",
       "HTTPS Enabled?": 2,
       "HTTPS Enforced?": 3,
@@ -5678,6 +6489,7 @@
       "Strict Transport Security (HSTS)": 3
     },
     {
+      "Canonical": "http://www.nps.gov",
       "Domain": "nps.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -5685,6 +6497,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.nrc.gov",
       "Domain": "nrc.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -5692,6 +6505,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "https://www.nrd.gov",
       "Domain": "nrd.gov",
       "HTTPS Enabled?": 2,
       "HTTPS Enforced?": 3,
@@ -5699,6 +6513,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "http://www.nrel.gov",
       "Domain": "nrel.gov",
       "HTTPS Enabled?": 2,
       "HTTPS Enforced?": 0,
@@ -5706,6 +6521,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "http://nro.gov",
       "Domain": "nro.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -5713,6 +6529,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://nrojr.gov",
       "Domain": "nrojr.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -5720,6 +6537,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "https://www.nsa.gov",
       "Domain": "nsa.gov",
       "HTTPS Enabled?": 2,
       "HTTPS Enforced?": 3,
@@ -5727,6 +6545,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "http://nsep.gov",
       "Domain": "nsep.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -5734,6 +6553,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.nsf.gov",
       "Domain": "nsf.gov",
       "HTTPS Enabled?": 2,
       "HTTPS Enforced?": 0,
@@ -5741,6 +6561,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "http://www.nsopw.gov",
       "Domain": "nsopw.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -5748,6 +6569,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.nstic.gov",
       "Domain": "nstic.gov",
       "HTTPS Enabled?": 1,
       "HTTPS Enforced?": 1,
@@ -5755,6 +6577,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "http://nswp.gov",
       "Domain": "nswp.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -5762,6 +6585,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.ntdprogram.gov",
       "Domain": "ntdprogram.gov",
       "HTTPS Enabled?": 2,
       "HTTPS Enforced?": 1,
@@ -5769,6 +6593,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "http://www.ntis.gov",
       "Domain": "ntis.gov",
       "HTTPS Enabled?": 2,
       "HTTPS Enforced?": 1,
@@ -5776,6 +6601,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "http://www.ntrc.gov",
       "Domain": "ntrc.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -5783,6 +6609,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.ntsb.gov",
       "Domain": "ntsb.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -5790,6 +6617,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.nutrition.gov",
       "Domain": "nutrition.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -5797,6 +6625,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.nutritionevidencelibrary.gov",
       "Domain": "nutritionevidencelibrary.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -5804,6 +6633,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.nvtc.gov",
       "Domain": "nvtc.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -5811,6 +6641,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "https://www.nwbc.gov",
       "Domain": "nwbc.gov",
       "HTTPS Enabled?": 2,
       "HTTPS Enforced?": 3,
@@ -5818,6 +6649,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "http://www.nwcg.gov",
       "Domain": "nwcg.gov",
       "HTTPS Enabled?": 1,
       "HTTPS Enforced?": 1,
@@ -5825,6 +6657,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "http://occ.gov",
       "Domain": "occ.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -5832,6 +6665,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://occhelps.gov",
       "Domain": "occhelps.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -5839,6 +6673,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.odni.gov",
       "Domain": "odni.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -5846,6 +6681,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.oea.gov",
       "Domain": "oea.gov",
       "HTTPS Enabled?": 1,
       "HTTPS Enforced?": 1,
@@ -5853,6 +6689,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "http://www.ofcm.gov",
       "Domain": "ofcm.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -5860,6 +6697,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "https://www.ofda.gov",
       "Domain": "ofda.gov",
       "HTTPS Enabled?": 2,
       "HTTPS Enforced?": 2,
@@ -5867,6 +6705,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "http://ofee.gov",
       "Domain": "ofee.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -5874,6 +6713,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.ofr.gov",
       "Domain": "ofr.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -5881,6 +6721,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://oge.gov",
       "Domain": "oge.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -5888,6 +6729,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.ogis.gov",
       "Domain": "ogis.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -5895,6 +6737,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://ojjdp.gov",
       "Domain": "ojjdp.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -5902,6 +6745,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://ojp.gov",
       "Domain": "ojp.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -5909,6 +6753,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.omb.gov",
       "Domain": "omb.gov",
       "HTTPS Enabled?": 2,
       "HTTPS Enforced?": 1,
@@ -5916,6 +6761,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "http://www.omblog.gov",
       "Domain": "omblog.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -5923,6 +6769,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.ondcp.gov",
       "Domain": "ondcp.gov",
       "HTTPS Enabled?": 2,
       "HTTPS Enforced?": 1,
@@ -5930,6 +6777,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "http://www.onguardonline.gov",
       "Domain": "onguardonline.gov",
       "HTTPS Enabled?": 2,
       "HTTPS Enforced?": 1,
@@ -5937,6 +6785,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "http://onhir.gov",
       "Domain": "onhir.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -5944,6 +6793,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.onlineonguard.gov",
       "Domain": "onlineonguard.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -5951,6 +6801,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://onlinewbc.gov",
       "Domain": "onlinewbc.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -5958,6 +6809,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://onrr.gov",
       "Domain": "onrr.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -5965,6 +6817,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.openinternet.gov",
       "Domain": "openinternet.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -5972,6 +6825,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "https://www.opensource.gov",
       "Domain": "opensource.gov",
       "HTTPS Enabled?": 2,
       "HTTPS Enforced?": 3,
@@ -5979,6 +6833,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "http://openworld.gov",
       "Domain": "openworld.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -5986,6 +6841,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "https://www.opic.gov",
       "Domain": "opic.gov",
       "HTTPS Enabled?": 2,
       "HTTPS Enforced?": 3,
@@ -5993,6 +6849,7 @@
       "Strict Transport Security (HSTS)": 1
     },
     {
+      "Canonical": "http://www.opm.gov",
       "Domain": "opm.gov",
       "HTTPS Enabled?": 2,
       "HTTPS Enforced?": 1,
@@ -6000,6 +6857,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "http://www.opportunity.gov",
       "Domain": "opportunity.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -6007,6 +6865,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.orau.gov",
       "Domain": "orau.gov",
       "HTTPS Enabled?": 2,
       "HTTPS Enforced?": 0,
@@ -6014,6 +6873,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "http://www.organdonor.gov",
       "Domain": "organdonor.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -6021,6 +6881,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.ornl.gov",
       "Domain": "ornl.gov",
       "HTTPS Enabled?": 2,
       "HTTPS Enforced?": 1,
@@ -6028,6 +6889,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "https://www.osac.gov",
       "Domain": "osac.gov",
       "HTTPS Enabled?": 2,
       "HTTPS Enforced?": 3,
@@ -6035,6 +6897,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "https://osc.gov",
       "Domain": "osc.gov",
       "HTTPS Enabled?": 2,
       "HTTPS Enforced?": 3,
@@ -6042,6 +6905,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "http://osdbu.gov",
       "Domain": "osdbu.gov",
       "HTTPS Enabled?": 1,
       "HTTPS Enforced?": 1,
@@ -6049,6 +6913,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "https://www.osha.gov",
       "Domain": "osha.gov",
       "HTTPS Enabled?": 2,
       "HTTPS Enforced?": 2,
@@ -6056,6 +6921,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "http://oshrc.gov",
       "Domain": "oshrc.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -6063,6 +6929,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.osm.gov",
       "Domain": "osm.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -6070,6 +6937,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.osmre.gov",
       "Domain": "osmre.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -6077,6 +6945,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.osti.gov",
       "Domain": "osti.gov",
       "HTTPS Enabled?": 2,
       "HTTPS Enforced?": 0,
@@ -6084,6 +6953,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "http://www.ostp.gov",
       "Domain": "ostp.gov",
       "HTTPS Enabled?": 2,
       "HTTPS Enforced?": 1,
@@ -6091,6 +6961,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "http://oti.gov",
       "Domain": "oti.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -6098,6 +6969,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://ots.gov",
       "Domain": "ots.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -6105,6 +6977,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://ourdocuments.gov",
       "Domain": "ourdocuments.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -6112,6 +6985,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://ovc.gov",
       "Domain": "ovc.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -6119,6 +6993,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "https://www.ovcttac.gov",
       "Domain": "ovcttac.gov",
       "HTTPS Enabled?": 2,
       "HTTPS Enforced?": 3,
@@ -6126,6 +7001,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "https://www.pacer.gov",
       "Domain": "pacer.gov",
       "HTTPS Enabled?": 2,
       "HTTPS Enforced?": 3,
@@ -6133,6 +7009,7 @@
       "Strict Transport Security (HSTS)": 1
     },
     {
+      "Canonical": "http://www.pandemicflu.gov",
       "Domain": "pandemicflu.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -6140,6 +7017,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.papahanaumokuakea.gov",
       "Domain": "papahanaumokuakea.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -6147,6 +7025,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.partner4solutions.gov",
       "Domain": "partner4solutions.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -6154,6 +7033,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://patriotbonds.gov",
       "Domain": "patriotbonds.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -6161,6 +7041,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "https://pay.gov",
       "Domain": "pay.gov",
       "HTTPS Enabled?": 1,
       "HTTPS Enforced?": 3,
@@ -6168,6 +7049,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "https://paymentaccuracy.gov",
       "Domain": "paymentaccuracy.gov",
       "HTTPS Enabled?": 2,
       "HTTPS Enforced?": 3,
@@ -6175,6 +7057,7 @@
       "Strict Transport Security (HSTS)": 3
     },
     {
+      "Canonical": "http://pbgc.gov",
       "Domain": "pbgc.gov",
       "HTTPS Enabled?": 2,
       "HTTPS Enforced?": 1,
@@ -6182,6 +7065,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "http://pcah.gov",
       "Domain": "pcah.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -6189,6 +7073,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.pcip.gov",
       "Domain": "pcip.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -6196,6 +7081,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "https://pclob.gov",
       "Domain": "pclob.gov",
       "HTTPS Enabled?": 2,
       "HTTPS Enforced?": 3,
@@ -6203,6 +7089,7 @@
       "Strict Transport Security (HSTS)": 3
     },
     {
+      "Canonical": "http://www.pdbcecc.gov",
       "Domain": "pdbcecc.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -6210,6 +7097,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://peacecore.gov",
       "Domain": "peacecore.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -6217,6 +7105,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://peacecorp.gov",
       "Domain": "peacecorp.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -6224,6 +7113,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.peacecorps.gov",
       "Domain": "peacecorps.gov",
       "HTTPS Enabled?": 2,
       "HTTPS Enforced?": 0,
@@ -6231,6 +7121,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "http://www.pentagon.gov",
       "Domain": "pentagon.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -6238,6 +7129,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.pepfar.gov",
       "Domain": "pepfar.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -6245,6 +7137,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.performance.gov",
       "Domain": "performance.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -6252,6 +7145,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.phe.gov",
       "Domain": "phe.gov",
       "HTTPS Enabled?": 1,
       "HTTPS Enforced?": 1,
@@ -6259,6 +7153,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "https://pic.gov",
       "Domain": "pic.gov",
       "HTTPS Enabled?": 2,
       "HTTPS Enforced?": 3,
@@ -6266,6 +7161,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "http://www.piedrasblancas.gov",
       "Domain": "piedrasblancas.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -6273,6 +7169,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.plainlanguage.gov",
       "Domain": "plainlanguage.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -6280,6 +7177,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://pmf.gov",
       "Domain": "pmf.gov",
       "HTTPS Enabled?": 2,
       "HTTPS Enforced?": 1,
@@ -6287,6 +7185,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "http://pmi.gov",
       "Domain": "pmi.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -6294,6 +7193,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.pnl.gov",
       "Domain": "pnl.gov",
       "HTTPS Enabled?": 2,
       "HTTPS Enforced?": 1,
@@ -6301,6 +7201,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "http://www.pnnl.gov",
       "Domain": "pnnl.gov",
       "HTTPS Enabled?": 2,
       "HTTPS Enforced?": 1,
@@ -6308,6 +7209,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "http://www.poolsafely.gov",
       "Domain": "poolsafely.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -6315,6 +7217,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.poolsafety.gov",
       "Domain": "poolsafety.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -6322,6 +7225,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.postoffice.gov",
       "Domain": "postoffice.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -6329,6 +7233,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://ppdcecc.gov",
       "Domain": "ppdcecc.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -6336,6 +7241,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "https://www.ppirs.gov",
       "Domain": "ppirs.gov",
       "HTTPS Enabled?": 1,
       "HTTPS Enforced?": 3,
@@ -6343,6 +7249,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "http://www.pracomment.gov",
       "Domain": "pracomment.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -6350,6 +7257,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.prc.gov",
       "Domain": "prc.gov",
       "HTTPS Enabled?": 2,
       "HTTPS Enforced?": 0,
@@ -6357,6 +7265,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "http://www.pregunteleakaren.gov",
       "Domain": "pregunteleakaren.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -6364,6 +7273,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://preserveamerica.gov",
       "Domain": "preserveamerica.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -6371,6 +7281,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.presidentialdocuments.gov",
       "Domain": "presidentialdocuments.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -6378,6 +7289,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.presidentialserviceawards.gov",
       "Domain": "presidentialserviceawards.gov",
       "HTTPS Enabled?": 2,
       "HTTPS Enforced?": 0,
@@ -6385,6 +7297,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "http://www.presidio.gov",
       "Domain": "presidio.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -6392,6 +7305,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.presidiotrust.gov",
       "Domain": "presidiotrust.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -6399,6 +7313,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://pretrialservices.gov",
       "Domain": "pretrialservices.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -6406,6 +7321,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.primarysources.gov",
       "Domain": "primarysources.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -6413,6 +7329,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.projectsafechildhood.gov",
       "Domain": "projectsafechildhood.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -6420,6 +7337,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.projectsafeneighborhoods.gov",
       "Domain": "projectsafeneighborhoods.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -6427,6 +7345,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.protecciondelconsumidor.gov",
       "Domain": "protecciondelconsumidor.gov",
       "HTTPS Enabled?": 2,
       "HTTPS Enforced?": 1,
@@ -6434,6 +7353,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "https://www.protectyourmove.gov",
       "Domain": "protectyourmove.gov",
       "HTTPS Enabled?": 2,
       "HTTPS Enforced?": 3,
@@ -6441,6 +7361,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "http://psa.gov",
       "Domain": "psa.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -6448,6 +7369,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.psc.gov",
       "Domain": "psc.gov",
       "HTTPS Enabled?": 1,
       "HTTPS Enforced?": 1,
@@ -6455,6 +7377,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "http://pscr.gov",
       "Domain": "pscr.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -6462,6 +7385,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "https://psob.gov",
       "Domain": "psob.gov",
       "HTTPS Enabled?": 2,
       "HTTPS Enforced?": 3,
@@ -6469,6 +7393,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "http://www.ptf.gov",
       "Domain": "ptf.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -6476,6 +7401,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.pubmed.gov",
       "Domain": "pubmed.gov",
       "HTTPS Enabled?": 2,
       "HTTPS Enforced?": 1,
@@ -6483,6 +7409,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "http://www.pubmedcentral.gov",
       "Domain": "pubmedcentral.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -6490,6 +7417,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "https://www.qatesttwai.gov",
       "Domain": "qatesttwai.gov",
       "HTTPS Enabled?": 1,
       "HTTPS Enforced?": 3,
@@ -6497,6 +7425,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "http://www.quic.gov",
       "Domain": "quic.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -6504,6 +7433,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.quick.gov",
       "Domain": "quick.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -6511,6 +7441,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.rcfl.gov",
       "Domain": "rcfl.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -6518,6 +7449,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.reachhigher.gov",
       "Domain": "reachhigher.gov",
       "HTTPS Enabled?": 2,
       "HTTPS Enforced?": 1,
@@ -6525,6 +7457,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "http://www.read.gov",
       "Domain": "read.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -6532,6 +7465,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.ready.gov",
       "Domain": "ready.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -6539,6 +7473,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.readybusiness.gov",
       "Domain": "readybusiness.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -6546,6 +7481,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://reaganlibrary.gov",
       "Domain": "reaganlibrary.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -6553,6 +7489,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://realestatesales.gov",
       "Domain": "realestatesales.gov",
       "HTTPS Enabled?": 2,
       "HTTPS Enforced?": 1,
@@ -6560,6 +7497,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "https://www.realpropertyprofile.gov",
       "Domain": "realpropertyprofile.gov",
       "HTTPS Enabled?": 2,
       "HTTPS Enforced?": 2,
@@ -6567,6 +7505,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "http://www.recalls.gov",
       "Domain": "recalls.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -6574,6 +7513,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.recovery.gov",
       "Domain": "recovery.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -6581,6 +7521,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://recoverymonth.gov",
       "Domain": "recoverymonth.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -6588,6 +7529,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.recreation.gov",
       "Domain": "recreation.gov",
       "HTTPS Enabled?": 2,
       "HTTPS Enforced?": 0,
@@ -6595,6 +7537,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "http://www.reentry.gov",
       "Domain": "reentry.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -6602,6 +7545,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://reginfo.gov",
       "Domain": "reginfo.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -6609,6 +7553,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.regulation.gov",
       "Domain": "regulation.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -6616,6 +7561,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.regulations.gov",
       "Domain": "regulations.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -6623,6 +7569,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://relocatefeds.gov",
       "Domain": "relocatefeds.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -6630,6 +7577,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://reo.gov",
       "Domain": "reo.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -6637,6 +7585,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.reportband.gov",
       "Domain": "reportband.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -6644,6 +7593,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.republicans.gov",
       "Domain": "republicans.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -6651,6 +7601,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.research.gov",
       "Domain": "research.gov",
       "HTTPS Enabled?": 2,
       "HTTPS Enforced?": 1,
@@ -6658,6 +7609,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "http://restorethegulf.gov",
       "Domain": "restorethegulf.gov",
       "HTTPS Enabled?": 2,
       "HTTPS Enforced?": 1,
@@ -6665,6 +7617,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "http://rivers.gov",
       "Domain": "rivers.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -6672,6 +7625,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://rocis.gov",
       "Domain": "rocis.gov",
       "HTTPS Enabled?": 1,
       "HTTPS Enforced?": 1,
@@ -6679,6 +7633,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "http://www.rrb.gov",
       "Domain": "rrb.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -6686,6 +7641,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://sac.gov",
       "Domain": "sac.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -6693,6 +7649,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.safecom.gov",
       "Domain": "safecom.gov",
       "HTTPS Enabled?": 2,
       "HTTPS Enforced?": 1,
@@ -6700,6 +7657,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "http://www.safecomprogram.gov",
       "Domain": "safecomprogram.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -6707,6 +7665,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.safercar.gov",
       "Domain": "safercar.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -6714,6 +7673,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.saferproduct.gov",
       "Domain": "saferproduct.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -6721,6 +7681,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.saferproducts.gov",
       "Domain": "saferproducts.gov",
       "HTTPS Enabled?": 2,
       "HTTPS Enforced?": 0,
@@ -6728,6 +7689,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "http://safertruck.gov",
       "Domain": "safertruck.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -6735,6 +7697,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "https://safetyact.gov",
       "Domain": "safetyact.gov",
       "HTTPS Enabled?": 1,
       "HTTPS Enforced?": 3,
@@ -6742,6 +7705,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "http://www.safetyvideos.gov",
       "Domain": "safetyvideos.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -6749,6 +7713,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.safeyouth.gov",
       "Domain": "safeyouth.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -6756,6 +7721,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.salmonrecovery.gov",
       "Domain": "salmonrecovery.gov",
       "HTTPS Enabled?": 2,
       "HTTPS Enforced?": 1,
@@ -6763,6 +7729,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "https://www.sam.gov",
       "Domain": "sam.gov",
       "HTTPS Enabled?": 1,
       "HTTPS Enforced?": 3,
@@ -6770,6 +7737,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "http://www.samhsa.gov",
       "Domain": "samhsa.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -6777,6 +7745,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.sandia.gov",
       "Domain": "sandia.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -6784,6 +7753,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.save.gov",
       "Domain": "save.gov",
       "HTTPS Enabled?": 2,
       "HTTPS Enforced?": 1,
@@ -6791,6 +7761,7 @@
       "Strict Transport Security (HSTS)": 3
     },
     {
+      "Canonical": "http://www.saveaward.gov",
       "Domain": "saveaward.gov",
       "HTTPS Enabled?": 2,
       "HTTPS Enforced?": 1,
@@ -6798,6 +7769,7 @@
       "Strict Transport Security (HSTS)": 3
     },
     {
+      "Canonical": "http://savingsbond.gov",
       "Domain": "savingsbond.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -6805,6 +7777,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://savingsbonds.gov",
       "Domain": "savingsbonds.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -6812,6 +7785,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://savingsbondwizard.gov",
       "Domain": "savingsbondwizard.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -6819,6 +7793,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "https://www.sba.gov",
       "Domain": "sba.gov",
       "HTTPS Enabled?": 2,
       "HTTPS Enforced?": 3,
@@ -6826,6 +7801,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "http://www.sbir.gov",
       "Domain": "sbir.gov",
       "HTTPS Enabled?": 1,
       "HTTPS Enforced?": 1,
@@ -6833,6 +7809,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "http://www.scidac.gov",
       "Domain": "scidac.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -6840,6 +7817,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.science.gov",
       "Domain": "science.gov",
       "HTTPS Enabled?": 2,
       "HTTPS Enforced?": 1,
@@ -6847,6 +7825,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "http://www.science360.gov",
       "Domain": "science360.gov",
       "HTTPS Enabled?": 1,
       "HTTPS Enforced?": 1,
@@ -6854,6 +7833,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "http://www.scienceaccelerator.gov",
       "Domain": "scienceaccelerator.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -6861,6 +7841,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "https://www.sciencebase.gov",
       "Domain": "sciencebase.gov",
       "HTTPS Enabled?": 2,
       "HTTPS Enforced?": 3,
@@ -6868,6 +7849,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "http://www.scienceeducation.gov",
       "Domain": "scienceeducation.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -6875,6 +7857,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.scijinks.gov",
       "Domain": "scijinks.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -6882,6 +7865,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.scra.gov",
       "Domain": "scra.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -6889,6 +7873,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.sdr.gov",
       "Domain": "sdr.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -6896,6 +7881,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.sec.gov",
       "Domain": "sec.gov",
       "HTTPS Enabled?": 2,
       "HTTPS Enforced?": 1,
@@ -6903,6 +7889,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "http://www.secretservice.gov",
       "Domain": "secretservice.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -6910,6 +7897,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://section108.gov",
       "Domain": "section108.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -6917,6 +7905,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://section508.gov",
       "Domain": "section508.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -6924,6 +7913,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.seguridadconsumidor.gov",
       "Domain": "seguridadconsumidor.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -6931,6 +7921,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://segurosocial.gov",
       "Domain": "segurosocial.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -6938,6 +7929,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.selectagents.gov",
       "Domain": "selectagents.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -6945,6 +7937,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.selectusa.gov",
       "Domain": "selectusa.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -6952,6 +7945,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.senate.gov",
       "Domain": "senate.gov",
       "HTTPS Enabled?": 2,
       "HTTPS Enforced?": 0,
@@ -6959,6 +7953,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "http://www.senatecalendar.gov",
       "Domain": "senatecalendar.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -6966,6 +7961,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.senaterestaurants.gov",
       "Domain": "senaterestaurants.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -6973,6 +7969,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.seniorcorps.gov",
       "Domain": "seniorcorps.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -6980,6 +7977,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.seniors.gov",
       "Domain": "seniors.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -6987,6 +7985,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.sentinel.gov",
       "Domain": "sentinel.gov",
       "HTTPS Enabled?": 2,
       "HTTPS Enforced?": 1,
@@ -6994,6 +7993,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "http://www.serve.gov",
       "Domain": "serve.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -7001,6 +8001,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.service.gov",
       "Domain": "service.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -7008,6 +8009,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.servicelearning.gov",
       "Domain": "servicelearning.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -7015,6 +8017,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.servicemembers.gov",
       "Domain": "servicemembers.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -7022,6 +8025,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "https://sftool.gov",
       "Domain": "sftool.gov",
       "HTTPS Enabled?": 2,
       "HTTPS Enforced?": 3,
@@ -7029,6 +8033,7 @@
       "Strict Transport Security (HSTS)": 3
     },
     {
+      "Canonical": "http://www.sharetheroadsafely.gov",
       "Domain": "sharetheroadsafely.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -7036,6 +8041,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://sierrawild.gov",
       "Domain": "sierrawild.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -7043,6 +8049,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.sigtarp.gov",
       "Domain": "sigtarp.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -7050,6 +8057,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.siteidiq.gov",
       "Domain": "siteidiq.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -7057,6 +8065,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://slgs.gov",
       "Domain": "slgs.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -7064,6 +8073,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.smallbusiness.gov",
       "Domain": "smallbusiness.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -7071,6 +8081,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://smart.gov",
       "Domain": "smart.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -7078,6 +8089,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.smartcheck.gov",
       "Domain": "smartcheck.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -7085,6 +8097,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "https://www.smartgrid.gov",
       "Domain": "smartgrid.gov",
       "HTTPS Enabled?": 2,
       "HTTPS Enforced?": 3,
@@ -7092,6 +8105,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "http://smokefree.gov",
       "Domain": "smokefree.gov",
       "HTTPS Enabled?": 1,
       "HTTPS Enforced?": 1,
@@ -7099,6 +8113,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "http://snap.gov",
       "Domain": "snap.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -7106,6 +8121,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://sns.gov",
       "Domain": "sns.gov",
       "HTTPS Enabled?": 1,
       "HTTPS Enforced?": 1,
@@ -7113,6 +8129,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "http://socialsecurity.gov",
       "Domain": "socialsecurity.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -7120,6 +8137,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.solardecathlon.gov",
       "Domain": "solardecathlon.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -7127,6 +8145,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.spaceweather.gov",
       "Domain": "spaceweather.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -7134,6 +8153,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.speaker.gov",
       "Domain": "speaker.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -7141,6 +8161,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.spectrum.gov",
       "Domain": "spectrum.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -7148,6 +8169,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.srs.gov",
       "Domain": "srs.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -7155,6 +8177,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://ssa.gov",
       "Domain": "ssa.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -7162,6 +8185,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://ssab.gov",
       "Domain": "ssab.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -7169,6 +8193,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.sss.gov",
       "Domain": "sss.gov",
       "HTTPS Enabled?": 1,
       "HTTPS Enforced?": 1,
@@ -7176,6 +8201,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "https://www.standards.gov",
       "Domain": "standards.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -7183,6 +8209,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://start2farm.gov",
       "Domain": "start2farm.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -7190,6 +8217,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.state.gov",
       "Domain": "state.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -7197,6 +8225,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://stennis.gov",
       "Domain": "stennis.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -7204,6 +8233,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.steroidabuse.gov",
       "Domain": "steroidabuse.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -7211,6 +8241,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://stopalcoholabuse.gov",
       "Domain": "stopalcoholabuse.gov",
       "HTTPS Enabled?": 2,
       "HTTPS Enforced?": 1,
@@ -7218,6 +8249,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "http://www.stopbullying.gov",
       "Domain": "stopbullying.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -7225,6 +8257,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.stopfakes.gov",
       "Domain": "stopfakes.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -7232,6 +8265,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.stopfraud.gov",
       "Domain": "stopfraud.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -7239,6 +8273,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.stopmedicarefraud.gov",
       "Domain": "stopmedicarefraud.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -7246,6 +8281,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "https://strategicsourcing.gov",
       "Domain": "strategicsourcing.gov",
       "HTTPS Enabled?": 2,
       "HTTPS Enforced?": 2,
@@ -7253,6 +8289,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "http://www.strongmiddleclass.gov",
       "Domain": "strongmiddleclass.gov",
       "HTTPS Enabled?": 2,
       "HTTPS Enforced?": 1,
@@ -7260,6 +8297,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "http://www.strongports.gov",
       "Domain": "strongports.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -7267,6 +8305,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "https://www.studentaid.gov",
       "Domain": "studentaid.gov",
       "HTTPS Enabled?": 2,
       "HTTPS Enforced?": 2,
@@ -7274,6 +8313,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "https://www.studentloans.gov",
       "Domain": "studentloans.gov",
       "HTTPS Enabled?": 2,
       "HTTPS Enforced?": 3,
@@ -7281,6 +8321,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "http://www.supportthevoter.gov",
       "Domain": "supportthevoter.gov",
       "HTTPS Enabled?": 2,
       "HTTPS Enforced?": 1,
@@ -7288,6 +8329,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "http://www.supremecourt.gov",
       "Domain": "supremecourt.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -7295,6 +8337,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.supremecourtus.gov",
       "Domain": "supremecourtus.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -7302,6 +8345,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.surgeongeneral.gov",
       "Domain": "surgeongeneral.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -7309,6 +8353,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://sustainability.gov",
       "Domain": "sustainability.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -7316,6 +8361,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.sustainablecommunities.gov",
       "Domain": "sustainablecommunities.gov",
       "HTTPS Enabled?": 2,
       "HTTPS Enforced?": 0,
@@ -7323,6 +8369,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "http://swpa.gov",
       "Domain": "swpa.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -7330,6 +8377,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "https://www.symbols.gov",
       "Domain": "symbols.gov",
       "HTTPS Enabled?": 2,
       "HTTPS Enforced?": 3,
@@ -7337,6 +8385,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "http://taaps.gov",
       "Domain": "taaps.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -7344,6 +8393,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.tax.gov",
       "Domain": "tax.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -7351,6 +8401,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "https://taxreform.gov",
       "Domain": "taxreform.gov",
       "HTTPS Enabled?": 2,
       "HTTPS Enforced?": 2,
@@ -7358,6 +8409,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "http://www.teachingprimarysources.gov",
       "Domain": "teachingprimarysources.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -7365,6 +8417,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.teachingwithprimarysources.gov",
       "Domain": "teachingwithprimarysources.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -7372,6 +8425,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://telework.gov",
       "Domain": "telework.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -7379,6 +8433,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.tfhrc.gov",
       "Domain": "tfhrc.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -7386,6 +8441,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://thecoolspot.gov",
       "Domain": "thecoolspot.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -7393,6 +8449,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://thepeoplesgarden.gov",
       "Domain": "thepeoplesgarden.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -7400,6 +8457,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.therealcost.gov",
       "Domain": "therealcost.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -7407,6 +8465,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.thesecondthing.gov",
       "Domain": "thesecondthing.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -7414,6 +8473,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.thomas.gov",
       "Domain": "thomas.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -7421,6 +8481,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.tigta.gov",
       "Domain": "tigta.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -7428,6 +8489,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://time.gov",
       "Domain": "time.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -7435,6 +8497,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://tissueengineering.gov",
       "Domain": "tissueengineering.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -7442,6 +8505,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.tobacco.gov",
       "Domain": "tobacco.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -7449,6 +8513,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.tps.gov",
       "Domain": "tps.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -7456,6 +8521,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://trade.gov",
       "Domain": "trade.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -7463,6 +8529,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.trafficsafetymarketing.gov",
       "Domain": "trafficsafetymarketing.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -7470,6 +8537,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.transparency.gov",
       "Domain": "transparency.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -7477,6 +8545,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.transportation.gov",
       "Domain": "transportation.gov",
       "HTTPS Enabled?": 2,
       "HTTPS Enforced?": 0,
@@ -7484,6 +8553,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "http://www.transportationresearch.gov",
       "Domain": "transportationresearch.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -7491,6 +8561,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.treas.gov",
       "Domain": "treas.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -7498,6 +8569,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "https://www.treaslockbox.gov",
       "Domain": "treaslockbox.gov",
       "HTTPS Enabled?": 1,
       "HTTPS Enforced?": 3,
@@ -7505,6 +8577,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "http://treasury.fed.us",
       "Domain": "treasury.fed.us",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -7512,6 +8585,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.treasury.gov",
       "Domain": "treasury.gov",
       "HTTPS Enabled?": 2,
       "HTTPS Enforced?": 0,
@@ -7519,6 +8593,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "http://treasuryauctions.gov",
       "Domain": "treasuryauctions.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -7526,6 +8601,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://treasurydirect.gov",
       "Domain": "treasurydirect.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -7533,6 +8609,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://treasuryhunt.gov",
       "Domain": "treasuryhunt.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -7540,6 +8617,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://treasuryscams.gov",
       "Domain": "treasuryscams.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -7547,6 +8625,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.tribaljusticeandsafety.gov",
       "Domain": "tribaljusticeandsafety.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -7554,6 +8633,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.truman.gov",
       "Domain": "truman.gov",
       "HTTPS Enabled?": 1,
       "HTTPS Enforced?": 1,
@@ -7561,6 +8641,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "http://www.tsa.gov",
       "Domain": "tsa.gov",
       "HTTPS Enabled?": 2,
       "HTTPS Enforced?": 1,
@@ -7568,6 +8649,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "http://www.tsc.gov",
       "Domain": "tsc.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -7575,6 +8657,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "https://www.tsp.gov",
       "Domain": "tsp.gov",
       "HTTPS Enabled?": 2,
       "HTTPS Enforced?": 3,
@@ -7582,6 +8665,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "http://www.tsunami.gov",
       "Domain": "tsunami.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -7589,6 +8673,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://tswg.gov",
       "Domain": "tswg.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -7596,6 +8681,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://ttb.gov",
       "Domain": "ttb.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -7603,6 +8689,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.ttbonline.gov",
       "Domain": "ttbonline.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -7610,6 +8697,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://tva.gov",
       "Domain": "tva.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -7617,6 +8705,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://ucrdatatool.gov",
       "Domain": "ucrdatatool.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -7624,6 +8713,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://udall.gov",
       "Domain": "udall.gov",
       "HTTPS Enabled?": 2,
       "HTTPS Enforced?": 1,
@@ -7631,6 +8721,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "http://www.unicor.gov",
       "Domain": "unicor.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -7638,6 +8729,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.unionreports.gov",
       "Domain": "unionreports.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -7645,6 +8737,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.unitedstates.gov",
       "Domain": "unitedstates.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -7652,6 +8745,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.unitedstatescongress.gov",
       "Domain": "unitedstatescongress.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -7659,6 +8753,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.unitedweride.gov",
       "Domain": "unitedweride.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -7666,6 +8761,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "https://unlocktalent.gov",
       "Domain": "unlocktalent.gov",
       "HTTPS Enabled?": 2,
       "HTTPS Enforced?": 3,
@@ -7673,6 +8769,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "http://urbanwaters.gov",
       "Domain": "urbanwaters.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -7680,6 +8777,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "https://www.us-cert.gov",
       "Domain": "us-cert.gov",
       "HTTPS Enabled?": 2,
       "HTTPS Enforced?": 2,
@@ -7687,6 +8785,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "http://www.us.gov",
       "Domain": "us.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -7694,6 +8793,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.usa.gov",
       "Domain": "usa.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -7701,6 +8801,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.usability.gov",
       "Domain": "usability.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -7708,6 +8809,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.usagov.gov",
       "Domain": "usagov.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -7715,6 +8817,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.usaid.gov",
       "Domain": "usaid.gov",
       "HTTPS Enabled?": 2,
       "HTTPS Enforced?": 0,
@@ -7722,6 +8825,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "http://www.usaidallnet.gov",
       "Domain": "usaidallnet.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -7729,6 +8833,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "https://www.usajobs.gov",
       "Domain": "usajobs.gov",
       "HTTPS Enabled?": 2,
       "HTTPS Enforced?": 2,
@@ -7736,6 +8841,7 @@
       "Strict Transport Security (HSTS)": 1
     },
     {
+      "Canonical": "https://usalearning.gov",
       "Domain": "usalearning.gov",
       "HTTPS Enabled?": 2,
       "HTTPS Enforced?": 2,
@@ -7743,6 +8849,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "http://www.usandc.gov",
       "Domain": "usandc.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -7750,6 +8857,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://usap.gov",
       "Domain": "usap.gov",
       "HTTPS Enabled?": 2,
       "HTTPS Enforced?": 1,
@@ -7757,6 +8865,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "http://www.usaperformance.gov",
       "Domain": "usaperformance.gov",
       "HTTPS Enabled?": 1,
       "HTTPS Enforced?": 1,
@@ -7764,6 +8873,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "https://www.usaspending.gov",
       "Domain": "usaspending.gov",
       "HTTPS Enabled?": 2,
       "HTTPS Enforced?": 3,
@@ -7771,6 +8881,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "http://www.usastaffing.gov",
       "Domain": "usastaffing.gov",
       "HTTPS Enabled?": 2,
       "HTTPS Enforced?": 1,
@@ -7778,6 +8889,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "http://www.usbankruptcy.gov",
       "Domain": "usbankruptcy.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -7785,6 +8897,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://usbg.gov",
       "Domain": "usbg.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -7792,6 +8905,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.usbr.gov",
       "Domain": "usbr.gov",
       "HTTPS Enabled?": 2,
       "HTTPS Enforced?": 1,
@@ -7799,6 +8913,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "http://uscapital.gov",
       "Domain": "uscapital.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -7806,6 +8921,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://uscapitol.gov",
       "Domain": "uscapitol.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -7813,6 +8929,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.uscapitolpolice.gov",
       "Domain": "uscapitolpolice.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -7820,6 +8937,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://uscapitolvisitorcenter.gov",
       "Domain": "uscapitolvisitorcenter.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -7827,6 +8945,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.uscc.gov",
       "Domain": "uscc.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -7834,6 +8953,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.usccr.gov",
       "Domain": "usccr.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -7841,6 +8961,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.uscirf.gov",
       "Domain": "uscirf.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -7848,6 +8969,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.uscis.gov",
       "Domain": "uscis.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -7855,6 +8977,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.uscode.gov",
       "Domain": "uscode.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -7862,6 +8985,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.uscongress.gov",
       "Domain": "uscongress.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -7869,6 +8993,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.usconsulate.gov",
       "Domain": "usconsulate.gov",
       "HTTPS Enabled?": 1,
       "HTTPS Enforced?": 1,
@@ -7876,6 +9001,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "http://www.uscourts.gov",
       "Domain": "uscourts.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -7883,6 +9009,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://uscvc.gov",
       "Domain": "uscvc.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -7890,6 +9017,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.usda.gov",
       "Domain": "usda.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -7897,6 +9025,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.usdapii.gov",
       "Domain": "usdapii.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -7904,6 +9033,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://usdebitcard.gov",
       "Domain": "usdebitcard.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -7911,6 +9041,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.usdoj.gov",
       "Domain": "usdoj.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -7918,6 +9049,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://usembassy-mexico.gov",
       "Domain": "usembassy-mexico.gov",
       "HTTPS Enabled?": 1,
       "HTTPS Enforced?": 1,
@@ -7925,6 +9057,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "http://www.usembassy.gov",
       "Domain": "usembassy.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -7932,6 +9065,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.userra.gov",
       "Domain": "userra.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -7939,6 +9073,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.usgcrp.gov",
       "Domain": "usgcrp.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -7946,6 +9081,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.usgeo.gov",
       "Domain": "usgeo.gov",
       "HTTPS Enabled?": 1,
       "HTTPS Enforced?": 1,
@@ -7953,6 +9089,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "http://www.usgovernment.gov",
       "Domain": "usgovernment.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -7960,6 +9097,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.usgovernmentmanual.gov",
       "Domain": "usgovernmentmanual.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -7967,6 +9105,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://usgs.gov",
       "Domain": "usgs.gov",
       "HTTPS Enabled?": 2,
       "HTTPS Enforced?": 1,
@@ -7974,6 +9113,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "http://www.ushmm.gov",
       "Domain": "ushmm.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -7981,6 +9121,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://usich.gov",
       "Domain": "usich.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -7988,6 +9129,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.usicn.gov",
       "Domain": "usicn.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -7995,6 +9137,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://usint.gov",
       "Domain": "usint.gov",
       "HTTPS Enabled?": 1,
       "HTTPS Enforced?": 1,
@@ -8002,6 +9145,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "http://www.usip.gov",
       "Domain": "usip.gov",
       "HTTPS Enabled?": 1,
       "HTTPS Enforced?": 1,
@@ -8009,6 +9153,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "http://usitc.gov",
       "Domain": "usitc.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -8016,6 +9161,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.usmarshals.gov",
       "Domain": "usmarshals.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -8023,6 +9169,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.usmint.gov",
       "Domain": "usmint.gov",
       "HTTPS Enabled?": 2,
       "HTTPS Enforced?": 1,
@@ -8030,6 +9177,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "http://usmission.gov",
       "Domain": "usmission.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -8037,6 +9185,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.usoge.gov",
       "Domain": "usoge.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -8044,6 +9193,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://usphs.gov",
       "Domain": "usphs.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -8051,6 +9201,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.uspis.gov",
       "Domain": "uspis.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -8058,6 +9209,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.usprobation.gov",
       "Domain": "usprobation.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -8065,6 +9217,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "https://www.usps.gov",
       "Domain": "usps.gov",
       "HTTPS Enabled?": 2,
       "HTTPS Enforced?": 3,
@@ -8072,6 +9225,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "https://uspsoig.gov",
       "Domain": "uspsoig.gov",
       "HTTPS Enabled?": 2,
       "HTTPS Enforced?": 3,
@@ -8079,6 +9233,7 @@
       "Strict Transport Security (HSTS)": 3
     },
     {
+      "Canonical": "http://www.uspto.gov",
       "Domain": "uspto.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -8086,6 +9241,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.ussc.gov",
       "Domain": "ussc.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -8093,6 +9249,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://ustaxcourt.gov",
       "Domain": "ustaxcourt.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -8100,6 +9257,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://ustda.gov",
       "Domain": "ustda.gov",
       "HTTPS Enabled?": 1,
       "HTTPS Enforced?": 1,
@@ -8107,6 +9265,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "https://ustr.gov",
       "Domain": "ustr.gov",
       "HTTPS Enabled?": 2,
       "HTTPS Enforced?": 3,
@@ -8114,6 +9273,7 @@
       "Strict Transport Security (HSTS)": 1
     },
     {
+      "Canonical": "http://www.ustreas.gov",
       "Domain": "ustreas.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -8121,6 +9281,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.usvpp.gov",
       "Domain": "usvpp.gov",
       "HTTPS Enabled?": 1,
       "HTTPS Enforced?": 1,
@@ -8128,6 +9289,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "http://www.utahfireinfo.gov",
       "Domain": "utahfireinfo.gov",
       "HTTPS Enabled?": 1,
       "HTTPS Enforced?": 1,
@@ -8135,6 +9297,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "http://va.gov",
       "Domain": "va.gov",
       "HTTPS Enabled?": 1,
       "HTTPS Enforced?": 1,
@@ -8142,6 +9305,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "http://www.vaccines.gov",
       "Domain": "vaccines.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -8149,6 +9313,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://vallescaldera.gov",
       "Domain": "vallescaldera.gov",
       "HTTPS Enabled?": 2,
       "HTTPS Enforced?": 1,
@@ -8156,6 +9321,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "http://www.vcf.gov",
       "Domain": "vcf.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -8163,6 +9329,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://vef.gov",
       "Domain": "vef.gov",
       "HTTPS Enabled?": 2,
       "HTTPS Enforced?": 1,
@@ -8170,6 +9337,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "http://www.vehiclehistory.gov",
       "Domain": "vehiclehistory.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -8177,6 +9345,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.vetbiz.gov",
       "Domain": "vetbiz.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -8184,6 +9353,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.veterans.gov",
       "Domain": "veterans.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -8191,6 +9361,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://visitthecapital.gov",
       "Domain": "visitthecapital.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -8198,6 +9369,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.visitthecapitol.gov",
       "Domain": "visitthecapitol.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -8205,6 +9377,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.vista.gov",
       "Domain": "vista.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -8212,6 +9385,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.vistacampus.gov",
       "Domain": "vistacampus.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -8219,6 +9393,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.voa.gov",
       "Domain": "voa.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -8226,6 +9401,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://volunteer.gov",
       "Domain": "volunteer.gov",
       "HTTPS Enabled?": 2,
       "HTTPS Enforced?": 1,
@@ -8233,6 +9409,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "http://www.volunteeringinamerica.gov",
       "Domain": "volunteeringinamerica.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -8240,6 +9417,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.wapa.gov",
       "Domain": "wapa.gov",
       "HTTPS Enabled?": 2,
       "HTTPS Enforced?": 1,
@@ -8247,6 +9425,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "http://www.wartimecontracting.gov",
       "Domain": "wartimecontracting.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -8254,6 +9433,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://watermonitor.gov",
       "Domain": "watermonitor.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -8261,6 +9441,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.wdl.gov",
       "Domain": "wdl.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -8268,6 +9449,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://wdol.gov",
       "Domain": "wdol.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -8275,6 +9457,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.weather.gov",
       "Domain": "weather.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -8282,6 +9465,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://webharvest.gov",
       "Domain": "webharvest.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -8289,6 +9473,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.welcometousa.gov",
       "Domain": "welcometousa.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -8296,6 +9481,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://wethepeople.gov",
       "Domain": "wethepeople.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -8303,6 +9489,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.wh.gov",
       "Domain": "wh.gov",
       "HTTPS Enabled?": 2,
       "HTTPS Enforced?": 1,
@@ -8310,6 +9497,7 @@
       "Strict Transport Security (HSTS)": 2
     },
     {
+      "Canonical": "http://www.whistleblowers.gov",
       "Domain": "whistleblowers.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -8317,6 +9505,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "https://www.whitehouse.gov",
       "Domain": "whitehouse.gov",
       "HTTPS Enabled?": 2,
       "HTTPS Enforced?": 3,
@@ -8324,6 +9513,7 @@
       "Strict Transport Security (HSTS)": 2
     },
     {
+      "Canonical": "http://whitehouseconferenceonaging.gov",
       "Domain": "whitehouseconferenceonaging.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -8331,6 +9521,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.whitehousedrugpolicy.gov",
       "Domain": "whitehousedrugpolicy.gov",
       "HTTPS Enabled?": 2,
       "HTTPS Enforced?": 1,
@@ -8338,6 +9529,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "http://www.wildfire.gov",
       "Domain": "wildfire.gov",
       "HTTPS Enabled?": 1,
       "HTTPS Enforced?": 1,
@@ -8345,6 +9537,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "http://www.wildlifeadaptationstrategy.gov",
       "Domain": "wildlifeadaptationstrategy.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -8352,6 +9545,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://www.windpoweringamerica.gov",
       "Domain": "windpoweringamerica.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -8359,6 +9553,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://wizard.gov",
       "Domain": "wizard.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -8366,6 +9561,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "https://www.wlci.gov",
       "Domain": "wlci.gov",
       "HTTPS Enabled?": 2,
       "HTTPS Enforced?": 2,
@@ -8373,6 +9569,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "http://www.womenbiz.gov",
       "Domain": "womenbiz.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -8380,6 +9577,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "https://www.womenfarmerclaims.gov",
       "Domain": "womenfarmerclaims.gov",
       "HTTPS Enabled?": 1,
       "HTTPS Enforced?": 3,
@@ -8387,6 +9585,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "http://womenshealth.gov",
       "Domain": "womenshealth.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -8394,6 +9593,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://womenshistorymonth.gov",
       "Domain": "womenshistorymonth.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -8401,6 +9601,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "https://www.workplace.gov",
       "Domain": "workplace.gov",
       "HTTPS Enabled?": 2,
       "HTTPS Enforced?": 3,
@@ -8408,6 +9609,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "http://www.worlddigitallibrary.gov",
       "Domain": "worlddigitallibrary.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -8415,6 +9617,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "http://worldwar1centennial.gov",
       "Domain": "worldwar1centennial.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -8422,6 +9625,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "https://www.wrp.gov",
       "Domain": "wrp.gov",
       "HTTPS Enabled?": 2,
       "HTTPS Enforced?": 3,
@@ -8429,6 +9633,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "http://ymp.gov",
       "Domain": "ymp.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,
@@ -8436,6 +9641,7 @@
       "Strict Transport Security (HSTS)": -1
     },
     {
+      "Canonical": "https://youthgo.gov",
       "Domain": "youthgo.gov",
       "HTTPS Enabled?": 2,
       "HTTPS Enforced?": 3,
@@ -8443,6 +9649,7 @@
       "Strict Transport Security (HSTS)": 0
     },
     {
+      "Canonical": "http://www.youthrules.gov",
       "Domain": "youthrules.gov",
       "HTTPS Enabled?": 0,
       "HTTPS Enforced?": -1,

--- a/assets/js/analytics/domains.js
+++ b/assets/js/analytics/domains.js
@@ -29,11 +29,13 @@ $(document).ready(function () {
 
       columns: [
         {data: "Domain", width: "210px"},
+        {data: "Canonical"},
         {data: "Participates in DAP?"}
       ],
 
       columnDefs: [
-        {render: display(names.dap), targets: 1}
+        {render: Utils.linkDomain, targets: 0},
+        {render: display(names.dap), targets: 2}
       ],
 
       "oLanguage": {

--- a/assets/js/https/domains.js
+++ b/assets/js/https/domains.js
@@ -48,7 +48,7 @@ $(document).ready(function () {
     }
   };
 
-  var link = function(data, type, row) {
+  var linkGrade = function(data, type, row) {
     var grade = display(names.grade)(data, type);
     if (type == "sort")
       return grade;
@@ -72,6 +72,7 @@ $(document).ready(function () {
 
       columns: [
         {data: "Domain", width: "210px"},
+        {data: "Canonical"},
         {data: "HTTPS Enabled?"},
         {data: "HTTPS Enforced?"},
         {data: "Strict Transport Security (HSTS)"},
@@ -80,10 +81,11 @@ $(document).ready(function () {
       ],
 
       columnDefs: [
-        {render: display(names.https), targets: 1},
-        {render: display(names.https_forced), targets: 2},
-        {render: display(names.hsts), targets: 3},
-        {render: link, targets: 4},
+        {render: Utils.linkDomain, targets: 0},
+        {render: display(names.https), targets: 2},
+        {render: display(names.https_forced), targets: 3},
+        {render: display(names.hsts), targets: 4},
+        {render: linkGrade, targets: 5},
       ],
 
       "oLanguage": {

--- a/assets/js/utils.js
+++ b/assets/js/utils.js
@@ -8,5 +8,15 @@ var Utils = {
           '<p>' + data + '%</p>' +
         '</span>' +
       '</div>';
+  },
+
+  linkDomain: function(data, type, row) {
+    if (type == "sort")
+      return data;
+    else
+      return "" +
+        "<a href=\"" + row['Canonical'] + "\" target=\"blank\">" +
+          data +
+        "</a>";
   }
 };

--- a/data/data.py
+++ b/data/data.py
@@ -32,7 +32,8 @@ LABELS = {
   'hsts': 'Strict Transport Security (HSTS)',
   'grade': 'SSL Labs Grade',
   'grade_agencies': 'SSL Labs (A- or higher)',
-  'dap': 'Participates in DAP?'
+  'dap': 'Participates in DAP?',
+  'more': 'More details'
 }
 
 ## global data
@@ -280,7 +281,10 @@ Given the data we have about a domain, what's the HTTPS row?
 '''
 def https_row_for(domain):
   inspect = domain_data[domain]['inspect']
-  row = {"Domain": domain}
+  row = {
+    "Domain": domain,
+    "Canonical": inspect["Canonical"]
+  }
 
   ###
   # Is it there? There for most clients? Not there?
@@ -391,11 +395,16 @@ def https_row_for(domain):
 
 # Given the data we have about a domain, what's the DAP row?
 def analytics_row_for(domain):
-  row = dict.copy(domain_data[domain]['analytics'])
+  analytics = domain_data[domain]['analytics']
+  inspect = domain_data[domain]['inspect']
 
-  # TODO: maybe there's a better way to rename this column?
-  row[LABELS['dap']] = boolean_nice(row['Participates in Analytics'])
-  del row["Participates in Analytics"]
+  row = {
+    "Domain": domain,
+    "Canonical": inspect["Canonical"]
+  }
+
+  # rename column in process
+  row[LABELS['dap']] = boolean_nice(analytics['Participates in Analytics'])
 
   return row
 

--- a/pages/analytics/domains.html
+++ b/pages/analytics/domains.html
@@ -21,6 +21,7 @@ description: "Which federal government domains are participating in the Digital 
       <thead>
         <tr>
           <th class="all">Domain</th>
+          <th class="never">Canonical</th>
           <th class="min-tablet">Participates in DAP?</th>
         </tr>
       </thead>

--- a/pages/https/domains.html
+++ b/pages/https/domains.html
@@ -19,6 +19,7 @@ description: "How federal government domains are doing at deploying HTTPS."
         <thead>
           <tr>
             <th class="all">Domain</th>
+            <th class="never">Canonical</th>
             <th class="min-tablet">HTTPS Enabled?</th>
             <th class="min-tablet">HTTPS Enforced?</th>
             <th class="min-tablet-l">Strict Transport Security (HSTS)</th>


### PR DESCRIPTION
Links domains in the DAP and HTTPS "domains" table to their website, in a new tab.

Significantly, this takes advantage of the actual analysis we've already done on domains to link to the correct "canonical" endpoint for a domain. So `nasa.gov` links to `http://www.nasa.gov` without any need for hardcoding!

This also bodes well for analytics.usa.gov -- depending on how we publish this data, analytics.usa.gov could dynamically incorporate this data to remove its hardcoded fixes on the front-end.

![screenshot from 2015-05-26 21 52 34](https://cloud.githubusercontent.com/assets/4592/7827150/896ce340-03f1-11e5-9748-3e33c591a2b5.png)

Fixes #134.