### PR TITLE
Revise HTTPS % methodology

### DIFF
--- a/assets/data/https.csv
+++ b/assets/data/https.csv
@@ -1,3 +1,3 @@
 status,value
-active,34
-inactive,66
+active,31
+inactive,69

--- a/assets/data/tables/https/agencies.json
+++ b/assets/data/tables/https/agencies.json
@@ -92,9 +92,9 @@
       "Agency": "Commodity Futures Trading Commission",
       "Enforces HTTPS": 0,
       "Number of Domains": 2,
-      "SSL Labs (A- or higher)": 50,
+      "SSL Labs (A- or higher)": 0,
       "Strict Transport Security (HSTS)": 0,
-      "Uses HTTPS": 50
+      "Uses HTTPS": 0
     },
     {
       "Agency": "Congressional Office of Compliance",
@@ -118,7 +118,7 @@
       "Number of Domains": 9,
       "SSL Labs (A- or higher)": 0,
       "Strict Transport Security (HSTS)": 0,
-      "Uses HTTPS": 22
+      "Uses HTTPS": 11
     },
     {
       "Agency": "Corporation for National & Community Service",
@@ -126,7 +126,7 @@
       "Number of Domains": 21,
       "SSL Labs (A- or higher)": 5,
       "Strict Transport Security (HSTS)": 0,
-      "Uses HTTPS": 10
+      "Uses HTTPS": 5
     },
     {
       "Agency": "Council of Inspector General on Integrity and Efficiency",
@@ -174,7 +174,7 @@
       "Number of Domains": 44,
       "SSL Labs (A- or higher)": 0,
       "Strict Transport Security (HSTS)": 0,
-      "Uses HTTPS": 39
+      "Uses HTTPS": 34
     },
     {
       "Agency": "Department of Commerce",
@@ -182,15 +182,15 @@
       "Number of Domains": 53,
       "SSL Labs (A- or higher)": 6,
       "Strict Transport Security (HSTS)": 0,
-      "Uses HTTPS": 21
+      "Uses HTTPS": 19
     },
     {
       "Agency": "Department of Defense",
       "Enforces HTTPS": 17,
       "Number of Domains": 23,
-      "SSL Labs (A- or higher)": 9,
+      "SSL Labs (A- or higher)": 4,
       "Strict Transport Security (HSTS)": 0,
-      "Uses HTTPS": 35
+      "Uses HTTPS": 30
     },
     {
       "Agency": "Department of Education",
@@ -198,7 +198,7 @@
       "Number of Domains": 16,
       "SSL Labs (A- or higher)": 6,
       "Strict Transport Security (HSTS)": 6,
-      "Uses HTTPS": 44
+      "Uses HTTPS": 38
     },
     {
       "Agency": "Department of Energy",
@@ -206,7 +206,7 @@
       "Number of Domains": 58,
       "SSL Labs (A- or higher)": 10,
       "Strict Transport Security (HSTS)": 0,
-      "Uses HTTPS": 45
+      "Uses HTTPS": 36
     },
     {
       "Agency": "Department of Health And Human Services",
@@ -214,15 +214,15 @@
       "Number of Domains": 112,
       "SSL Labs (A- or higher)": 12,
       "Strict Transport Security (HSTS)": 3,
-      "Uses HTTPS": 33
+      "Uses HTTPS": 32
     },
     {
       "Agency": "Department of Homeland Security",
       "Enforces HTTPS": 25,
       "Number of Domains": 24,
-      "SSL Labs (A- or higher)": 12,
+      "SSL Labs (A- or higher)": 8,
       "Strict Transport Security (HSTS)": 0,
-      "Uses HTTPS": 62
+      "Uses HTTPS": 46
     },
     {
       "Agency": "Department of Housing And Urban Development",
@@ -236,9 +236,9 @@
       "Agency": "Department of Justice",
       "Enforces HTTPS": 14,
       "Number of Domains": 66,
-      "SSL Labs (A- or higher)": 6,
+      "SSL Labs (A- or higher)": 5,
       "Strict Transport Security (HSTS)": 0,
-      "Uses HTTPS": 20
+      "Uses HTTPS": 18
     },
     {
       "Agency": "Department of Labor",
@@ -262,7 +262,7 @@
       "Number of Domains": 32,
       "SSL Labs (A- or higher)": 3,
       "Strict Transport Security (HSTS)": 0,
-      "Uses HTTPS": 38
+      "Uses HTTPS": 25
     },
     {
       "Agency": "Department of Veterans Affairs",
@@ -278,7 +278,7 @@
       "Number of Domains": 83,
       "SSL Labs (A- or higher)": 2,
       "Strict Transport Security (HSTS)": 0,
-      "Uses HTTPS": 35
+      "Uses HTTPS": 33
     },
     {
       "Agency": "Department of the Treasury",
@@ -286,7 +286,7 @@
       "Number of Domains": 85,
       "SSL Labs (A- or higher)": 1,
       "Strict Transport Security (HSTS)": 0,
-      "Uses HTTPS": 29
+      "Uses HTTPS": 27
     },
     {
       "Agency": "Director of National Intelligence",
@@ -374,7 +374,7 @@
       "Number of Domains": 2,
       "SSL Labs (A- or higher)": 0,
       "Strict Transport Security (HSTS)": 0,
-      "Uses HTTPS": 50
+      "Uses HTTPS": 0
     },
     {
       "Agency": "Federal Housing Finance Agency Office of Inspector General",
@@ -406,7 +406,7 @@
       "Number of Domains": 1,
       "SSL Labs (A- or higher)": 0,
       "Strict Transport Security (HSTS)": 0,
-      "Uses HTTPS": 100
+      "Uses HTTPS": 0
     },
     {
       "Agency": "Federal Reserve System",
@@ -414,7 +414,7 @@
       "Number of Domains": 6,
       "SSL Labs (A- or higher)": 0,
       "Strict Transport Security (HSTS)": 0,
-      "Uses HTTPS": 83
+      "Uses HTTPS": 67
     },
     {
       "Agency": "Federal Retirement Thrift Investment Board",
@@ -438,7 +438,7 @@
       "Number of Domains": 94,
       "SSL Labs (A- or higher)": 5,
       "Strict Transport Security (HSTS)": 6,
-      "Uses HTTPS": 52
+      "Uses HTTPS": 51
     },
     {
       "Agency": "Government Printing Office",
@@ -638,7 +638,7 @@
       "Number of Domains": 1,
       "SSL Labs (A- or higher)": 0,
       "Strict Transport Security (HSTS)": 0,
-      "Uses HTTPS": 100
+      "Uses HTTPS": 0
     },
     {
       "Agency": "National Nanotechnology Coordination Office",
@@ -646,7 +646,7 @@
       "Number of Domains": 1,
       "SSL Labs (A- or higher)": 0,
       "Strict Transport Security (HSTS)": 0,
-      "Uses HTTPS": 100
+      "Uses HTTPS": 0
     },
     {
       "Agency": "National Science Foundation",
@@ -654,7 +654,7 @@
       "Number of Domains": 8,
       "SSL Labs (A- or higher)": 0,
       "Strict Transport Security (HSTS)": 0,
-      "Uses HTTPS": 88
+      "Uses HTTPS": 75
     },
     {
       "Agency": "National Security Agency",
@@ -734,7 +734,7 @@
       "Number of Domains": 1,
       "SSL Labs (A- or higher)": 0,
       "Strict Transport Security (HSTS)": 0,
-      "Uses HTTPS": 100
+      "Uses HTTPS": 0
     },
     {
       "Agency": "Railroad Retirement Board",
@@ -756,9 +756,9 @@
       "Agency": "Securities and Exchange Commission",
       "Enforces HTTPS": 0,
       "Number of Domains": 3,
-      "SSL Labs (A- or higher)": 33,
+      "SSL Labs (A- or higher)": 0,
       "Strict Transport Security (HSTS)": 0,
-      "Uses HTTPS": 67
+      "Uses HTTPS": 33
     },
     {
       "Agency": "Selective Service System",
@@ -782,7 +782,7 @@
       "Number of Domains": 1,
       "SSL Labs (A- or higher)": 0,
       "Strict Transport Security (HSTS)": 0,
-      "Uses HTTPS": 100
+      "Uses HTTPS": 0
     },
     {
       "Agency": "Social Security Administration",
@@ -844,9 +844,9 @@
       "Agency": "The Legislative Branch (Congress)",
       "Enforces HTTPS": 5,
       "Number of Domains": 41,
-      "SSL Labs (A- or higher)": 5,
+      "SSL Labs (A- or higher)": 2,
       "Strict Transport Security (HSTS)": 0,
-      "Uses HTTPS": 22
+      "Uses HTTPS": 17
     },
     {
       "Agency": "The United States World War One Centennial Commission",
@@ -894,7 +894,7 @@
       "Number of Domains": 3,
       "SSL Labs (A- or higher)": 0,
       "Strict Transport Security (HSTS)": 0,
-      "Uses HTTPS": 33
+      "Uses HTTPS": 0
     },
     {
       "Agency": "U. S. Postal Service",
@@ -908,9 +908,9 @@
       "Agency": "U.S. Agency for International Development",
       "Enforces HTTPS": 9,
       "Number of Domains": 11,
-      "SSL Labs (A- or higher)": 9,
+      "SSL Labs (A- or higher)": 0,
       "Strict Transport Security (HSTS)": 0,
-      "Uses HTTPS": 36
+      "Uses HTTPS": 18
     },
     {
       "Agency": "U.S. Chemical Safety and Hazard Investigation Board",
@@ -956,9 +956,9 @@
       "Agency": "United Stated Global Change Research Program",
       "Enforces HTTPS": 0,
       "Number of Domains": 4,
-      "SSL Labs (A- or higher)": 25,
+      "SSL Labs (A- or higher)": 0,
       "Strict Transport Security (HSTS)": 0,
-      "Uses HTTPS": 50
+      "Uses HTTPS": 25
     },
     {
       "Agency": "United States Office of Government Ethics",

--- a/assets/data/tables/https/agencies.json
+++ b/assets/data/tables/https/agencies.json
@@ -2,971 +2,971 @@
   "data": [
     {
       "Agency": "AMTRAK",
-      "HTTPS Enabled?": 100,
-      "HTTPS Enforced?": 0,
+      "Enforces HTTPS": 0,
       "Number of Domains": 1,
       "SSL Labs (A- or higher)": 0,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 100
     },
     {
       "Agency": "Administrative Conference of the United States",
-      "HTTPS Enabled?": 100,
-      "HTTPS Enforced?": 100,
+      "Enforces HTTPS": 100,
       "Number of Domains": 1,
       "SSL Labs (A- or higher)": 100,
-      "Strict Transport Security (HSTS)": 100
+      "Strict Transport Security (HSTS)": 100,
+      "Uses HTTPS": 100
     },
     {
       "Agency": "Advisory Council on Historic Preservation",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": 0,
+      "Enforces HTTPS": 0,
       "Number of Domains": 2,
       "SSL Labs (A- or higher)": 0,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 0
     },
     {
       "Agency": "American Battle Monuments Commission",
-      "HTTPS Enabled?": 100,
-      "HTTPS Enforced?": 0,
+      "Enforces HTTPS": 0,
       "Number of Domains": 1,
       "SSL Labs (A- or higher)": 0,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 100
     },
     {
       "Agency": "Appalachian Regional Commission",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": 0,
+      "Enforces HTTPS": 0,
       "Number of Domains": 1,
       "SSL Labs (A- or higher)": 0,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 0
     },
     {
       "Agency": "Appraisal Subcommittee",
-      "HTTPS Enabled?": 100,
-      "HTTPS Enforced?": 100,
+      "Enforces HTTPS": 100,
       "Number of Domains": 1,
       "SSL Labs (A- or higher)": 0,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 100
     },
     {
       "Agency": "Armed Forces Retirement Home",
-      "HTTPS Enabled?": 100,
-      "HTTPS Enforced?": 100,
+      "Enforces HTTPS": 100,
       "Number of Domains": 1,
       "SSL Labs (A- or higher)": 0,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 100
     },
     {
       "Agency": "Central Intelligence Agency",
-      "HTTPS Enabled?": 67,
-      "HTTPS Enforced?": 67,
+      "Enforces HTTPS": 67,
       "Number of Domains": 3,
       "SSL Labs (A- or higher)": 33,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 67
     },
     {
       "Agency": "Christopher Columbus Fellowship Foundation",
-      "HTTPS Enabled?": 100,
-      "HTTPS Enforced?": 0,
+      "Enforces HTTPS": 0,
       "Number of Domains": 1,
       "SSL Labs (A- or higher)": 0,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 100
     },
     {
       "Agency": "Civil Air Patrol",
-      "HTTPS Enabled?": 100,
-      "HTTPS Enforced?": 0,
+      "Enforces HTTPS": 0,
       "Number of Domains": 1,
       "SSL Labs (A- or higher)": 0,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 100
     },
     {
       "Agency": "Comm for People Who Are Blind/Severly Disabled",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": 0,
+      "Enforces HTTPS": 0,
       "Number of Domains": 2,
       "SSL Labs (A- or higher)": 0,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 0
     },
     {
       "Agency": "Commodity Futures Trading Commission",
-      "HTTPS Enabled?": 50,
-      "HTTPS Enforced?": 0,
+      "Enforces HTTPS": 0,
       "Number of Domains": 2,
       "SSL Labs (A- or higher)": 50,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 50
     },
     {
       "Agency": "Congressional Office of Compliance",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": 0,
+      "Enforces HTTPS": 0,
       "Number of Domains": 1,
       "SSL Labs (A- or higher)": 0,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 0
     },
     {
       "Agency": "Consumer Financial Protection Bureau",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": 0,
+      "Enforces HTTPS": 0,
       "Number of Domains": 10,
       "SSL Labs (A- or higher)": 0,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 0
     },
     {
       "Agency": "Consumer Product Safety Commission",
-      "HTTPS Enabled?": 22,
-      "HTTPS Enforced?": 0,
+      "Enforces HTTPS": 0,
       "Number of Domains": 9,
       "SSL Labs (A- or higher)": 0,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 22
     },
     {
       "Agency": "Corporation for National & Community Service",
-      "HTTPS Enabled?": 10,
-      "HTTPS Enforced?": 5,
+      "Enforces HTTPS": 5,
       "Number of Domains": 21,
       "SSL Labs (A- or higher)": 5,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 10
     },
     {
       "Agency": "Council of Inspector General on Integrity and Efficiency",
-      "HTTPS Enabled?": 100,
-      "HTTPS Enforced?": 100,
+      "Enforces HTTPS": 100,
       "Number of Domains": 1,
       "SSL Labs (A- or higher)": 0,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 100
     },
     {
       "Agency": "Court Services and Offender Supervision",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": 0,
+      "Enforces HTTPS": 0,
       "Number of Domains": 4,
       "SSL Labs (A- or higher)": 0,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 0
     },
     {
       "Agency": "Defense Nuclear Facilities Safety Board",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": 0,
+      "Enforces HTTPS": 0,
       "Number of Domains": 1,
       "SSL Labs (A- or higher)": 0,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 0
     },
     {
       "Agency": "Delta Regional Authority",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": 0,
+      "Enforces HTTPS": 0,
       "Number of Domains": 1,
       "SSL Labs (A- or higher)": 0,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 0
     },
     {
       "Agency": "Denali Commission",
-      "HTTPS Enabled?": 100,
-      "HTTPS Enforced?": 0,
+      "Enforces HTTPS": 0,
       "Number of Domains": 1,
       "SSL Labs (A- or higher)": 0,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 100
     },
     {
       "Agency": "Department of Agriculture",
-      "HTTPS Enabled?": 39,
-      "HTTPS Enforced?": 16,
+      "Enforces HTTPS": 16,
       "Number of Domains": 44,
       "SSL Labs (A- or higher)": 0,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 39
     },
     {
       "Agency": "Department of Commerce",
-      "HTTPS Enabled?": 21,
-      "HTTPS Enforced?": 0,
+      "Enforces HTTPS": 0,
       "Number of Domains": 53,
       "SSL Labs (A- or higher)": 6,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 21
     },
     {
       "Agency": "Department of Defense",
-      "HTTPS Enabled?": 35,
-      "HTTPS Enforced?": 17,
+      "Enforces HTTPS": 17,
       "Number of Domains": 23,
       "SSL Labs (A- or higher)": 9,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 35
     },
     {
       "Agency": "Department of Education",
-      "HTTPS Enabled?": 44,
-      "HTTPS Enforced?": 19,
+      "Enforces HTTPS": 19,
       "Number of Domains": 16,
       "SSL Labs (A- or higher)": 6,
-      "Strict Transport Security (HSTS)": 6
+      "Strict Transport Security (HSTS)": 6,
+      "Uses HTTPS": 44
     },
     {
       "Agency": "Department of Energy",
-      "HTTPS Enabled?": 45,
-      "HTTPS Enforced?": 10,
+      "Enforces HTTPS": 10,
       "Number of Domains": 58,
       "SSL Labs (A- or higher)": 10,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 45
     },
     {
       "Agency": "Department of Health And Human Services",
-      "HTTPS Enabled?": 33,
-      "HTTPS Enforced?": 9,
+      "Enforces HTTPS": 9,
       "Number of Domains": 112,
       "SSL Labs (A- or higher)": 12,
-      "Strict Transport Security (HSTS)": 3
+      "Strict Transport Security (HSTS)": 3,
+      "Uses HTTPS": 33
     },
     {
       "Agency": "Department of Homeland Security",
-      "HTTPS Enabled?": 62,
-      "HTTPS Enforced?": 25,
+      "Enforces HTTPS": 25,
       "Number of Domains": 24,
       "SSL Labs (A- or higher)": 12,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 62
     },
     {
       "Agency": "Department of Housing And Urban Development",
-      "HTTPS Enabled?": 10,
-      "HTTPS Enforced?": 0,
+      "Enforces HTTPS": 0,
       "Number of Domains": 10,
       "SSL Labs (A- or higher)": 0,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 10
     },
     {
       "Agency": "Department of Justice",
-      "HTTPS Enabled?": 20,
-      "HTTPS Enforced?": 14,
+      "Enforces HTTPS": 14,
       "Number of Domains": 66,
       "SSL Labs (A- or higher)": 6,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 20
     },
     {
       "Agency": "Department of Labor",
-      "HTTPS Enabled?": 25,
-      "HTTPS Enforced?": 15,
+      "Enforces HTTPS": 15,
       "Number of Domains": 20,
       "SSL Labs (A- or higher)": 0,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 25
     },
     {
       "Agency": "Department of State",
-      "HTTPS Enabled?": 45,
-      "HTTPS Enforced?": 18,
+      "Enforces HTTPS": 18,
       "Number of Domains": 22,
       "SSL Labs (A- or higher)": 0,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 45
     },
     {
       "Agency": "Department of Transportation",
-      "HTTPS Enabled?": 38,
-      "HTTPS Enforced?": 6,
+      "Enforces HTTPS": 6,
       "Number of Domains": 32,
       "SSL Labs (A- or higher)": 3,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 38
     },
     {
       "Agency": "Department of Veterans Affairs",
-      "HTTPS Enabled?": 50,
-      "HTTPS Enforced?": 17,
+      "Enforces HTTPS": 17,
       "Number of Domains": 6,
       "SSL Labs (A- or higher)": 0,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 50
     },
     {
       "Agency": "Department of the Interior",
-      "HTTPS Enabled?": 35,
-      "HTTPS Enforced?": 5,
+      "Enforces HTTPS": 5,
       "Number of Domains": 83,
       "SSL Labs (A- or higher)": 2,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 35
     },
     {
       "Agency": "Department of the Treasury",
-      "HTTPS Enabled?": 29,
-      "HTTPS Enforced?": 19,
+      "Enforces HTTPS": 19,
       "Number of Domains": 85,
       "SSL Labs (A- or higher)": 1,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 29
     },
     {
       "Agency": "Director of National Intelligence",
-      "HTTPS Enabled?": 18,
-      "HTTPS Enforced?": 0,
+      "Enforces HTTPS": 0,
       "Number of Domains": 11,
       "SSL Labs (A- or higher)": 0,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 18
     },
     {
       "Agency": "Environmental Protection Agency",
-      "HTTPS Enabled?": 20,
-      "HTTPS Enforced?": 7,
+      "Enforces HTTPS": 7,
       "Number of Domains": 15,
       "SSL Labs (A- or higher)": 0,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 20
     },
     {
       "Agency": "Equal Employment Opportunity Commission",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": 0,
+      "Enforces HTTPS": 0,
       "Number of Domains": 1,
       "SSL Labs (A- or higher)": 0,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 0
     },
     {
       "Agency": "Executive Office of the President",
-      "HTTPS Enabled?": 74,
-      "HTTPS Enforced?": 19,
+      "Enforces HTTPS": 19,
       "Number of Domains": 31,
       "SSL Labs (A- or higher)": 45,
-      "Strict Transport Security (HSTS)": 32
+      "Strict Transport Security (HSTS)": 32,
+      "Uses HTTPS": 74
     },
     {
       "Agency": "Export/Import Bank of the U.S.",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": 0,
+      "Enforces HTTPS": 0,
       "Number of Domains": 1,
       "SSL Labs (A- or higher)": 0,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 0
     },
     {
       "Agency": "Farm Credit Administration",
-      "HTTPS Enabled?": 50,
-      "HTTPS Enforced?": 0,
+      "Enforces HTTPS": 0,
       "Number of Domains": 2,
       "SSL Labs (A- or higher)": 0,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 50
     },
     {
       "Agency": "Federal Communications Commission",
-      "HTTPS Enabled?": 12,
-      "HTTPS Enforced?": 0,
+      "Enforces HTTPS": 0,
       "Number of Domains": 8,
       "SSL Labs (A- or higher)": 0,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 12
     },
     {
       "Agency": "Federal Deposit Insurance Corporation",
-      "HTTPS Enabled?": 22,
-      "HTTPS Enforced?": 22,
+      "Enforces HTTPS": 22,
       "Number of Domains": 9,
       "SSL Labs (A- or higher)": 11,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 22
     },
     {
       "Agency": "Federal Elections Commission",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": 0,
+      "Enforces HTTPS": 0,
       "Number of Domains": 1,
       "SSL Labs (A- or higher)": 0,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 0
     },
     {
       "Agency": "Federal Energy Regulatory Commission",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": 0,
+      "Enforces HTTPS": 0,
       "Number of Domains": 2,
       "SSL Labs (A- or higher)": 0,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 0
     },
     {
       "Agency": "Federal Housing Finance Agency",
-      "HTTPS Enabled?": 50,
-      "HTTPS Enforced?": 0,
+      "Enforces HTTPS": 0,
       "Number of Domains": 2,
       "SSL Labs (A- or higher)": 0,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 50
     },
     {
       "Agency": "Federal Housing Finance Agency Office of Inspector General",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": 0,
+      "Enforces HTTPS": 0,
       "Number of Domains": 1,
       "SSL Labs (A- or higher)": 0,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 0
     },
     {
       "Agency": "Federal Labor Relations Authority",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": 0,
+      "Enforces HTTPS": 0,
       "Number of Domains": 1,
       "SSL Labs (A- or higher)": 0,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 0
     },
     {
       "Agency": "Federal Maritime Commission",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": 0,
+      "Enforces HTTPS": 0,
       "Number of Domains": 1,
       "SSL Labs (A- or higher)": 0,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 0
     },
     {
       "Agency": "Federal Mediation and Conciliation Service",
-      "HTTPS Enabled?": 100,
-      "HTTPS Enforced?": 0,
+      "Enforces HTTPS": 0,
       "Number of Domains": 1,
       "SSL Labs (A- or higher)": 0,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 100
     },
     {
       "Agency": "Federal Reserve System",
-      "HTTPS Enabled?": 83,
-      "HTTPS Enforced?": 17,
+      "Enforces HTTPS": 17,
       "Number of Domains": 6,
       "SSL Labs (A- or higher)": 0,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 83
     },
     {
       "Agency": "Federal Retirement Thrift Investment Board",
-      "HTTPS Enabled?": 33,
-      "HTTPS Enforced?": 33,
+      "Enforces HTTPS": 33,
       "Number of Domains": 3,
       "SSL Labs (A- or higher)": 0,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 33
     },
     {
       "Agency": "Federal Trade Commission",
-      "HTTPS Enabled?": 59,
-      "HTTPS Enforced?": 27,
+      "Enforces HTTPS": 27,
       "Number of Domains": 22,
       "SSL Labs (A- or higher)": 27,
-      "Strict Transport Security (HSTS)": 18
+      "Strict Transport Security (HSTS)": 18,
+      "Uses HTTPS": 59
     },
     {
       "Agency": "General Services Administration",
-      "HTTPS Enabled?": 52,
-      "HTTPS Enforced?": 27,
+      "Enforces HTTPS": 27,
       "Number of Domains": 94,
       "SSL Labs (A- or higher)": 5,
-      "Strict Transport Security (HSTS)": 6
+      "Strict Transport Security (HSTS)": 6,
+      "Uses HTTPS": 52
     },
     {
       "Agency": "Government Printing Office",
-      "HTTPS Enabled?": 13,
-      "HTTPS Enforced?": 4,
+      "Enforces HTTPS": 4,
       "Number of Domains": 23,
       "SSL Labs (A- or higher)": 4,
-      "Strict Transport Security (HSTS)": 4
+      "Strict Transport Security (HSTS)": 4,
+      "Uses HTTPS": 13
     },
     {
       "Agency": "Harry S. Truman Scholarship Foundation",
-      "HTTPS Enabled?": 100,
-      "HTTPS Enforced?": 0,
+      "Enforces HTTPS": 0,
       "Number of Domains": 1,
       "SSL Labs (A- or higher)": 0,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 100
     },
     {
       "Agency": "Institute of Museum and Library Services",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": 0,
+      "Enforces HTTPS": 0,
       "Number of Domains": 1,
       "SSL Labs (A- or higher)": 0,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 0
     },
     {
       "Agency": "Inter-American Foundation",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": 0,
+      "Enforces HTTPS": 0,
       "Number of Domains": 1,
       "SSL Labs (A- or higher)": 0,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 0
     },
     {
       "Agency": "International Broadcasting Bureau",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": 0,
+      "Enforces HTTPS": 0,
       "Number of Domains": 3,
       "SSL Labs (A- or higher)": 0,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 0
     },
     {
       "Agency": "James Madison Memorial Fellowship Foundation",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": 0,
+      "Enforces HTTPS": 0,
       "Number of Domains": 1,
       "SSL Labs (A- or higher)": 0,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 0
     },
     {
       "Agency": "Legal Services Corporation",
-      "HTTPS Enabled?": 100,
-      "HTTPS Enforced?": 0,
+      "Enforces HTTPS": 0,
       "Number of Domains": 1,
       "SSL Labs (A- or higher)": 0,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 100
     },
     {
       "Agency": "Library of Congress",
-      "HTTPS Enabled?": 5,
-      "HTTPS Enforced?": 2,
+      "Enforces HTTPS": 2,
       "Number of Domains": 42,
       "SSL Labs (A- or higher)": 0,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 5
     },
     {
       "Agency": "Marine Mammal Commission",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": 0,
+      "Enforces HTTPS": 0,
       "Number of Domains": 1,
       "SSL Labs (A- or higher)": 0,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 0
     },
     {
       "Agency": "Medicaid and CHIP Payment and Access Commission",
-      "HTTPS Enabled?": 100,
-      "HTTPS Enforced?": 100,
+      "Enforces HTTPS": 100,
       "Number of Domains": 1,
       "SSL Labs (A- or higher)": 100,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 100
     },
     {
       "Agency": "Medical Payment Advisory Commission",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": 0,
+      "Enforces HTTPS": 0,
       "Number of Domains": 1,
       "SSL Labs (A- or higher)": 0,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 0
     },
     {
       "Agency": "Merit Systems Protection Board",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": 0,
+      "Enforces HTTPS": 0,
       "Number of Domains": 1,
       "SSL Labs (A- or higher)": 0,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 0
     },
     {
       "Agency": "Millennium Challenge Corporation",
-      "HTTPS Enabled?": 100,
-      "HTTPS Enforced?": 100,
+      "Enforces HTTPS": 100,
       "Number of Domains": 1,
       "SSL Labs (A- or higher)": 0,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 100
     },
     {
       "Agency": "Morris K. Udall Foundation",
-      "HTTPS Enabled?": 100,
-      "HTTPS Enforced?": 0,
+      "Enforces HTTPS": 0,
       "Number of Domains": 2,
       "SSL Labs (A- or higher)": 0,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 100
     },
     {
       "Agency": "National Aeronautics and Space Administration",
-      "HTTPS Enabled?": 60,
-      "HTTPS Enforced?": 0,
+      "Enforces HTTPS": 0,
       "Number of Domains": 5,
       "SSL Labs (A- or higher)": 20,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 60
     },
     {
       "Agency": "National Archives and Records Administration",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": 0,
+      "Enforces HTTPS": 0,
       "Number of Domains": 16,
       "SSL Labs (A- or higher)": 0,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 0
     },
     {
       "Agency": "National Capital Planning Commission",
-      "HTTPS Enabled?": 100,
-      "HTTPS Enforced?": 0,
+      "Enforces HTTPS": 0,
       "Number of Domains": 1,
       "SSL Labs (A- or higher)": 100,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 100
     },
     {
       "Agency": "National Council on Disability",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": 0,
+      "Enforces HTTPS": 0,
       "Number of Domains": 1,
       "SSL Labs (A- or higher)": 0,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 0
     },
     {
       "Agency": "National Credit Union Administration",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": 0,
+      "Enforces HTTPS": 0,
       "Number of Domains": 2,
       "SSL Labs (A- or higher)": 0,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 0
     },
     {
       "Agency": "National Endowment for the Arts",
-      "HTTPS Enabled?": 100,
-      "HTTPS Enforced?": 0,
+      "Enforces HTTPS": 0,
       "Number of Domains": 2,
       "SSL Labs (A- or higher)": 0,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 100
     },
     {
       "Agency": "National Endowment for the Humanities",
-      "HTTPS Enabled?": 50,
-      "HTTPS Enforced?": 0,
+      "Enforces HTTPS": 0,
       "Number of Domains": 4,
       "SSL Labs (A- or higher)": 0,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 50
     },
     {
       "Agency": "National Gallery of Art",
-      "HTTPS Enabled?": 100,
-      "HTTPS Enforced?": 0,
+      "Enforces HTTPS": 0,
       "Number of Domains": 1,
       "SSL Labs (A- or higher)": 0,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 100
     },
     {
       "Agency": "National Indian Gaming Commission",
-      "HTTPS Enabled?": 100,
-      "HTTPS Enforced?": 0,
+      "Enforces HTTPS": 0,
       "Number of Domains": 1,
       "SSL Labs (A- or higher)": 0,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 100
     },
     {
       "Agency": "National Labor Relations Board",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": 0,
+      "Enforces HTTPS": 0,
       "Number of Domains": 1,
       "SSL Labs (A- or higher)": 0,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 0
     },
     {
       "Agency": "National Mediation Board",
-      "HTTPS Enabled?": 100,
-      "HTTPS Enforced?": 0,
+      "Enforces HTTPS": 0,
       "Number of Domains": 1,
       "SSL Labs (A- or higher)": 0,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 100
     },
     {
       "Agency": "National Nanotechnology Coordination Office",
-      "HTTPS Enabled?": 100,
-      "HTTPS Enforced?": 0,
+      "Enforces HTTPS": 0,
       "Number of Domains": 1,
       "SSL Labs (A- or higher)": 0,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 100
     },
     {
       "Agency": "National Science Foundation",
-      "HTTPS Enabled?": 88,
-      "HTTPS Enforced?": 0,
+      "Enforces HTTPS": 0,
       "Number of Domains": 8,
       "SSL Labs (A- or higher)": 0,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 88
     },
     {
       "Agency": "National Security Agency",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": 0,
+      "Enforces HTTPS": 0,
       "Number of Domains": 1,
       "SSL Labs (A- or higher)": 0,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 0
     },
     {
       "Agency": "National Transportation Safety Board",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": 0,
+      "Enforces HTTPS": 0,
       "Number of Domains": 1,
       "SSL Labs (A- or higher)": 0,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 0
     },
     {
       "Agency": "Networking Information Technology Research and Development (NITRD)",
-      "HTTPS Enabled?": 50,
-      "HTTPS Enforced?": 50,
+      "Enforces HTTPS": 50,
       "Number of Domains": 2,
       "SSL Labs (A- or higher)": 50,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 50
     },
     {
       "Agency": "Nuclear Regulatory Commission",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": 0,
+      "Enforces HTTPS": 0,
       "Number of Domains": 1,
       "SSL Labs (A- or higher)": 0,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 0
     },
     {
       "Agency": "Occupational Safety & Health Review Commission",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": 0,
+      "Enforces HTTPS": 0,
       "Number of Domains": 1,
       "SSL Labs (A- or higher)": 0,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 0
     },
     {
       "Agency": "Office of Government Ethics",
-      "HTTPS Enabled?": 100,
-      "HTTPS Enforced?": 100,
+      "Enforces HTTPS": 100,
       "Number of Domains": 1,
       "SSL Labs (A- or higher)": 100,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 100
     },
     {
       "Agency": "Office of Personnel Management",
-      "HTTPS Enabled?": 57,
-      "HTTPS Enforced?": 29,
+      "Enforces HTTPS": 29,
       "Number of Domains": 21,
       "SSL Labs (A- or higher)": 0,
-      "Strict Transport Security (HSTS)": 5
+      "Strict Transport Security (HSTS)": 5,
+      "Uses HTTPS": 57
     },
     {
       "Agency": "Overseas Private Investment Corporation",
-      "HTTPS Enabled?": 100,
-      "HTTPS Enforced?": 100,
+      "Enforces HTTPS": 100,
       "Number of Domains": 1,
       "SSL Labs (A- or higher)": 100,
-      "Strict Transport Security (HSTS)": 100
+      "Strict Transport Security (HSTS)": 100,
+      "Uses HTTPS": 100
     },
     {
       "Agency": "Pension Benefit Guaranty Corporation",
-      "HTTPS Enabled?": 100,
-      "HTTPS Enforced?": 0,
+      "Enforces HTTPS": 0,
       "Number of Domains": 1,
       "SSL Labs (A- or higher)": 0,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 100
     },
     {
       "Agency": "Postal Rate Commission",
-      "HTTPS Enabled?": 100,
-      "HTTPS Enforced?": 0,
+      "Enforces HTTPS": 0,
       "Number of Domains": 1,
       "SSL Labs (A- or higher)": 0,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 100
     },
     {
       "Agency": "Railroad Retirement Board",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": 0,
+      "Enforces HTTPS": 0,
       "Number of Domains": 1,
       "SSL Labs (A- or higher)": 0,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 0
     },
     {
       "Agency": "Recovery Accountability and Transparency Board",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": 0,
+      "Enforces HTTPS": 0,
       "Number of Domains": 5,
       "SSL Labs (A- or higher)": 0,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 0
     },
     {
       "Agency": "Securities and Exchange Commission",
-      "HTTPS Enabled?": 67,
-      "HTTPS Enforced?": 0,
+      "Enforces HTTPS": 0,
       "Number of Domains": 3,
       "SSL Labs (A- or higher)": 33,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 67
     },
     {
       "Agency": "Selective Service System",
-      "HTTPS Enabled?": 100,
-      "HTTPS Enforced?": 0,
+      "Enforces HTTPS": 0,
       "Number of Domains": 1,
       "SSL Labs (A- or higher)": 0,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 100
     },
     {
       "Agency": "Small Business Administration",
-      "HTTPS Enabled?": 29,
-      "HTTPS Enforced?": 29,
+      "Enforces HTTPS": 29,
       "Number of Domains": 7,
       "SSL Labs (A- or higher)": 0,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 29
     },
     {
       "Agency": "Smithsonian Institution",
-      "HTTPS Enabled?": 100,
-      "HTTPS Enforced?": 0,
+      "Enforces HTTPS": 0,
       "Number of Domains": 1,
       "SSL Labs (A- or higher)": 0,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 100
     },
     {
       "Agency": "Social Security Administration",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": 0,
+      "Enforces HTTPS": 0,
       "Number of Domains": 3,
       "SSL Labs (A- or higher)": 0,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 0
     },
     {
       "Agency": "Social Security Advisory Board",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": 0,
+      "Enforces HTTPS": 0,
       "Number of Domains": 1,
       "SSL Labs (A- or higher)": 0,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 0
     },
     {
       "Agency": "Stennis Center for Public Service",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": 0,
+      "Enforces HTTPS": 0,
       "Number of Domains": 1,
       "SSL Labs (A- or higher)": 0,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 0
     },
     {
       "Agency": "Tennessee Valley Authority",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": 0,
+      "Enforces HTTPS": 0,
       "Number of Domains": 1,
       "SSL Labs (A- or higher)": 0,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 0
     },
     {
       "Agency": "Terrorist Screening Center",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": 0,
+      "Enforces HTTPS": 0,
       "Number of Domains": 1,
       "SSL Labs (A- or higher)": 0,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 0
     },
     {
       "Agency": "The Intelligence Community",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": 0,
+      "Enforces HTTPS": 0,
       "Number of Domains": 1,
       "SSL Labs (A- or higher)": 0,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 0
     },
     {
       "Agency": "The Judicial Branch (Courts)",
-      "HTTPS Enabled?": 6,
-      "HTTPS Enforced?": 6,
+      "Enforces HTTPS": 6,
       "Number of Domains": 16,
       "SSL Labs (A- or higher)": 6,
-      "Strict Transport Security (HSTS)": 6
+      "Strict Transport Security (HSTS)": 6,
+      "Uses HTTPS": 6
     },
     {
       "Agency": "The Legislative Branch (Congress)",
-      "HTTPS Enabled?": 22,
-      "HTTPS Enforced?": 5,
+      "Enforces HTTPS": 5,
       "Number of Domains": 41,
       "SSL Labs (A- or higher)": 5,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 22
     },
     {
       "Agency": "The United States World War One Centennial Commission",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": 0,
+      "Enforces HTTPS": 0,
       "Number of Domains": 1,
       "SSL Labs (A- or higher)": 0,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 0
     },
     {
       "Agency": "U. S. Access Board",
-      "HTTPS Enabled?": 100,
-      "HTTPS Enforced?": 0,
+      "Enforces HTTPS": 0,
       "Number of Domains": 1,
       "SSL Labs (A- or higher)": 0,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 100
     },
     {
       "Agency": "U. S. Holocaust Memorial Museum",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": 0,
+      "Enforces HTTPS": 0,
       "Number of Domains": 1,
       "SSL Labs (A- or higher)": 0,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 0
     },
     {
       "Agency": "U. S. International Trade Commission",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": 0,
+      "Enforces HTTPS": 0,
       "Number of Domains": 1,
       "SSL Labs (A- or higher)": 0,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 0
     },
     {
       "Agency": "U. S. Office of Special Counsel",
-      "HTTPS Enabled?": 100,
-      "HTTPS Enforced?": 100,
+      "Enforces HTTPS": 100,
       "Number of Domains": 1,
       "SSL Labs (A- or higher)": 100,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 100
     },
     {
       "Agency": "U. S. Peace Corps",
-      "HTTPS Enabled?": 33,
-      "HTTPS Enforced?": 0,
+      "Enforces HTTPS": 0,
       "Number of Domains": 3,
       "SSL Labs (A- or higher)": 0,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 33
     },
     {
       "Agency": "U. S. Postal Service",
-      "HTTPS Enabled?": 25,
-      "HTTPS Enforced?": 25,
+      "Enforces HTTPS": 25,
       "Number of Domains": 4,
       "SSL Labs (A- or higher)": 25,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 25
     },
     {
       "Agency": "U.S. Agency for International Development",
-      "HTTPS Enabled?": 36,
-      "HTTPS Enforced?": 9,
+      "Enforces HTTPS": 9,
       "Number of Domains": 11,
       "SSL Labs (A- or higher)": 9,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 36
     },
     {
       "Agency": "U.S. Chemical Safety and Hazard Investigation Board",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": 0,
+      "Enforces HTTPS": 0,
       "Number of Domains": 3,
       "SSL Labs (A- or higher)": 0,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 0
     },
     {
       "Agency": "U.S. Commission of Fine Arts",
-      "HTTPS Enabled?": 100,
-      "HTTPS Enforced?": 0,
+      "Enforces HTTPS": 0,
       "Number of Domains": 1,
       "SSL Labs (A- or higher)": 0,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 100
     },
     {
       "Agency": "U.S. Postal Service, Office of Inspector General",
-      "HTTPS Enabled?": 100,
-      "HTTPS Enforced?": 100,
+      "Enforces HTTPS": 100,
       "Number of Domains": 1,
       "SSL Labs (A- or higher)": 100,
-      "Strict Transport Security (HSTS)": 100
+      "Strict Transport Security (HSTS)": 100,
+      "Uses HTTPS": 100
     },
     {
       "Agency": "U.S. Trade and Development Agency",
-      "HTTPS Enabled?": 100,
-      "HTTPS Enforced?": 0,
+      "Enforces HTTPS": 0,
       "Number of Domains": 1,
       "SSL Labs (A- or higher)": 0,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 100
     },
     {
       "Agency": "US Interagency Council on Homelessness",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": 0,
+      "Enforces HTTPS": 0,
       "Number of Domains": 2,
       "SSL Labs (A- or higher)": 0,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 0
     },
     {
       "Agency": "United Stated Global Change Research Program",
-      "HTTPS Enabled?": 50,
-      "HTTPS Enforced?": 0,
+      "Enforces HTTPS": 0,
       "Number of Domains": 4,
       "SSL Labs (A- or higher)": 25,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 50
     },
     {
       "Agency": "United States Office of Government Ethics",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": 0,
+      "Enforces HTTPS": 0,
       "Number of Domains": 2,
       "SSL Labs (A- or higher)": 0,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 0
     }
   ]
 }

--- a/assets/data/tables/https/domains.json
+++ b/assets/data/tables/https/domains.json
@@ -3,9658 +3,9658 @@
     {
       "Canonical": "http://www.18f.gov",
       "Domain": "18f.gov",
-      "HTTPS Enabled?": 2,
-      "HTTPS Enforced?": 1,
+      "Enforces HTTPS": 1,
       "SSL Labs Grade": 6,
-      "Strict Transport Security (HSTS)": 1
+      "Strict Transport Security (HSTS)": 1,
+      "Uses HTTPS": 2
     },
     {
       "Canonical": "http://404.gov",
       "Domain": "404.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://9-11commission.gov",
       "Domain": "9-11commission.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://911.gov",
       "Domain": "911.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://911commission.gov",
       "Domain": "911commission.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.aapi.gov",
       "Domain": "aapi.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.abandonedmines.gov",
       "Domain": "abandonedmines.gov",
-      "HTTPS Enabled?": 2,
-      "HTTPS Enforced?": 1,
+      "Enforces HTTPS": 1,
       "SSL Labs Grade": 5,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 2
     },
     {
       "Canonical": "http://abilityone.gov",
       "Domain": "abilityone.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://abmc.gov",
       "Domain": "abmc.gov",
-      "HTTPS Enabled?": 1,
-      "HTTPS Enforced?": 1,
+      "Enforces HTTPS": 1,
       "SSL Labs Grade": 2,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 1
     },
     {
       "Canonical": "http://www.access-board.gov",
       "Domain": "access-board.gov",
-      "HTTPS Enabled?": 2,
-      "HTTPS Enforced?": 1,
+      "Enforces HTTPS": 1,
       "SSL Labs Grade": 0,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 2
     },
     {
       "Canonical": "http://www.acf.gov",
       "Domain": "acf.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://achp.gov",
       "Domain": "achp.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://acl.gov",
       "Domain": "acl.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "https://www.acquisition.gov",
       "Domain": "acquisition.gov",
-      "HTTPS Enabled?": 1,
-      "HTTPS Enforced?": 3,
+      "Enforces HTTPS": 3,
       "SSL Labs Grade": 3,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 1
     },
     {
       "Canonical": "https://www.acus.gov",
       "Domain": "acus.gov",
-      "HTTPS Enabled?": 2,
-      "HTTPS Enforced?": 3,
+      "Enforces HTTPS": 3,
       "SSL Labs Grade": 4,
-      "Strict Transport Security (HSTS)": 3
+      "Strict Transport Security (HSTS)": 3,
+      "Uses HTTPS": 2
     },
     {
       "Canonical": "http://acwi.gov",
       "Domain": "acwi.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.ada.gov",
       "Domain": "ada.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://adlnet.gov",
       "Domain": "adlnet.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.admongo.gov",
       "Domain": "admongo.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.adr.gov",
       "Domain": "adr.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.advantage.gov",
       "Domain": "advantage.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "https://afadvantage.gov",
       "Domain": "afadvantage.gov",
-      "HTTPS Enabled?": 2,
-      "HTTPS Enforced?": 3,
+      "Enforces HTTPS": 3,
       "SSL Labs Grade": 2,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 2
     },
     {
       "Canonical": "http://www.aff.gov",
       "Domain": "aff.gov",
-      "HTTPS Enabled?": 2,
-      "HTTPS Enforced?": 1,
+      "Enforces HTTPS": 1,
       "SSL Labs Grade": 3,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 2
     },
     {
       "Canonical": "https://www.afrh.gov",
       "Domain": "afrh.gov",
-      "HTTPS Enabled?": 1,
-      "HTTPS Enforced?": 3,
+      "Enforces HTTPS": 3,
       "SSL Labs Grade": 3,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 1
     },
     {
       "Canonical": "http://africanamericanhistorymonth.gov",
       "Domain": "africanamericanhistorymonth.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.afterschool.gov",
       "Domain": "afterschool.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.agingstats.gov",
       "Domain": "agingstats.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.ahcpr.gov",
       "Domain": "ahcpr.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.ahrq.gov",
       "Domain": "ahrq.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "https://aids.gov",
       "Domain": "aids.gov",
-      "HTTPS Enabled?": 2,
-      "HTTPS Enforced?": 3,
+      "Enforces HTTPS": 3,
       "SSL Labs Grade": 6,
-      "Strict Transport Security (HSTS)": 3
+      "Strict Transport Security (HSTS)": 3,
+      "Uses HTTPS": 2
     },
     {
       "Canonical": "http://airnow.gov",
       "Domain": "airnow.gov",
-      "HTTPS Enabled?": 1,
-      "HTTPS Enforced?": 1,
+      "Enforces HTTPS": 1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 1
     },
     {
       "Canonical": "http://alaskacenters.gov",
       "Domain": "alaskacenters.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.alertaenlinea.gov",
       "Domain": "alertaenlinea.gov",
-      "HTTPS Enabled?": 2,
-      "HTTPS Enforced?": 1,
+      "Enforces HTTPS": 1,
       "SSL Labs Grade": 3,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 2
     },
     {
       "Canonical": "http://www.altusandc.gov",
       "Domain": "altusandc.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://alzheimers.gov",
       "Domain": "alzheimers.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "https://www.ama.gov",
       "Domain": "ama.gov",
-      "HTTPS Enabled?": 1,
-      "HTTPS Enforced?": 3,
+      "Enforces HTTPS": 3,
       "SSL Labs Grade": 0,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 1
     },
     {
       "Canonical": "http://amberalert.gov",
       "Domain": "amberalert.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.america.gov",
       "Domain": "america.gov",
-      "HTTPS Enabled?": 1,
-      "HTTPS Enforced?": 1,
+      "Enforces HTTPS": 1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 1
     },
     {
       "Canonical": "http://www.americanjobcenter.gov",
       "Domain": "americanjobcenter.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://americanlatinomuseum.gov",
       "Domain": "americanlatinomuseum.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.americanmemory.gov",
       "Domain": "americanmemory.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.americasgreatoutdoors.gov",
       "Domain": "americasgreatoutdoors.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.americasheroesatwork.gov",
       "Domain": "americasheroesatwork.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.americaslibrary.gov",
       "Domain": "americaslibrary.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.americasstory.gov",
       "Domain": "americasstory.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.americastory.gov",
       "Domain": "americastory.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.americathebeautifulquarters.gov",
       "Domain": "americathebeautifulquarters.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.americore.gov",
       "Domain": "americore.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.americorp.gov",
       "Domain": "americorp.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.americorps.gov",
       "Domain": "americorps.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.americorpsconnect.gov",
       "Domain": "americorpsconnect.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.americorpsweek.gov",
       "Domain": "americorpsweek.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "https://www.ameslab.gov",
       "Domain": "ameslab.gov",
-      "HTTPS Enabled?": 2,
-      "HTTPS Enforced?": 3,
+      "Enforces HTTPS": 3,
       "SSL Labs Grade": 4,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 2
     },
     {
       "Canonical": "http://amtrakoig.gov",
       "Domain": "amtrakoig.gov",
-      "HTTPS Enabled?": 1,
-      "HTTPS Enforced?": 1,
+      "Enforces HTTPS": 1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 1
     },
     {
       "Canonical": "http://www.anl.gov",
       "Domain": "anl.gov",
-      "HTTPS Enabled?": 2,
-      "HTTPS Enforced?": 0,
+      "Enforces HTTPS": 0,
       "SSL Labs Grade": 2,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 2
     },
     {
       "Canonical": "http://www.annualcreditreport.gov",
       "Domain": "annualcreditreport.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.anstaskforce.gov",
       "Domain": "anstaskforce.gov",
-      "HTTPS Enabled?": 1,
-      "HTTPS Enforced?": 1,
+      "Enforces HTTPS": 1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 1
     },
     {
       "Canonical": "http://aoa.gov",
       "Domain": "aoa.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.aoc.gov",
       "Domain": "aoc.gov",
-      "HTTPS Enabled?": 2,
-      "HTTPS Enforced?": 0,
+      "Enforces HTTPS": 0,
       "SSL Labs Grade": 5,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 2
     },
     {
       "Canonical": "http://www.ap.gov",
       "Domain": "ap.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "https://www.applicationmanager.gov",
       "Domain": "applicationmanager.gov",
-      "HTTPS Enabled?": 2,
-      "HTTPS Enforced?": 3,
+      "Enforces HTTPS": 3,
       "SSL Labs Grade": 3,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 2
     },
     {
       "Canonical": "http://apps.gov",
       "Domain": "apps.gov",
-      "HTTPS Enabled?": 1,
-      "HTTPS Enforced?": 1,
+      "Enforces HTTPS": 1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 1
     },
     {
       "Canonical": "http://www.arc.gov",
       "Domain": "arc.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://archives.gov",
       "Domain": "archives.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://arctic.gov",
       "Domain": "arctic.gov",
-      "HTTPS Enabled?": 1,
-      "HTTPS Enforced?": 1,
+      "Enforces HTTPS": 1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 1
     },
     {
       "Canonical": "http://arcticgas.gov",
       "Domain": "arcticgas.gov",
-      "HTTPS Enabled?": 1,
-      "HTTPS Enforced?": 1,
+      "Enforces HTTPS": 1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 1
     },
     {
       "Canonical": "http://www.arm.gov",
       "Domain": "arm.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.ars-grin.gov",
       "Domain": "ars-grin.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://arts.gov",
       "Domain": "arts.gov",
-      "HTTPS Enabled?": 1,
-      "HTTPS Enforced?": 1,
+      "Enforces HTTPS": 1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 1
     },
     {
       "Canonical": "https://www.asap.gov",
       "Domain": "asap.gov",
-      "HTTPS Enabled?": 1,
-      "HTTPS Enforced?": 3,
+      "Enforces HTTPS": 3,
       "SSL Labs Grade": 0,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 1
     },
     {
       "Canonical": "https://www.asc.gov",
       "Domain": "asc.gov",
-      "HTTPS Enabled?": 2,
-      "HTTPS Enforced?": 3,
+      "Enforces HTTPS": 3,
       "SSL Labs Grade": 3,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 2
     },
     {
       "Canonical": "http://asianpacificheritage.gov",
       "Domain": "asianpacificheritage.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.askkaren.gov",
       "Domain": "askkaren.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.astrongmiddleclass.gov",
       "Domain": "astrongmiddleclass.gov",
-      "HTTPS Enabled?": 2,
-      "HTTPS Enforced?": 1,
+      "Enforces HTTPS": 1,
       "SSL Labs Grade": 5,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 2
     },
     {
       "Canonical": "http://www.atf.gov",
       "Domain": "atf.gov",
-      "HTTPS Enabled?": 2,
-      "HTTPS Enforced?": 1,
+      "Enforces HTTPS": 1,
       "SSL Labs Grade": 5,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 2
     },
     {
       "Canonical": "http://www.atvsafety.gov",
       "Domain": "atvsafety.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.autocommunities.gov",
       "Domain": "autocommunities.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://aviationweather.gov",
       "Domain": "aviationweather.gov",
-      "HTTPS Enabled?": 2,
-      "HTTPS Enforced?": 1,
+      "Enforces HTTPS": 1,
       "SSL Labs Grade": 3,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 2
     },
     {
       "Canonical": "http://ayudaconmibanco.gov",
       "Domain": "ayudaconmibanco.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.bam.gov",
       "Domain": "bam.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://bankanswers.gov",
       "Domain": "bankanswers.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://bankcustomer.gov",
       "Domain": "bankcustomer.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://bankcustomerassistance.gov",
       "Domain": "bankcustomerassistance.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://bankhelp.gov",
       "Domain": "bankhelp.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://banknet.gov",
       "Domain": "banknet.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.bankruptcy.gov",
       "Domain": "bankruptcy.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.bbg.gov",
       "Domain": "bbg.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.bcfp.gov",
       "Domain": "bcfp.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://bea.gov",
       "Domain": "bea.gov",
-      "HTTPS Enabled?": 2,
-      "HTTPS Enforced?": 1,
+      "Enforces HTTPS": 1,
       "SSL Labs Grade": 4,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 2
     },
     {
       "Canonical": "http://www.befoodsafe.gov",
       "Domain": "befoodsafe.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.benefits.gov",
       "Domain": "benefits.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://bep.gov",
       "Domain": "bep.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.bestbonesforever.gov",
       "Domain": "bestbonesforever.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.betobaccofree.gov",
       "Domain": "betobaccofree.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.bfelob.gov",
       "Domain": "bfelob.gov",
-      "HTTPS Enabled?": 2,
-      "HTTPS Enforced?": 1,
+      "Enforces HTTPS": 1,
       "SSL Labs Grade": 0,
-      "Strict Transport Security (HSTS)": 3
+      "Strict Transport Security (HSTS)": 3,
+      "Uses HTTPS": 2
     },
     {
       "Canonical": "https://bfem.gov",
       "Domain": "bfem.gov",
-      "HTTPS Enabled?": 2,
-      "HTTPS Enforced?": 3,
+      "Enforces HTTPS": 3,
       "SSL Labs Grade": 0,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 2
     },
     {
       "Canonical": "http://bia.gov",
       "Domain": "bia.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.bioeco.gov",
       "Domain": "bioeco.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://bioethics.gov",
       "Domain": "bioethics.gov",
-      "HTTPS Enabled?": 1,
-      "HTTPS Enforced?": 1,
+      "Enforces HTTPS": 1,
       "SSL Labs Grade": 2,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 1
     },
     {
       "Canonical": "http://biomassboard.gov",
       "Domain": "biomassboard.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.biometriccoe.gov",
       "Domain": "biometriccoe.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://biometrics.gov",
       "Domain": "biometrics.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://biopreferred.gov",
       "Domain": "biopreferred.gov",
-      "HTTPS Enabled?": 1,
-      "HTTPS Enforced?": 1,
+      "Enforces HTTPS": 1,
       "SSL Labs Grade": 1,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 1
     },
     {
       "Canonical": "https://www.bja.gov",
       "Domain": "bja.gov",
-      "HTTPS Enabled?": 2,
-      "HTTPS Enforced?": 3,
+      "Enforces HTTPS": 3,
       "SSL Labs Grade": 2,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 2
     },
     {
       "Canonical": "http://bjs.gov",
       "Domain": "bjs.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.bldrdoc.gov",
       "Domain": "bldrdoc.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.blm.gov",
       "Domain": "blm.gov",
-      "HTTPS Enabled?": 2,
-      "HTTPS Enforced?": 0,
+      "Enforces HTTPS": 0,
       "SSL Labs Grade": 3,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 2
     },
     {
       "Canonical": "http://blmntl.gov",
       "Domain": "blmntl.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.bls.gov",
       "Domain": "bls.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.bnl.gov",
       "Domain": "bnl.gov",
-      "HTTPS Enabled?": 2,
-      "HTTPS Enforced?": 0,
+      "Enforces HTTPS": 0,
       "SSL Labs Grade": 3,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 2
     },
     {
       "Canonical": "http://www.boem.gov",
       "Domain": "boem.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://boemre.gov",
       "Domain": "boemre.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://bondpro.gov",
       "Domain": "bondpro.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.bop.gov",
       "Domain": "bop.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.bpa.gov",
       "Domain": "bpa.gov",
-      "HTTPS Enabled?": 2,
-      "HTTPS Enforced?": 1,
+      "Enforces HTTPS": 1,
       "SSL Labs Grade": 2,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 2
     },
     {
       "Canonical": "http://brac.gov",
       "Domain": "brac.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.broadband.gov",
       "Domain": "broadband.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://broadbandmap.gov",
       "Domain": "broadbandmap.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.browsetopics.gov",
       "Domain": "browsetopics.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.bsee.gov",
       "Domain": "bsee.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.bts.gov",
       "Domain": "bts.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.budget.gov",
       "Domain": "budget.gov",
-      "HTTPS Enabled?": 2,
-      "HTTPS Enforced?": 1,
+      "Enforces HTTPS": 1,
       "SSL Labs Grade": 5,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 2
     },
     {
       "Canonical": "http://www.buildingamerica.gov",
       "Domain": "buildingamerica.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.business.gov",
       "Domain": "business.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.businessusa.gov",
       "Domain": "businessusa.gov",
-      "HTTPS Enabled?": 2,
-      "HTTPS Enforced?": 1,
+      "Enforces HTTPS": 1,
       "SSL Labs Grade": 3,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 2
     },
     {
       "Canonical": "http://buyaccessible.gov",
       "Domain": "buyaccessible.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://buyusa.gov",
       "Domain": "buyusa.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.c3.gov",
       "Domain": "c3.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.cancer.gov",
       "Domain": "cancer.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.cancernet.gov",
       "Domain": "cancernet.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "https://cao.gov",
       "Domain": "cao.gov",
-      "HTTPS Enabled?": 2,
-      "HTTPS Enforced?": 3,
+      "Enforces HTTPS": 3,
       "SSL Labs Grade": 0,
-      "Strict Transport Security (HSTS)": 3
+      "Strict Transport Security (HSTS)": 3,
+      "Uses HTTPS": 2
     },
     {
       "Canonical": "http://capitol.gov",
       "Domain": "capitol.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.capitolflags.gov",
       "Domain": "capitolflags.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.capitolhill.gov",
       "Domain": "capitolhill.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.capnhq.gov",
       "Domain": "capnhq.gov",
-      "HTTPS Enabled?": 2,
-      "HTTPS Enforced?": 1,
+      "Enforces HTTPS": 1,
       "SSL Labs Grade": 3,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 2
     },
     {
       "Canonical": "http://www.carboncyclescience.gov",
       "Domain": "carboncyclescience.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.casl.gov",
       "Domain": "casl.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://cbca.gov",
       "Domain": "cbca.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.cbo.gov",
       "Domain": "cbo.gov",
-      "HTTPS Enabled?": 2,
-      "HTTPS Enforced?": 1,
+      "Enforces HTTPS": 1,
       "SSL Labs Grade": 4,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 2
     },
     {
       "Canonical": "http://cbonews.gov",
       "Domain": "cbonews.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.cbp.gov",
       "Domain": "cbp.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://ccac.gov",
       "Domain": "ccac.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.ccr.gov",
       "Domain": "ccr.gov",
-      "HTTPS Enabled?": 1,
-      "HTTPS Enforced?": 1,
+      "Enforces HTTPS": 1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 1
     },
     {
       "Canonical": "http://www.cdc.gov",
       "Domain": "cdc.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.cdco.gov",
       "Domain": "cdco.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://cdfifund.gov",
       "Domain": "cdfifund.gov",
-      "HTTPS Enabled?": 1,
-      "HTTPS Enforced?": 1,
+      "Enforces HTTPS": 1,
       "SSL Labs Grade": 1,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 1
     },
     {
       "Canonical": "http://www.cebaf.gov",
       "Domain": "cebaf.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.cecc.gov",
       "Domain": "cecc.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://cendi.gov",
       "Domain": "cendi.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://census.gov",
       "Domain": "census.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://cfa.gov",
       "Domain": "cfa.gov",
-      "HTTPS Enabled?": 2,
-      "HTTPS Enforced?": 1,
+      "Enforces HTTPS": 1,
       "SSL Labs Grade": 3,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 2
     },
     {
       "Canonical": "https://www.cfda.gov",
       "Domain": "cfda.gov",
-      "HTTPS Enabled?": 1,
-      "HTTPS Enforced?": 3,
+      "Enforces HTTPS": 3,
       "SSL Labs Grade": 2,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 1
     },
     {
       "Canonical": "http://www.cflhd.gov",
       "Domain": "cflhd.gov",
-      "HTTPS Enabled?": 1,
-      "HTTPS Enforced?": 1,
+      "Enforces HTTPS": 1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 1
     },
     {
       "Canonical": "https://cfo.gov",
       "Domain": "cfo.gov",
-      "HTTPS Enabled?": 2,
-      "HTTPS Enforced?": 3,
+      "Enforces HTTPS": 3,
       "SSL Labs Grade": 0,
-      "Strict Transport Security (HSTS)": 3
+      "Strict Transport Security (HSTS)": 3,
+      "Uses HTTPS": 2
     },
     {
       "Canonical": "http://www.cfpa.gov",
       "Domain": "cfpa.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.cfpb.gov",
       "Domain": "cfpb.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.cftc.gov",
       "Domain": "cftc.gov",
-      "HTTPS Enabled?": 1,
-      "HTTPS Enforced?": 0,
+      "Enforces HTTPS": 0,
       "SSL Labs Grade": 5,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 1
     },
     {
       "Canonical": "http://www.challenge.gov",
       "Domain": "challenge.gov",
-      "HTTPS Enabled?": 2,
-      "HTTPS Enforced?": 1,
+      "Enforces HTTPS": 1,
       "SSL Labs Grade": 3,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 2
     },
     {
       "Canonical": "http://www.challenges.gov",
       "Domain": "challenges.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://change.gov",
       "Domain": "change.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://chcoc.gov",
       "Domain": "chcoc.gov",
-      "HTTPS Enabled?": 2,
-      "HTTPS Enforced?": 1,
+      "Enforces HTTPS": 1,
       "SSL Labs Grade": 3,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 2
     },
     {
       "Canonical": "http://www.chemsafety.gov",
       "Domain": "chemsafety.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.childreninadversity.gov",
       "Domain": "childreninadversity.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.childstats.gov",
       "Domain": "childstats.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "https://childwelfare.gov",
       "Domain": "childwelfare.gov",
-      "HTTPS Enabled?": 2,
-      "HTTPS Enforced?": 3,
+      "Enforces HTTPS": 3,
       "SSL Labs Grade": 5,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 2
     },
     {
       "Canonical": "http://chinacommission.gov",
       "Domain": "chinacommission.gov",
-      "HTTPS Enabled?": 1,
-      "HTTPS Enforced?": 1,
+      "Enforces HTTPS": 1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 1
     },
     {
       "Canonical": "http://choosemyplate.gov",
       "Domain": "choosemyplate.gov",
-      "HTTPS Enabled?": 1,
-      "HTTPS Enforced?": 1,
+      "Enforces HTTPS": 1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 1
     },
     {
       "Canonical": "http://www.christophercolumbusfoundation.gov",
       "Domain": "christophercolumbusfoundation.gov",
-      "HTTPS Enabled?": 2,
-      "HTTPS Enforced?": 1,
+      "Enforces HTTPS": 1,
       "SSL Labs Grade": 3,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 2
     },
     {
       "Canonical": "https://www.cia.gov",
       "Domain": "cia.gov",
-      "HTTPS Enabled?": 2,
-      "HTTPS Enforced?": 3,
+      "Enforces HTTPS": 3,
       "SSL Labs Grade": 5,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 2
     },
     {
       "Canonical": "https://cio.gov",
       "Domain": "cio.gov",
-      "HTTPS Enabled?": 2,
-      "HTTPS Enforced?": 3,
+      "Enforces HTTPS": 3,
       "SSL Labs Grade": 0,
-      "Strict Transport Security (HSTS)": 3
+      "Strict Transport Security (HSTS)": 3,
+      "Uses HTTPS": 2
     },
     {
       "Canonical": "http://www.citizencorps.gov",
       "Domain": "citizencorps.gov",
-      "HTTPS Enabled?": 2,
-      "HTTPS Enforced?": 1,
+      "Enforces HTTPS": 1,
       "SSL Labs Grade": 4,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 2
     },
     {
       "Canonical": "http://www.citizens.gov",
       "Domain": "citizens.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://civilianresponsecorps.gov",
       "Domain": "civilianresponsecorps.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://civilrightsusa.gov",
       "Domain": "civilrightsusa.gov",
-      "HTTPS Enabled?": 1,
-      "HTTPS Enforced?": 1,
+      "Enforces HTTPS": 1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 1
     },
     {
       "Canonical": "http://climate.gov",
       "Domain": "climate.gov",
-      "HTTPS Enabled?": 2,
-      "HTTPS Enforced?": 1,
+      "Enforces HTTPS": 1,
       "SSL Labs Grade": 5,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 2
     },
     {
       "Canonical": "http://www.clinicaltrial.gov",
       "Domain": "clinicaltrial.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "https://clinicaltrials.gov",
       "Domain": "clinicaltrials.gov",
-      "HTTPS Enabled?": 2,
-      "HTTPS Enforced?": 3,
+      "Enforces HTTPS": 3,
       "SSL Labs Grade": 3,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 2
     },
     {
       "Canonical": "http://clintonlibrary.gov",
       "Domain": "clintonlibrary.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.clubdrugs.gov",
       "Domain": "clubdrugs.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://cms.gov",
       "Domain": "cms.gov",
-      "HTTPS Enabled?": 2,
-      "HTTPS Enforced?": 1,
+      "Enforces HTTPS": 1,
       "SSL Labs Grade": 4,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 2
     },
     {
       "Canonical": "http://www.cmts.gov",
       "Domain": "cmts.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.cncs.gov",
       "Domain": "cncs.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://cncsoig.gov",
       "Domain": "cncsoig.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.cns.gov",
       "Domain": "cns.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "https://www.cnss.gov",
       "Domain": "cnss.gov",
-      "HTTPS Enabled?": 1,
-      "HTTPS Enforced?": 3,
+      "Enforces HTTPS": 3,
       "SSL Labs Grade": 1,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 1
     },
     {
       "Canonical": "http://coast2050.gov",
       "Domain": "coast2050.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://coastalamerica.gov",
       "Domain": "coastalamerica.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.college.gov",
       "Domain": "college.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://collegedrinkingprevention.gov",
       "Domain": "collegedrinkingprevention.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.collegenavigator.gov",
       "Domain": "collegenavigator.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.commerce.gov",
       "Domain": "commerce.gov",
-      "HTTPS Enabled?": 2,
-      "HTTPS Enforced?": 0,
+      "Enforces HTTPS": 0,
       "SSL Labs Grade": 2,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 2
     },
     {
       "Canonical": "http://www.complaintreferralexpress.gov",
       "Domain": "complaintreferralexpress.gov",
-      "HTTPS Enabled?": 2,
-      "HTTPS Enforced?": 1,
+      "Enforces HTTPS": 1,
       "SSL Labs Grade": 0,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 2
     },
     {
       "Canonical": "http://www.compliance.gov",
       "Domain": "compliance.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://comptrollerofthecurrency.gov",
       "Domain": "comptrollerofthecurrency.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.computers4learning.gov",
       "Domain": "computers4learning.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://computersforlearning.gov",
       "Domain": "computersforlearning.gov",
-      "HTTPS Enabled?": 2,
-      "HTTPS Enforced?": 1,
+      "Enforces HTTPS": 1,
       "SSL Labs Grade": 4,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 2
     },
     {
       "Canonical": "https://congress.gov",
       "Domain": "congress.gov",
-      "HTTPS Enabled?": 2,
-      "HTTPS Enforced?": 3,
+      "Enforces HTTPS": 3,
       "SSL Labs Grade": 3,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 2
     },
     {
       "Canonical": "http://www.congressionaldirectory.gov",
       "Domain": "congressionaldirectory.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.congressionalrecord.gov",
       "Domain": "congressionalrecord.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.connect.gov",
       "Domain": "connect.gov",
-      "HTTPS Enabled?": 2,
-      "HTTPS Enforced?": 1,
+      "Enforces HTTPS": 1,
       "SSL Labs Grade": 3,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 2
     },
     {
       "Canonical": "http://www.consumer.gov",
       "Domain": "consumer.gov",
-      "HTTPS Enabled?": 2,
-      "HTTPS Enforced?": 1,
+      "Enforces HTTPS": 1,
       "SSL Labs Grade": 3,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 2
     },
     {
       "Canonical": "http://www.consumeraction.gov",
       "Domain": "consumeraction.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.consumerbureau.gov",
       "Domain": "consumerbureau.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.consumerfinance.gov",
       "Domain": "consumerfinance.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.consumerfinancial.gov",
       "Domain": "consumerfinancial.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.consumerfinancialbureau.gov",
       "Domain": "consumerfinancialbureau.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.consumerfinancialprotectionbureau.gov",
       "Domain": "consumerfinancialprotectionbureau.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.consumerprotection.gov",
       "Domain": "consumerprotection.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.consumerprotectionbureau.gov",
       "Domain": "consumerprotectionbureau.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "https://consumersentinel.gov",
       "Domain": "consumersentinel.gov",
-      "HTTPS Enabled?": 2,
-      "HTTPS Enforced?": 3,
+      "Enforces HTTPS": 3,
       "SSL Labs Grade": 4,
-      "Strict Transport Security (HSTS)": 3
+      "Strict Transport Security (HSTS)": 3,
+      "Uses HTTPS": 2
     },
     {
       "Canonical": "http://www.consumidor.gov",
       "Domain": "consumidor.gov",
-      "HTTPS Enabled?": 2,
-      "HTTPS Enforced?": 1,
+      "Enforces HTTPS": 1,
       "SSL Labs Grade": 3,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 2
     },
     {
       "Canonical": "http://continentalshelf.gov",
       "Domain": "continentalshelf.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "https://www.contractdirectory.gov",
       "Domain": "contractdirectory.gov",
-      "HTTPS Enabled?": 1,
-      "HTTPS Enforced?": 3,
+      "Enforces HTTPS": 3,
       "SSL Labs Grade": 0,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 1
     },
     {
       "Canonical": "http://www.coop-uspto.gov",
       "Domain": "coop-uspto.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://copyright.gov",
       "Domain": "copyright.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.coralreef.gov",
       "Domain": "coralreef.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.cosponsor.gov",
       "Domain": "cosponsor.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.counterwmd.gov",
       "Domain": "counterwmd.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "https://www.cpars.gov",
       "Domain": "cpars.gov",
-      "HTTPS Enabled?": 1,
-      "HTTPS Enforced?": 3,
+      "Enforces HTTPS": 3,
       "SSL Labs Grade": 3,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 1
     },
     {
       "Canonical": "https://www.cpnireporting.gov",
       "Domain": "cpnireporting.gov",
-      "HTTPS Enabled?": 1,
-      "HTTPS Enforced?": 3,
+      "Enforces HTTPS": 3,
       "SSL Labs Grade": 1,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 1
     },
     {
       "Canonical": "http://www.cpsc.gov",
       "Domain": "cpsc.gov",
-      "HTTPS Enabled?": 2,
-      "HTTPS Enforced?": 1,
+      "Enforces HTTPS": 1,
       "SSL Labs Grade": 3,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 2
     },
     {
       "Canonical": "http://www.crimesolutions.gov",
       "Domain": "crimesolutions.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://crimevictims.gov",
       "Domain": "crimevictims.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.crt2014-2024review.gov",
       "Domain": "crt2014-2024review.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.csb.gov",
       "Domain": "csb.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://csce.gov",
       "Domain": "csce.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.csosa.fed.us",
       "Domain": "csosa.fed.us",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://csosa.gov",
       "Domain": "csosa.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://cttso.gov",
       "Domain": "cttso.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "https://www.cuidadodesalud.gov",
       "Domain": "cuidadodesalud.gov",
-      "HTTPS Enabled?": 2,
-      "HTTPS Enforced?": 3,
+      "Enforces HTTPS": 3,
       "SSL Labs Grade": 6,
-      "Strict Transport Security (HSTS)": 1
+      "Strict Transport Security (HSTS)": 1,
+      "Uses HTTPS": 2
     },
     {
       "Canonical": "http://www.cupcao.gov",
       "Domain": "cupcao.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://cwc.gov",
       "Domain": "cwc.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.cybercrime.gov",
       "Domain": "cybercrime.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.data.gov",
       "Domain": "data.gov",
-      "HTTPS Enabled?": 2,
-      "HTTPS Enforced?": 1,
+      "Enforces HTTPS": 1,
       "SSL Labs Grade": 3,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 2
     },
     {
       "Canonical": "http://www.dcsc.gov",
       "Domain": "dcsc.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.dea.gov",
       "Domain": "dea.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://deadiversion.gov",
       "Domain": "deadiversion.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.defense.gov",
       "Domain": "defense.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.democraticleader.gov",
       "Domain": "democraticleader.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.democraticwhip.gov",
       "Domain": "democraticwhip.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.dems.gov",
       "Domain": "dems.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://denali.gov",
       "Domain": "denali.gov",
-      "HTTPS Enabled?": 1,
-      "HTTPS Enforced?": 1,
+      "Enforces HTTPS": 1,
       "SSL Labs Grade": 2,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 1
     },
     {
       "Canonical": "http://dfafacts.gov",
       "Domain": "dfafacts.gov",
-      "HTTPS Enabled?": 2,
-      "HTTPS Enforced?": 1,
+      "Enforces HTTPS": 1,
       "SSL Labs Grade": 0,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 2
     },
     {
       "Canonical": "http://www.dhhs.gov",
       "Domain": "dhhs.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.dhs.gov",
       "Domain": "dhs.gov",
-      "HTTPS Enabled?": 2,
-      "HTTPS Enforced?": 0,
+      "Enforces HTTPS": 0,
       "SSL Labs Grade": 3,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 2
     },
     {
       "Canonical": "http://www.diabetescommittee.gov",
       "Domain": "diabetescommittee.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.dietaryguidelines.gov",
       "Domain": "dietaryguidelines.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.digitalgov.gov",
       "Domain": "digitalgov.gov",
-      "HTTPS Enabled?": 2,
-      "HTTPS Enforced?": 1,
+      "Enforces HTTPS": 1,
       "SSL Labs Grade": 3,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 2
     },
     {
       "Canonical": "http://www.digitalliteracy.gov",
       "Domain": "digitalliteracy.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://digitalpreservation.gov",
       "Domain": "digitalpreservation.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.digitalstewardship.gov",
       "Domain": "digitalstewardship.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://digitizationguidelines.gov",
       "Domain": "digitizationguidelines.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "https://www.directoasucuenta.gov",
       "Domain": "directoasucuenta.gov",
-      "HTTPS Enabled?": 2,
-      "HTTPS Enforced?": 3,
+      "Enforces HTTPS": 3,
       "SSL Labs Grade": 0,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 2
     },
     {
       "Canonical": "https://www.disability.gov",
       "Domain": "disability.gov",
-      "HTTPS Enabled?": 2,
-      "HTTPS Enforced?": 3,
+      "Enforces HTTPS": 3,
       "SSL Labs Grade": 0,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 2
     },
     {
       "Canonical": "http://www.disasterassistance.gov",
       "Domain": "disasterassistance.gov",
-      "HTTPS Enabled?": 2,
-      "HTTPS Enforced?": 0,
+      "Enforces HTTPS": 0,
       "SSL Labs Grade": 3,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 2
     },
     {
       "Canonical": "http://disasterhousing.gov",
       "Domain": "disasterhousing.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://distracteddriving.gov",
       "Domain": "distracteddriving.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.distraction.gov",
       "Domain": "distraction.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.dna.gov",
       "Domain": "dna.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.dnfsb.gov",
       "Domain": "dnfsb.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.dni.gov",
       "Domain": "dni.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.dnsops.gov",
       "Domain": "dnsops.gov",
-      "HTTPS Enabled?": 1,
-      "HTTPS Enforced?": 1,
+      "Enforces HTTPS": 1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 1
     },
     {
       "Canonical": "http://www.doc.gov",
       "Domain": "doc.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "https://www.docline.gov",
       "Domain": "docline.gov",
-      "HTTPS Enabled?": 2,
-      "HTTPS Enforced?": 0,
+      "Enforces HTTPS": 0,
       "SSL Labs Grade": 3,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 2
     },
     {
       "Canonical": "http://www.dod.gov",
       "Domain": "dod.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.doe.gov",
       "Domain": "doe.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.doeal.gov",
       "Domain": "doeal.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.doi.gov",
       "Domain": "doi.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.doioig.gov",
       "Domain": "doioig.gov",
-      "HTTPS Enabled?": 2,
-      "HTTPS Enforced?": 1,
+      "Enforces HTTPS": 1,
       "SSL Labs Grade": 0,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 2
     },
     {
       "Canonical": "http://dol-esa.gov",
       "Domain": "dol-esa.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://dol.gov",
       "Domain": "dol.gov",
-      "HTTPS Enabled?": 2,
-      "HTTPS Enforced?": 1,
+      "Enforces HTTPS": 1,
       "SSL Labs Grade": 3,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 2
     },
     {
       "Canonical": "http://doleta.gov",
       "Domain": "doleta.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "https://donotcall.gov",
       "Domain": "donotcall.gov",
-      "HTTPS Enabled?": 2,
-      "HTTPS Enforced?": 3,
+      "Enforces HTTPS": 3,
       "SSL Labs Grade": 4,
-      "Strict Transport Security (HSTS)": 3
+      "Strict Transport Security (HSTS)": 3,
+      "Uses HTTPS": 2
     },
     {
       "Canonical": "http://www.dontserveteens.gov",
       "Domain": "dontserveteens.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.dot.gov",
       "Domain": "dot.gov",
-      "HTTPS Enabled?": 2,
-      "HTTPS Enforced?": 0,
+      "Enforces HTTPS": 0,
       "SSL Labs Grade": 3,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 2
     },
     {
       "Canonical": "https://www.dotgov.gov",
       "Domain": "dotgov.gov",
-      "HTTPS Enabled?": 2,
-      "HTTPS Enforced?": 3,
+      "Enforces HTTPS": 3,
       "SSL Labs Grade": 3,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 2
     },
     {
       "Canonical": "https://www.dotideahub.gov",
       "Domain": "dotideahub.gov",
-      "HTTPS Enabled?": 2,
-      "HTTPS Enforced?": 3,
+      "Enforces HTTPS": 3,
       "SSL Labs Grade": 3,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 2
     },
     {
       "Canonical": "http://dottrafficrecords.gov",
       "Domain": "dottrafficrecords.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://dottrcc.gov",
       "Domain": "dottrcc.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://dra.gov",
       "Domain": "dra.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.drought.gov",
       "Domain": "drought.gov",
-      "HTTPS Enabled?": 2,
-      "HTTPS Enforced?": 1,
+      "Enforces HTTPS": 1,
       "SSL Labs Grade": 5,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 2
     },
     {
       "Canonical": "http://www.drugabuse.gov",
       "Domain": "drugabuse.gov",
-      "HTTPS Enabled?": 2,
-      "HTTPS Enforced?": 1,
+      "Enforces HTTPS": 1,
       "SSL Labs Grade": 4,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 2
     },
     {
       "Canonical": "http://www.drugfreeworkplace.gov",
       "Domain": "drugfreeworkplace.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.drywallresponse.gov",
       "Domain": "drywallresponse.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "https://www.dsac.gov",
       "Domain": "dsac.gov",
-      "HTTPS Enabled?": 2,
-      "HTTPS Enforced?": 2,
+      "Enforces HTTPS": 2,
       "SSL Labs Grade": 5,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 2
     },
     {
       "Canonical": "http://www.dtv.gov",
       "Domain": "dtv.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.e-qip.gov",
       "Domain": "e-qip.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://e3.gov",
       "Domain": "e3.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.eac.gov",
       "Domain": "eac.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.earmarks.gov",
       "Domain": "earmarks.gov",
-      "HTTPS Enabled?": 2,
-      "HTTPS Enforced?": 1,
+      "Enforces HTTPS": 1,
       "SSL Labs Grade": 0,
-      "Strict Transport Security (HSTS)": 3
+      "Strict Transport Security (HSTS)": 3,
+      "Uses HTTPS": 2
     },
     {
       "Canonical": "http://www.earthquake.gov",
       "Domain": "earthquake.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.ecfr.gov",
       "Domain": "ecfr.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "https://economicinclusion.gov",
       "Domain": "economicinclusion.gov",
-      "HTTPS Enabled?": 2,
-      "HTTPS Enforced?": 3,
+      "Enforces HTTPS": 3,
       "SSL Labs Grade": 3,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 2
     },
     {
       "Canonical": "http://econsumer.gov",
       "Domain": "econsumer.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://ecopartnerships.gov",
       "Domain": "ecopartnerships.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "https://www.ecpic.gov",
       "Domain": "ecpic.gov",
-      "HTTPS Enabled?": 2,
-      "HTTPS Enforced?": 2,
+      "Enforces HTTPS": 2,
       "SSL Labs Grade": 3,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 2
     },
     {
       "Canonical": "http://www.ecr.gov",
       "Domain": "ecr.gov",
-      "HTTPS Enabled?": 2,
-      "HTTPS Enforced?": 1,
+      "Enforces HTTPS": 1,
       "SSL Labs Grade": 3,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 2
     },
     {
       "Canonical": "http://www.ed.gov",
       "Domain": "ed.gov",
-      "HTTPS Enabled?": 2,
-      "HTTPS Enforced?": 1,
+      "Enforces HTTPS": 1,
       "SSL Labs Grade": 3,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 2
     },
     {
       "Canonical": "http://eda.gov",
       "Domain": "eda.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.edison.gov",
       "Domain": "edison.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.edpubs.gov",
       "Domain": "edpubs.gov",
-      "HTTPS Enabled?": 2,
-      "HTTPS Enforced?": 0,
+      "Enforces HTTPS": 0,
       "SSL Labs Grade": 0,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 2
     },
     {
       "Canonical": "http://www.education.gov",
       "Domain": "education.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.educationjobsfund.gov",
       "Domain": "educationjobsfund.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://eeoc.gov",
       "Domain": "eeoc.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.eforms.gov",
       "Domain": "eforms.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "https://www.eftps.gov",
       "Domain": "eftps.gov",
-      "HTTPS Enabled?": 2,
-      "HTTPS Enforced?": 3,
+      "Enforces HTTPS": 3,
       "SSL Labs Grade": 2,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 2
     },
     {
       "Canonical": "http://www.egov.gov",
       "Domain": "egov.gov",
-      "HTTPS Enabled?": 2,
-      "HTTPS Enforced?": 1,
+      "Enforces HTTPS": 1,
       "SSL Labs Grade": 5,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 2
     },
     {
       "Canonical": "http://www.eia.gov",
       "Domain": "eia.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://eisenhowermemorial.gov",
       "Domain": "eisenhowermemorial.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.eldercare.gov",
       "Domain": "eldercare.gov",
-      "HTTPS Enabled?": 2,
-      "HTTPS Enforced?": 1,
+      "Enforces HTTPS": 1,
       "SSL Labs Grade": 2,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 2
     },
     {
       "Canonical": "http://www.emergency-federal-register.gov",
       "Domain": "emergency-federal-register.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "https://www.employeeexpress.gov",
       "Domain": "employeeexpress.gov",
-      "HTTPS Enabled?": 2,
-      "HTTPS Enforced?": 3,
+      "Enforces HTTPS": 3,
       "SSL Labs Grade": 3,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 2
     },
     {
       "Canonical": "https://empowhr.gov",
       "Domain": "empowhr.gov",
-      "HTTPS Enabled?": 1,
-      "HTTPS Enforced?": 3,
+      "Enforces HTTPS": 3,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 1
     },
     {
       "Canonical": "http://ems.gov",
       "Domain": "ems.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://endingthedocumentgame.gov",
       "Domain": "endingthedocumentgame.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://energy.gov",
       "Domain": "energy.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.energycodes.gov",
       "Domain": "energycodes.gov",
-      "HTTPS Enabled?": 2,
-      "HTTPS Enforced?": 1,
+      "Enforces HTTPS": 1,
       "SSL Labs Grade": 3,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 2
     },
     {
       "Canonical": "http://www.energyplus.gov",
       "Domain": "energyplus.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.energysaver.gov",
       "Domain": "energysaver.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.energysavers.gov",
       "Domain": "energysavers.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.energystar.gov",
       "Domain": "energystar.gov",
-      "HTTPS Enabled?": 2,
-      "HTTPS Enforced?": 1,
+      "Enforces HTTPS": 1,
       "SSL Labs Grade": 3,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 2
     },
     {
       "Canonical": "http://www.eop.gov",
       "Domain": "eop.gov",
-      "HTTPS Enabled?": 2,
-      "HTTPS Enforced?": 1,
+      "Enforces HTTPS": 1,
       "SSL Labs Grade": 5,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 2
     },
     {
       "Canonical": "http://www.epa-echo.gov",
       "Domain": "epa-echo.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.epa-otis.gov",
       "Domain": "epa-otis.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://epa.gov",
       "Domain": "epa.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.epls.gov",
       "Domain": "epls.gov",
-      "HTTPS Enabled?": 1,
-      "HTTPS Enforced?": 1,
+      "Enforces HTTPS": 1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 1
     },
     {
       "Canonical": "http://www.errp.gov",
       "Domain": "errp.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://esa.gov",
       "Domain": "esa.gov",
-      "HTTPS Enabled?": 1,
-      "HTTPS Enforced?": 1,
+      "Enforces HTTPS": 1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 1
     },
     {
       "Canonical": "http://www.esc.gov",
       "Domain": "esc.gov",
-      "HTTPS Enabled?": 2,
-      "HTTPS Enforced?": 1,
+      "Enforces HTTPS": 1,
       "SSL Labs Grade": 3,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 2
     },
     {
       "Canonical": "http://www.espanol.gov",
       "Domain": "espanol.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://espanolforlawenforcement.gov",
       "Domain": "espanolforlawenforcement.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "https://www.esrs.gov",
       "Domain": "esrs.gov",
-      "HTTPS Enabled?": 2,
-      "HTTPS Enforced?": 3,
+      "Enforces HTTPS": 3,
       "SSL Labs Grade": 2,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 2
     },
     {
       "Canonical": "https://www.eta-find.gov",
       "Domain": "eta-find.gov",
-      "HTTPS Enabled?": 2,
-      "HTTPS Enforced?": 3,
+      "Enforces HTTPS": 3,
       "SSL Labs Grade": 0,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 2
     },
     {
       "Canonical": "http://www.ethics.gov",
       "Domain": "ethics.gov",
-      "HTTPS Enabled?": 2,
-      "HTTPS Enforced?": 1,
+      "Enforces HTTPS": 1,
       "SSL Labs Grade": 5,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 2
     },
     {
       "Canonical": "http://www.ethicsburg.gov",
       "Domain": "ethicsburg.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.evergladesrestoration.gov",
       "Domain": "evergladesrestoration.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.execsec.gov",
       "Domain": "execsec.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.exim.gov",
       "Domain": "exim.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.exploretsp.gov",
       "Domain": "exploretsp.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://export.gov",
       "Domain": "export.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://eyenote.gov",
       "Domain": "eyenote.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.faa.gov",
       "Domain": "faa.gov",
-      "HTTPS Enabled?": 2,
-      "HTTPS Enforced?": 1,
+      "Enforces HTTPS": 1,
       "SSL Labs Grade": 3,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 2
     },
     {
       "Canonical": "http://www.faasafety.gov",
       "Domain": "faasafety.gov",
-      "HTTPS Enabled?": 2,
-      "HTTPS Enforced?": 0,
+      "Enforces HTTPS": 0,
       "SSL Labs Grade": 3,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 2
     },
     {
       "Canonical": "http://faca.gov",
       "Domain": "faca.gov",
-      "HTTPS Enabled?": 2,
-      "HTTPS Enforced?": 1,
+      "Enforces HTTPS": 1,
       "SSL Labs Grade": 3,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 2
     },
     {
       "Canonical": "http://facadatabase.gov",
       "Domain": "facadatabase.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://fafsa.gov",
       "Domain": "fafsa.gov",
-      "HTTPS Enabled?": 2,
-      "HTTPS Enforced?": 1,
+      "Enforces HTTPS": 1,
       "SSL Labs Grade": 0,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 2
     },
     {
       "Canonical": "http://www.fai.gov",
       "Domain": "fai.gov",
-      "HTTPS Enabled?": 1,
-      "HTTPS Enforced?": 0,
+      "Enforces HTTPS": 0,
       "SSL Labs Grade": 0,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 1
     },
     {
       "Canonical": "https://www.fan.gov",
       "Domain": "fan.gov",
-      "HTTPS Enabled?": 2,
-      "HTTPS Enforced?": 2,
+      "Enforces HTTPS": 2,
       "SSL Labs Grade": 3,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 2
     },
     {
       "Canonical": "https://fapiis.gov",
       "Domain": "fapiis.gov",
-      "HTTPS Enabled?": 1,
-      "HTTPS Enforced?": 3,
+      "Enforces HTTPS": 3,
       "SSL Labs Grade": 3,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 1
     },
     {
       "Canonical": "http://www.faq.gov",
       "Domain": "faq.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.fara.gov",
       "Domain": "fara.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "https://www.farmerclaims.gov",
       "Domain": "farmerclaims.gov",
-      "HTTPS Enabled?": 1,
-      "HTTPS Enforced?": 3,
+      "Enforces HTTPS": 3,
       "SSL Labs Grade": 2,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 1
     },
     {
       "Canonical": "http://fasab.gov",
       "Domain": "fasab.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "https://fatherhood.gov",
       "Domain": "fatherhood.gov",
-      "HTTPS Enabled?": 2,
-      "HTTPS Enforced?": 3,
+      "Enforces HTTPS": 3,
       "SSL Labs Grade": 5,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 2
     },
     {
       "Canonical": "http://www.fbi.gov",
       "Domain": "fbi.gov",
-      "HTTPS Enabled?": 2,
-      "HTTPS Enforced?": 0,
+      "Enforces HTTPS": 0,
       "SSL Labs Grade": 4,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 2
     },
     {
       "Canonical": "http://www.fbiic.gov",
       "Domain": "fbiic.gov",
-      "HTTPS Enabled?": 2,
-      "HTTPS Enforced?": 1,
+      "Enforces HTTPS": 1,
       "SSL Labs Grade": 3,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 2
     },
     {
       "Canonical": "https://www.fbijobs.gov",
       "Domain": "fbijobs.gov",
-      "HTTPS Enabled?": 2,
-      "HTTPS Enforced?": 2,
+      "Enforces HTTPS": 2,
       "SSL Labs Grade": 4,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 2
     },
     {
       "Canonical": "https://www.fbo.gov",
       "Domain": "fbo.gov",
-      "HTTPS Enabled?": 1,
-      "HTTPS Enforced?": 3,
+      "Enforces HTTPS": 3,
       "SSL Labs Grade": 2,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 1
     },
     {
       "Canonical": "http://fca.gov",
       "Domain": "fca.gov",
-      "HTTPS Enabled?": 1,
-      "HTTPS Enforced?": 1,
+      "Enforces HTTPS": 1,
       "SSL Labs Grade": 3,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 1
     },
     {
       "Canonical": "http://www.fcc.gov",
       "Domain": "fcc.gov",
-      "HTTPS Enabled?": 2,
-      "HTTPS Enforced?": 1,
+      "Enforces HTTPS": 1,
       "SSL Labs Grade": 3,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 2
     },
     {
       "Canonical": "http://www.fccuniversity.gov",
       "Domain": "fccuniversity.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.fcg.gov",
       "Domain": "fcg.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.fcic.gov",
       "Domain": "fcic.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://fcsic.gov",
       "Domain": "fcsic.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://fcsm.gov",
       "Domain": "fcsm.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.fda.gov",
       "Domain": "fda.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "https://fdic.gov",
       "Domain": "fdic.gov",
-      "HTTPS Enabled?": 2,
-      "HTTPS Enforced?": 3,
+      "Enforces HTTPS": 3,
       "SSL Labs Grade": 4,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 2
     },
     {
       "Canonical": "http://fdicbets.gov",
       "Domain": "fdicbets.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.fdicconnect.gov",
       "Domain": "fdicconnect.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://fdicig.gov",
       "Domain": "fdicig.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://fdicoig.gov",
       "Domain": "fdicoig.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://fdicseguro.gov",
       "Domain": "fdicseguro.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.fdlp.gov",
       "Domain": "fdlp.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.fdms.gov",
       "Domain": "fdms.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "https://www.fdr.gov",
       "Domain": "fdr.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.fdsys.gov",
       "Domain": "fdsys.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://feb.gov",
       "Domain": "feb.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://fec.gov",
       "Domain": "fec.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.fedbizopps.gov",
       "Domain": "fedbizopps.gov",
-      "HTTPS Enabled?": 1,
-      "HTTPS Enforced?": 1,
+      "Enforces HTTPS": 1,
       "SSL Labs Grade": 2,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 1
     },
     {
       "Canonical": "https://www.fedcenter.gov",
       "Domain": "fedcenter.gov",
-      "HTTPS Enabled?": 2,
-      "HTTPS Enforced?": 3,
+      "Enforces HTTPS": 3,
       "SSL Labs Grade": 0,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 2
     },
     {
       "Canonical": "http://www.federalaccountability.gov",
       "Domain": "federalaccountability.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.federalcourts.gov",
       "Domain": "federalcourts.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://federalinvestments.gov",
       "Domain": "federalinvestments.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.federaljobs.gov",
       "Domain": "federaljobs.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.federalprobation.gov",
       "Domain": "federalprobation.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "https://www.federalregister.gov",
       "Domain": "federalregister.gov",
-      "HTTPS Enabled?": 2,
-      "HTTPS Enforced?": 2,
+      "Enforces HTTPS": 2,
       "SSL Labs Grade": 5,
-      "Strict Transport Security (HSTS)": 3
+      "Strict Transport Security (HSTS)": 3,
+      "Uses HTTPS": 2
     },
     {
       "Canonical": "http://www.federalreporting.gov",
       "Domain": "federalreporting.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://federalreserve.gov",
       "Domain": "federalreserve.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://federalreserveconsumerhelp.gov",
       "Domain": "federalreserveconsumerhelp.gov",
-      "HTTPS Enabled?": 2,
-      "HTTPS Enforced?": 1,
+      "Enforces HTTPS": 1,
       "SSL Labs Grade": 3,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 2
     },
     {
       "Canonical": "http://www.federalrules.gov",
       "Domain": "federalrules.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.federaltransparency.gov",
       "Domain": "federaltransparency.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.fedforms.gov",
       "Domain": "fedforms.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://fedidcard.gov",
       "Domain": "fedidcard.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://fedinvest.gov",
       "Domain": "fedinvest.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.fedjobs.gov",
       "Domain": "fedjobs.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "https://fedpartnership.gov",
       "Domain": "fedpartnership.gov",
-      "HTTPS Enabled?": 2,
-      "HTTPS Enforced?": 3,
+      "Enforces HTTPS": 3,
       "SSL Labs Grade": 3,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 2
     },
     {
       "Canonical": "http://www.fedramp.gov",
       "Domain": "fedramp.gov",
-      "HTTPS Enabled?": 2,
-      "HTTPS Enforced?": 1,
+      "Enforces HTTPS": 1,
       "SSL Labs Grade": 3,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 2
     },
     {
       "Canonical": "http://fedrealestate.gov",
       "Domain": "fedrealestate.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.fedreg.gov",
       "Domain": "fedreg.gov",
-      "HTTPS Enabled?": 2,
-      "HTTPS Enforced?": 1,
+      "Enforces HTTPS": 1,
       "SSL Labs Grade": 0,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 2
     },
     {
       "Canonical": "http://fedrooms.gov",
       "Domain": "fedrooms.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://fedshirevets.gov",
       "Domain": "fedshirevets.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://fedstats.gov",
       "Domain": "fedstats.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://feedthefuture.gov",
       "Domain": "feedthefuture.gov",
-      "HTTPS Enabled?": 2,
-      "HTTPS Enforced?": 0,
+      "Enforces HTTPS": 0,
       "SSL Labs Grade": 5,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 2
     },
     {
       "Canonical": "http://www.fegli.gov",
       "Domain": "fegli.gov",
-      "HTTPS Enabled?": 2,
-      "HTTPS Enforced?": 1,
+      "Enforces HTTPS": 1,
       "SSL Labs Grade": 3,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 2
     },
     {
       "Canonical": "http://www.fema.gov",
       "Domain": "fema.gov",
-      "HTTPS Enabled?": 2,
-      "HTTPS Enforced?": 1,
+      "Enforces HTTPS": 1,
       "SSL Labs Grade": 3,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 2
     },
     {
       "Canonical": "https://www.femalefarmerclaims.gov",
       "Domain": "femalefarmerclaims.gov",
-      "HTTPS Enabled?": 1,
-      "HTTPS Enforced?": 3,
+      "Enforces HTTPS": 3,
       "SSL Labs Grade": 1,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 1
     },
     {
       "Canonical": "http://ferc.gov",
       "Domain": "ferc.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://fercalt.gov",
       "Domain": "fercalt.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.ffiec.gov",
       "Domain": "ffiec.gov",
-      "HTTPS Enabled?": 2,
-      "HTTPS Enforced?": 1,
+      "Enforces HTTPS": 1,
       "SSL Labs Grade": 3,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 2
     },
     {
       "Canonical": "http://fgdc.gov",
       "Domain": "fgdc.gov",
-      "HTTPS Enabled?": 2,
-      "HTTPS Enforced?": 1,
+      "Enforces HTTPS": 1,
       "SSL Labs Grade": 3,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 2
     },
     {
       "Canonical": "http://www.fha.gov",
       "Domain": "fha.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.fhfa.gov",
       "Domain": "fhfa.gov",
-      "HTTPS Enabled?": 1,
-      "HTTPS Enforced?": 0,
+      "Enforces HTTPS": 0,
       "SSL Labs Grade": 3,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 1
     },
     {
       "Canonical": "http://www.fhfaoig.gov",
       "Domain": "fhfaoig.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://fido.gov",
       "Domain": "fido.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://fightingmalaria.gov",
       "Domain": "fightingmalaria.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://financialresearch.gov",
       "Domain": "financialresearch.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.financialstability.gov",
       "Domain": "financialstability.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://fincen.gov",
       "Domain": "fincen.gov",
-      "HTTPS Enabled?": 1,
-      "HTTPS Enforced?": 1,
+      "Enforces HTTPS": 1,
       "SSL Labs Grade": 3,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 1
     },
     {
       "Canonical": "http://findyouthinfo.gov",
       "Domain": "findyouthinfo.gov",
-      "HTTPS Enabled?": 1,
-      "HTTPS Enforced?": 1,
+      "Enforces HTTPS": 1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 1
     },
     {
       "Canonical": "http://www.firecode.gov",
       "Domain": "firecode.gov",
-      "HTTPS Enabled?": 2,
-      "HTTPS Enforced?": 1,
+      "Enforces HTTPS": 1,
       "SSL Labs Grade": 3,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 2
     },
     {
       "Canonical": "http://www.fireleadership.gov",
       "Domain": "fireleadership.gov",
-      "HTTPS Enabled?": 1,
-      "HTTPS Enforced?": 1,
+      "Enforces HTTPS": 1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 1
     },
     {
       "Canonical": "http://www.firenet.gov",
       "Domain": "firenet.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.firescience.gov",
       "Domain": "firescience.gov",
-      "HTTPS Enabled?": 2,
-      "HTTPS Enforced?": 1,
+      "Enforces HTTPS": 1,
       "SSL Labs Grade": 3,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 2
     },
     {
       "Canonical": "http://www.firstfreedom.gov",
       "Domain": "firstfreedom.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.firstgov.gov",
       "Domain": "firstgov.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://firstnet.gov",
       "Domain": "firstnet.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.firstresponder.gov",
       "Domain": "firstresponder.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "https://www.firstrespondertraining.gov",
       "Domain": "firstrespondertraining.gov",
-      "HTTPS Enabled?": 2,
-      "HTTPS Enforced?": 0,
+      "Enforces HTTPS": 0,
       "SSL Labs Grade": 3,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 2
     },
     {
       "Canonical": "http://www.fiscalcommission.gov",
       "Domain": "fiscalcommission.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.fishwatch.gov",
       "Domain": "fishwatch.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://fitness.gov",
       "Domain": "fitness.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.fjc.gov",
       "Domain": "fjc.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "https://www.fleta.gov",
       "Domain": "fleta.gov",
-      "HTTPS Enabled?": 2,
-      "HTTPS Enforced?": 3,
+      "Enforces HTTPS": 3,
       "SSL Labs Grade": 3,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 2
     },
     {
       "Canonical": "https://www.fletc.gov",
       "Domain": "fletc.gov",
-      "HTTPS Enabled?": 2,
-      "HTTPS Enforced?": 3,
+      "Enforces HTTPS": 3,
       "SSL Labs Grade": 3,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 2
     },
     {
       "Canonical": "https://www.flightschoolcandidates.gov",
       "Domain": "flightschoolcandidates.gov",
-      "HTTPS Enabled?": 2,
-      "HTTPS Enforced?": 3,
+      "Enforces HTTPS": 3,
       "SSL Labs Grade": 3,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 2
     },
     {
       "Canonical": "https://www.floodsmart.gov",
       "Domain": "floodsmart.gov",
-      "HTTPS Enabled?": 2,
-      "HTTPS Enforced?": 0,
+      "Enforces HTTPS": 0,
       "SSL Labs Grade": 4,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 2
     },
     {
       "Canonical": "http://flra.gov",
       "Domain": "flra.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.flu.gov",
       "Domain": "flu.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.fmc.gov",
       "Domain": "fmc.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.fmcs.gov",
       "Domain": "fmcs.gov",
-      "HTTPS Enabled?": 2,
-      "HTTPS Enforced?": 0,
+      "Enforces HTTPS": 0,
       "SSL Labs Grade": 0,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 2
     },
     {
       "Canonical": "http://fmi.gov",
       "Domain": "fmi.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.fmip.gov",
       "Domain": "fmip.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://fmshrc.gov",
       "Domain": "fmshrc.gov",
-      "HTTPS Enabled?": 2,
-      "HTTPS Enforced?": 1,
+      "Enforces HTTPS": 1,
       "SSL Labs Grade": 3,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 2
     },
     {
       "Canonical": "http://fnal.gov",
       "Domain": "fnal.gov",
-      "HTTPS Enabled?": 2,
-      "HTTPS Enforced?": 1,
+      "Enforces HTTPS": 1,
       "SSL Labs Grade": 3,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 2
     },
     {
       "Canonical": "http://www.foia.gov",
       "Domain": "foia.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.foodsafety.gov",
       "Domain": "foodsafety.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.foodsafetyjobs.gov",
       "Domain": "foodsafetyjobs.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.foodsafetyworkinggroup.gov",
       "Domain": "foodsafetyworkinggroup.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://fordlibrarymuseum.gov",
       "Domain": "fordlibrarymuseum.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://foreignassistance.gov",
       "Domain": "foreignassistance.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://forestsandrangelands.gov",
       "Domain": "forestsandrangelands.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.forfeiture.gov",
       "Domain": "forfeiture.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.forms.gov",
       "Domain": "forms.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.fpds.gov",
       "Domain": "fpds.gov",
-      "HTTPS Enabled?": 2,
-      "HTTPS Enforced?": 1,
+      "Enforces HTTPS": 1,
       "SSL Labs Grade": 0,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 2
     },
     {
       "Canonical": "http://frcc.gov",
       "Domain": "frcc.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.freecreditreport.gov",
       "Domain": "freecreditreport.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://frtib.gov",
       "Domain": "frtib.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://frtr.gov",
       "Domain": "frtr.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.fruitsandveggiesmatter.gov",
       "Domain": "fruitsandveggiesmatter.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.fs.fed.us",
       "Domain": "fs.fed.us",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.fsafeds.gov",
       "Domain": "fsafeds.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.fsapubs.gov",
       "Domain": "fsapubs.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "https://www.fsd.gov",
       "Domain": "fsd.gov",
-      "HTTPS Enabled?": 1,
-      "HTTPS Enforced?": 3,
+      "Enforces HTTPS": 3,
       "SSL Labs Grade": 0,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 1
     },
     {
       "Canonical": "http://www.fsgb.gov",
       "Domain": "fsgb.gov",
-      "HTTPS Enabled?": 2,
-      "HTTPS Enforced?": 1,
+      "Enforces HTTPS": 1,
       "SSL Labs Grade": 3,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 2
     },
     {
       "Canonical": "http://www.fsoc.gov",
       "Domain": "fsoc.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "https://www.fsrs.gov",
       "Domain": "fsrs.gov",
-      "HTTPS Enabled?": 2,
-      "HTTPS Enforced?": 3,
+      "Enforces HTTPS": 3,
       "SSL Labs Grade": 2,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 2
     },
     {
       "Canonical": "http://www.fswg.gov",
       "Domain": "fswg.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "https://www.ftc.gov",
       "Domain": "ftc.gov",
-      "HTTPS Enabled?": 2,
-      "HTTPS Enforced?": 3,
+      "Enforces HTTPS": 3,
       "SSL Labs Grade": 3,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 2
     },
     {
       "Canonical": "https://ftccomplaintassistant.gov",
       "Domain": "ftccomplaintassistant.gov",
-      "HTTPS Enabled?": 2,
-      "HTTPS Enforced?": 3,
+      "Enforces HTTPS": 3,
       "SSL Labs Grade": 4,
-      "Strict Transport Security (HSTS)": 3
+      "Strict Transport Security (HSTS)": 3,
+      "Uses HTTPS": 2
     },
     {
       "Canonical": "https://ftcefile.gov",
       "Domain": "ftcefile.gov",
-      "HTTPS Enabled?": 2,
-      "HTTPS Enforced?": 3,
+      "Enforces HTTPS": 3,
       "SSL Labs Grade": 5,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 2
     },
     {
       "Canonical": "https://www.fttesttwai.gov",
       "Domain": "fttesttwai.gov",
-      "HTTPS Enabled?": 1,
-      "HTTPS Enforced?": 3,
+      "Enforces HTTPS": 3,
       "SSL Labs Grade": 1,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 1
     },
     {
       "Canonical": "http://fueleconomy.gov",
       "Domain": "fueleconomy.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.fvap.gov",
       "Domain": "fvap.gov",
-      "HTTPS Enabled?": 2,
-      "HTTPS Enforced?": 0,
+      "Enforces HTTPS": 0,
       "SSL Labs Grade": 5,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 2
     },
     {
       "Canonical": "http://www.fws.gov",
       "Domain": "fws.gov",
-      "HTTPS Enabled?": 2,
-      "HTTPS Enforced?": 1,
+      "Enforces HTTPS": 1,
       "SSL Labs Grade": 3,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 2
     },
     {
       "Canonical": "https://www.g5.gov",
       "Domain": "g5.gov",
-      "HTTPS Enabled?": 2,
-      "HTTPS Enforced?": 3,
+      "Enforces HTTPS": 3,
       "SSL Labs Grade": 4,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 2
     },
     {
       "Canonical": "http://gao.gov",
       "Domain": "gao.gov",
-      "HTTPS Enabled?": 1,
-      "HTTPS Enforced?": 1,
+      "Enforces HTTPS": 1,
       "SSL Labs Grade": 3,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 1
     },
     {
       "Canonical": "http://gaonet.gov",
       "Domain": "gaonet.gov",
-      "HTTPS Enabled?": 1,
-      "HTTPS Enforced?": 1,
+      "Enforces HTTPS": 1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 1
     },
     {
       "Canonical": "http://www.gcdamp.gov",
       "Domain": "gcdamp.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.gcmrc.gov",
       "Domain": "gcmrc.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.genbank.gov",
       "Domain": "genbank.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.genome.gov",
       "Domain": "genome.gov",
-      "HTTPS Enabled?": 2,
-      "HTTPS Enforced?": 1,
+      "Enforces HTTPS": 1,
       "SSL Labs Grade": 3,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 2
     },
     {
       "Canonical": "http://www.geocommunicator.gov",
       "Domain": "geocommunicator.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.geomac.gov",
       "Domain": "geomac.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://geoplatform.gov",
       "Domain": "geoplatform.gov",
-      "HTTPS Enabled?": 2,
-      "HTTPS Enforced?": 1,
+      "Enforces HTTPS": 1,
       "SSL Labs Grade": 3,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 2
     },
     {
       "Canonical": "http://www.georgewbushlibrary.gov",
       "Domain": "georgewbushlibrary.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.getinvolved.gov",
       "Domain": "getinvolved.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://getsmartaboutdrugs.gov",
       "Domain": "getsmartaboutdrugs.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.getyouhome.gov",
       "Domain": "getyouhome.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://ghi.gov",
       "Domain": "ghi.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.ginniemae.gov",
       "Domain": "ginniemae.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://girlshealth.gov",
       "Domain": "girlshealth.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.globalchange.gov",
       "Domain": "globalchange.gov",
-      "HTTPS Enabled?": 2,
-      "HTTPS Enforced?": 0,
+      "Enforces HTTPS": 0,
       "SSL Labs Grade": 5,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 2
     },
     {
       "Canonical": "http://www.globalentry.gov",
       "Domain": "globalentry.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.globalhealth.gov",
       "Domain": "globalhealth.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.globe.gov",
       "Domain": "globe.gov",
-      "HTTPS Enabled?": 2,
-      "HTTPS Enforced?": 1,
+      "Enforces HTTPS": 1,
       "SSL Labs Grade": 3,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 2
     },
     {
       "Canonical": "http://www.gobierno.gov",
       "Domain": "gobierno.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.gobiernousa.gov",
       "Domain": "gobiernousa.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "https://www.godirect.gov",
       "Domain": "godirect.gov",
-      "HTTPS Enabled?": 2,
-      "HTTPS Enforced?": 3,
+      "Enforces HTTPS": 3,
       "SSL Labs Grade": 0,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 2
     },
     {
       "Canonical": "http://www.goes-r.gov",
       "Domain": "goes-r.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://golearn.gov",
       "Domain": "golearn.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.gop.gov",
       "Domain": "gop.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.gopconference.gov",
       "Domain": "gopconference.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.gopleader.gov",
       "Domain": "gopleader.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.govbenefits.gov",
       "Domain": "govbenefits.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.governmentjobs.gov",
       "Domain": "governmentjobs.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.govloans.gov",
       "Domain": "govloans.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.govsales.gov",
       "Domain": "govsales.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://gpo.gov",
       "Domain": "gpo.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.gpoaccess.gov",
       "Domain": "gpoaccess.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.gps.gov",
       "Domain": "gps.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.grants.gov",
       "Domain": "grants.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "https://grantsolutions.gov",
       "Domain": "grantsolutions.gov",
-      "HTTPS Enabled?": 2,
-      "HTTPS Enforced?": 3,
+      "Enforces HTTPS": 3,
       "SSL Labs Grade": 3,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 2
     },
     {
       "Canonical": "http://www.green.gov",
       "Domain": "green.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://greengov.gov",
       "Domain": "greengov.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.gsa.gov",
       "Domain": "gsa.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "https://gsaadvantage.gov",
       "Domain": "gsaadvantage.gov",
-      "HTTPS Enabled?": 2,
-      "HTTPS Enforced?": 3,
+      "Enforces HTTPS": 3,
       "SSL Labs Grade": 2,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 2
     },
     {
       "Canonical": "http://www.gsaauctions.gov",
       "Domain": "gsaauctions.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.gsadvantage.gov",
       "Domain": "gsadvantage.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "https://www.gsaig.gov",
       "Domain": "gsaig.gov",
-      "HTTPS Enabled?": 2,
-      "HTTPS Enforced?": 2,
+      "Enforces HTTPS": 2,
       "SSL Labs Grade": 3,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 2
     },
     {
       "Canonical": "http://gsaxcess.gov",
       "Domain": "gsaxcess.gov",
-      "HTTPS Enabled?": 2,
-      "HTTPS Enforced?": 1,
+      "Enforces HTTPS": 1,
       "SSL Labs Grade": 4,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 2
     },
     {
       "Canonical": "http://www.guideline.gov",
       "Domain": "guideline.gov",
-      "HTTPS Enabled?": 2,
-      "HTTPS Enforced?": 1,
+      "Enforces HTTPS": 1,
       "SSL Labs Grade": 0,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 2
     },
     {
       "Canonical": "http://www.guidelines.gov",
       "Domain": "guidelines.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "https://www.gwa.gov",
       "Domain": "gwa.gov",
-      "HTTPS Enabled?": 1,
-      "HTTPS Enforced?": 3,
+      "Enforces HTTPS": 3,
       "SSL Labs Grade": 0,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 1
     },
     {
       "Canonical": "http://www.hanford.gov",
       "Domain": "hanford.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://harp.gov",
       "Domain": "harp.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://hc.gov",
       "Domain": "hc.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.hcqualitycommission.gov",
       "Domain": "hcqualitycommission.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://health.gov",
       "Domain": "health.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "https://www.healthcare.gov",
       "Domain": "healthcare.gov",
-      "HTTPS Enabled?": 2,
-      "HTTPS Enforced?": 3,
+      "Enforces HTTPS": 3,
       "SSL Labs Grade": 6,
-      "Strict Transport Security (HSTS)": 1
+      "Strict Transport Security (HSTS)": 1,
+      "Uses HTTPS": 2
     },
     {
       "Canonical": "http://www.healthdata.gov",
       "Domain": "healthdata.gov",
-      "HTTPS Enabled?": 2,
-      "HTTPS Enforced?": 1,
+      "Enforces HTTPS": 1,
       "SSL Labs Grade": 5,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 2
     },
     {
       "Canonical": "http://healthfinder.gov",
       "Domain": "healthfinder.gov",
-      "HTTPS Enabled?": 2,
-      "HTTPS Enforced?": 1,
+      "Enforces HTTPS": 1,
       "SSL Labs Grade": 0,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 2
     },
     {
       "Canonical": "http://www.healthindicators.gov",
       "Domain": "healthindicators.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://healthit.gov",
       "Domain": "healthit.gov",
-      "HTTPS Enabled?": 1,
-      "HTTPS Enforced?": 1,
+      "Enforces HTTPS": 1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 1
     },
     {
       "Canonical": "http://healthreform.gov",
       "Domain": "healthreform.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.healthypeople.gov",
       "Domain": "healthypeople.gov",
-      "HTTPS Enabled?": 2,
-      "HTTPS Enforced?": 1,
+      "Enforces HTTPS": 1,
       "SSL Labs Grade": 3,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 2
     },
     {
       "Canonical": "http://www.hearttruth.gov",
       "Domain": "hearttruth.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.helpingamericasyouth.gov",
       "Domain": "helpingamericasyouth.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://helpwithmybank.gov",
       "Domain": "helpwithmybank.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://helpwithmycheckingaccount.gov",
       "Domain": "helpwithmycheckingaccount.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://helpwithmycreditcard.gov",
       "Domain": "helpwithmycreditcard.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://helpwithmycreditcardbank.gov",
       "Domain": "helpwithmycreditcardbank.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://helpwithmymortgage.gov",
       "Domain": "helpwithmymortgage.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://helpwithmymortgagebank.gov",
       "Domain": "helpwithmymortgagebank.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.hhs.gov",
       "Domain": "hhs.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.hhsoig.gov",
       "Domain": "hhsoig.gov",
-      "HTTPS Enabled?": 1,
-      "HTTPS Enforced?": 1,
+      "Enforces HTTPS": 1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 1
     },
     {
       "Canonical": "http://www.highperformancebuildings.gov",
       "Domain": "highperformancebuildings.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.hill.gov",
       "Domain": "hill.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "https://www.hispanicfarmerclaims.gov",
       "Domain": "hispanicfarmerclaims.gov",
-      "HTTPS Enabled?": 1,
-      "HTTPS Enforced?": 3,
+      "Enforces HTTPS": 3,
       "SSL Labs Grade": 2,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 1
     },
     {
       "Canonical": "http://hispanicheritagemonth.gov",
       "Domain": "hispanicheritagemonth.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.hiv.gov",
       "Domain": "hiv.gov",
-      "HTTPS Enabled?": 1,
-      "HTTPS Enforced?": 1,
+      "Enforces HTTPS": 1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 1
     },
     {
       "Canonical": "http://www.homeenergyscore.gov",
       "Domain": "homeenergyscore.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.homelandsecurity.gov",
       "Domain": "homelandsecurity.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://homesales.gov",
       "Domain": "homesales.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.house.gov",
       "Domain": "house.gov",
-      "HTTPS Enabled?": 2,
-      "HTTPS Enforced?": 1,
+      "Enforces HTTPS": 1,
       "SSL Labs Grade": 0,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 2
     },
     {
       "Canonical": "http://www.housecalendar.gov",
       "Domain": "housecalendar.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.housecommunications.gov",
       "Domain": "housecommunications.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.housedemocrats.gov",
       "Domain": "housedemocrats.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.housedems.gov",
       "Domain": "housedems.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://houselive.gov",
       "Domain": "houselive.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.howto.gov",
       "Domain": "howto.gov",
-      "HTTPS Enabled?": 2,
-      "HTTPS Enforced?": 1,
+      "Enforces HTTPS": 1,
       "SSL Labs Grade": 1,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 2
     },
     {
       "Canonical": "http://hrsa.gov",
       "Domain": "hrsa.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "https://hru.gov",
       "Domain": "hru.gov",
-      "HTTPS Enabled?": 2,
-      "HTTPS Enforced?": 3,
+      "Enforces HTTPS": 3,
       "SSL Labs Grade": 3,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 2
     },
     {
       "Canonical": "http://hsa.gov",
       "Domain": "hsa.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "https://hsr.gov",
       "Domain": "hsr.gov",
-      "HTTPS Enabled?": 2,
-      "HTTPS Enforced?": 3,
+      "Enforces HTTPS": 3,
       "SSL Labs Grade": 5,
-      "Strict Transport Security (HSTS)": 3
+      "Strict Transport Security (HSTS)": 3,
+      "Uses HTTPS": 2
     },
     {
       "Canonical": "http://hud.gov",
       "Domain": "hud.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.hudoig.gov",
       "Domain": "hudoig.gov",
-      "HTTPS Enabled?": 2,
-      "HTTPS Enforced?": 1,
+      "Enforces HTTPS": 1,
       "SSL Labs Grade": 3,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 2
     },
     {
       "Canonical": "http://www.humanities.gov",
       "Domain": "humanities.gov",
-      "HTTPS Enabled?": 1,
-      "HTTPS Enforced?": 1,
+      "Enforces HTTPS": 1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 1
     },
     {
       "Canonical": "http://www.humanrights.gov",
       "Domain": "humanrights.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.hurricanes.gov",
       "Domain": "hurricanes.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://hydrogen.gov",
       "Domain": "hydrogen.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "https://www.iad.gov",
       "Domain": "iad.gov",
-      "HTTPS Enabled?": 1,
-      "HTTPS Enforced?": 3,
+      "Enforces HTTPS": 3,
       "SSL Labs Grade": 1,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 1
     },
     {
       "Canonical": "http://www.iaf.gov",
       "Domain": "iaf.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://iarpa-ideas.gov",
       "Domain": "iarpa-ideas.gov",
-      "HTTPS Enabled?": 2,
-      "HTTPS Enforced?": 1,
+      "Enforces HTTPS": 1,
       "SSL Labs Grade": 3,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 2
     },
     {
       "Canonical": "http://www.iarpa.gov",
       "Domain": "iarpa.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.iat.gov",
       "Domain": "iat.gov",
-      "HTTPS Enabled?": 2,
-      "HTTPS Enforced?": 1,
+      "Enforces HTTPS": 1,
       "SSL Labs Grade": 2,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 2
     },
     {
       "Canonical": "https://www.iawg.gov",
       "Domain": "iawg.gov",
-      "HTTPS Enabled?": 2,
-      "HTTPS Enforced?": 3,
+      "Enforces HTTPS": 3,
       "SSL Labs Grade": 3,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 2
     },
     {
       "Canonical": "http://www.ibb.gov",
       "Domain": "ibb.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://ibwc.gov",
       "Domain": "ibwc.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.ic3.gov",
       "Domain": "ic3.gov",
-      "HTTPS Enabled?": 2,
-      "HTTPS Enforced?": 1,
+      "Enforces HTTPS": 1,
       "SSL Labs Grade": 3,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 2
     },
     {
       "Canonical": "https://www.icass.gov",
       "Domain": "icass.gov",
-      "HTTPS Enabled?": 2,
-      "HTTPS Enforced?": 2,
+      "Enforces HTTPS": 2,
       "SSL Labs Grade": 3,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 2
     },
     {
       "Canonical": "http://icbemp.gov",
       "Domain": "icbemp.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.ice.gov",
       "Domain": "ice.gov",
-      "HTTPS Enabled?": 2,
-      "HTTPS Enforced?": 1,
+      "Enforces HTTPS": 1,
       "SSL Labs Grade": 3,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 2
     },
     {
       "Canonical": "http://www.ich.gov",
       "Domain": "ich.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://icjointduty.gov",
       "Domain": "icjointduty.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.identitytheft.gov",
       "Domain": "identitytheft.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://idmanagement.gov",
       "Domain": "idmanagement.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.idtheft.gov",
       "Domain": "idtheft.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.iedison.gov",
       "Domain": "iedison.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "https://www.ignet.gov",
       "Domain": "ignet.gov",
-      "HTTPS Enabled?": 1,
-      "HTTPS Enforced?": 3,
+      "Enforces HTTPS": 3,
       "SSL Labs Grade": 3,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 1
     },
     {
       "Canonical": "http://www.ihs.gov",
       "Domain": "ihs.gov",
-      "HTTPS Enabled?": 2,
-      "HTTPS Enforced?": 1,
+      "Enforces HTTPS": 1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 2
     },
     {
       "Canonical": "http://iiog.gov",
       "Domain": "iiog.gov",
-      "HTTPS Enabled?": 1,
-      "HTTPS Enforced?": 1,
+      "Enforces HTTPS": 1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 1
     },
     {
       "Canonical": "http://www.imls.gov",
       "Domain": "imls.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://indianaffairs.gov",
       "Domain": "indianaffairs.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.inel.gov",
       "Domain": "inel.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.info.gov",
       "Domain": "info.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "https://inl.gov",
       "Domain": "inl.gov",
-      "HTTPS Enabled?": 2,
-      "HTTPS Enforced?": 3,
+      "Enforces HTTPS": 3,
       "SSL Labs Grade": 5,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 2
     },
     {
       "Canonical": "http://insurekidsnow.gov",
       "Domain": "insurekidsnow.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "https://www.integrity.gov",
       "Domain": "integrity.gov",
-      "HTTPS Enabled?": 2,
-      "HTTPS Enforced?": 3,
+      "Enforces HTTPS": 3,
       "SSL Labs Grade": 4,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 2
     },
     {
       "Canonical": "http://www.intelink.gov",
       "Domain": "intelink.gov",
-      "HTTPS Enabled?": 2,
-      "HTTPS Enforced?": 1,
+      "Enforces HTTPS": 1,
       "SSL Labs Grade": 0,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 2
     },
     {
       "Canonical": "http://intelligence.gov",
       "Domain": "intelligence.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.interior.gov",
       "Domain": "interior.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.interpol.gov",
       "Domain": "interpol.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://invasivespecies.gov",
       "Domain": "invasivespecies.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.invasivespeciesinfo.gov",
       "Domain": "invasivespeciesinfo.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://investor.gov",
       "Domain": "investor.gov",
-      "HTTPS Enabled?": 2,
-      "HTTPS Enforced?": 0,
+      "Enforces HTTPS": 0,
       "SSL Labs Grade": 5,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 2
     },
     {
       "Canonical": "https://www.ioss.gov",
       "Domain": "ioss.gov",
-      "HTTPS Enabled?": 1,
-      "HTTPS Enforced?": 3,
+      "Enforces HTTPS": 3,
       "SSL Labs Grade": 1,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 1
     },
     {
       "Canonical": "https://www.ipac.gov",
       "Domain": "ipac.gov",
-      "HTTPS Enabled?": 1,
-      "HTTPS Enforced?": 3,
+      "Enforces HTTPS": 3,
       "SSL Labs Grade": 0,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 1
     },
     {
       "Canonical": "http://ipcc-wg2.gov",
       "Domain": "ipcc-wg2.gov",
-      "HTTPS Enabled?": 2,
-      "HTTPS Enforced?": 1,
+      "Enforces HTTPS": 1,
       "SSL Labs Grade": 2,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 2
     },
     {
       "Canonical": "http://www.ipm.gov",
       "Domain": "ipm.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.ipp.gov",
       "Domain": "ipp.gov",
-      "HTTPS Enabled?": 2,
-      "HTTPS Enforced?": 1,
+      "Enforces HTTPS": 1,
       "SSL Labs Grade": 3,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 2
     },
     {
       "Canonical": "http://www.iprcenter.gov",
       "Domain": "iprcenter.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.irs.gov",
       "Domain": "irs.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.irsauctions.gov",
       "Domain": "irsauctions.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.irssales.gov",
       "Domain": "irssales.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.irsvideos.gov",
       "Domain": "irsvideos.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://ise.gov",
       "Domain": "ise.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.isitdoneyet.gov",
       "Domain": "isitdoneyet.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "https://isotope.gov",
       "Domain": "isotope.gov",
-      "HTTPS Enabled?": 2,
-      "HTTPS Enforced?": 3,
+      "Enforces HTTPS": 3,
       "SSL Labs Grade": 3,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 2
     },
     {
       "Canonical": "https://isotopes.gov",
       "Domain": "isotopes.gov",
-      "HTTPS Enabled?": 2,
-      "HTTPS Enforced?": 3,
+      "Enforces HTTPS": 3,
       "SSL Labs Grade": 3,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 2
     },
     {
       "Canonical": "http://www.italladdsup.gov",
       "Domain": "italladdsup.gov",
-      "HTTPS Enabled?": 1,
-      "HTTPS Enforced?": 1,
+      "Enforces HTTPS": 1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 1
     },
     {
       "Canonical": "http://www.itap.gov",
       "Domain": "itap.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "https://itdashboard.gov",
       "Domain": "itdashboard.gov",
-      "HTTPS Enabled?": 2,
-      "HTTPS Enforced?": 3,
+      "Enforces HTTPS": 3,
       "SSL Labs Grade": 0,
-      "Strict Transport Security (HSTS)": 3
+      "Strict Transport Security (HSTS)": 3,
+      "Uses HTTPS": 2
     },
     {
       "Canonical": "http://itds.gov",
       "Domain": "itds.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.itis.gov",
       "Domain": "itis.gov",
-      "HTTPS Enabled?": 2,
-      "HTTPS Enforced?": 0,
+      "Enforces HTTPS": 0,
       "SSL Labs Grade": 3,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 2
     },
     {
       "Canonical": "http://www.itrd.gov",
       "Domain": "itrd.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "https://www.its.gov",
       "Domain": "its.gov",
-      "HTTPS Enabled?": 1,
-      "HTTPS Enforced?": 3,
+      "Enforces HTTPS": 3,
       "SSL Labs Grade": 0,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 1
     },
     {
       "Canonical": "http://www.jamesmadison.gov",
       "Domain": "jamesmadison.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.jccs.gov",
       "Domain": "jccs.gov",
-      "HTTPS Enabled?": 1,
-      "HTTPS Enforced?": 1,
+      "Enforces HTTPS": 1,
       "SSL Labs Grade": 1,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 1
     },
     {
       "Canonical": "https://www.jct.gov",
       "Domain": "jct.gov",
-      "HTTPS Enabled?": 2,
-      "HTTPS Enforced?": 2,
+      "Enforces HTTPS": 2,
       "SSL Labs Grade": 0,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 2
     },
     {
       "Canonical": "http://jem.gov",
       "Domain": "jem.gov",
-      "HTTPS Enabled?": 2,
-      "HTTPS Enforced?": 1,
+      "Enforces HTTPS": 1,
       "SSL Labs Grade": 3,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 2
     },
     {
       "Canonical": "http://jewishheritage.gov",
       "Domain": "jewishheritage.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://jewishheritagemonth.gov",
       "Domain": "jewishheritagemonth.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.jimmycarterlibrary.gov",
       "Domain": "jimmycarterlibrary.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.jmc.gov",
       "Domain": "jmc.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.jobcenter.gov",
       "Domain": "jobcenter.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.jobcorps.gov",
       "Domain": "jobcorps.gov",
-      "HTTPS Enabled?": 2,
-      "HTTPS Enforced?": 1,
+      "Enforces HTTPS": 1,
       "SSL Labs Grade": 3,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 2
     },
     {
       "Canonical": "http://www.joiningforces.gov",
       "Domain": "joiningforces.gov",
-      "HTTPS Enabled?": 2,
-      "HTTPS Enforced?": 1,
+      "Enforces HTTPS": 1,
       "SSL Labs Grade": 5,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 2
     },
     {
       "Canonical": "http://www.judicialconference.gov",
       "Domain": "judicialconference.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.justice.gov",
       "Domain": "justice.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://justthinktwice.gov",
       "Domain": "justthinktwice.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://juvenilecouncil.gov",
       "Domain": "juvenilecouncil.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://jwod.gov",
       "Domain": "jwod.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.kids.gov",
       "Domain": "kids.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://klamathrestoration.gov",
       "Domain": "klamathrestoration.gov",
-      "HTTPS Enabled?": 1,
-      "HTTPS Enforced?": 1,
+      "Enforces HTTPS": 1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 1
     },
     {
       "Canonical": "http://www.labor.gov",
       "Domain": "labor.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.lacoast.gov",
       "Domain": "lacoast.gov",
-      "HTTPS Enabled?": 2,
-      "HTTPS Enforced?": 1,
+      "Enforces HTTPS": 1,
       "SSL Labs Grade": 3,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 2
     },
     {
       "Canonical": "http://landfire.gov",
       "Domain": "landfire.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.landimaging.gov",
       "Domain": "landimaging.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://lanl.gov",
       "Domain": "lanl.gov",
-      "HTTPS Enabled?": 2,
-      "HTTPS Enforced?": 1,
+      "Enforces HTTPS": 1,
       "SSL Labs Grade": 4,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 2
     },
     {
       "Canonical": "https://www.latinofarmerclaims.gov",
       "Domain": "latinofarmerclaims.gov",
-      "HTTPS Enabled?": 1,
-      "HTTPS Enforced?": 3,
+      "Enforces HTTPS": 3,
       "SSL Labs Grade": 2,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 1
     },
     {
       "Canonical": "http://www.law.gov",
       "Domain": "law.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.lbl.gov",
       "Domain": "lbl.gov",
-      "HTTPS Enabled?": 2,
-      "HTTPS Enforced?": 1,
+      "Enforces HTTPS": 1,
       "SSL Labs Grade": 3,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 2
     },
     {
       "Canonical": "http://lca.gov",
       "Domain": "lca.gov",
-      "HTTPS Enabled?": 2,
-      "HTTPS Enforced?": 0,
+      "Enforces HTTPS": 0,
       "SSL Labs Grade": 3,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 2
     },
     {
       "Canonical": "http://www.lcacommons.gov",
       "Domain": "lcacommons.gov",
-      "HTTPS Enabled?": 2,
-      "HTTPS Enforced?": 0,
+      "Enforces HTTPS": 0,
       "SSL Labs Grade": 2,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 2
     },
     {
       "Canonical": "http://www.lcrmscp.gov",
       "Domain": "lcrmscp.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.learnandserve.gov",
       "Domain": "learnandserve.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "https://www.learnperformance.gov",
       "Domain": "learnperformance.gov",
-      "HTTPS Enabled?": 2,
-      "HTTPS Enforced?": 2,
+      "Enforces HTTPS": 2,
       "SSL Labs Grade": 3,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 2
     },
     {
       "Canonical": "http://www.legislative.gov",
       "Domain": "legislative.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.legislativebranch.gov",
       "Domain": "legislativebranch.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.lep.gov",
       "Domain": "lep.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.letsmove.gov",
       "Domain": "letsmove.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.library-of-congress.gov",
       "Domain": "library-of-congress.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.libraryofcongress.gov",
       "Domain": "libraryofcongress.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.lifeline.gov",
       "Domain": "lifeline.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.lis.gov",
       "Domain": "lis.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.listo.gov",
       "Domain": "listo.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.literacy.gov",
       "Domain": "literacy.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.llis.gov",
       "Domain": "llis.gov",
-      "HTTPS Enabled?": 2,
-      "HTTPS Enforced?": 1,
+      "Enforces HTTPS": 1,
       "SSL Labs Grade": 4,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 2
     },
     {
       "Canonical": "https://www.llnl.gov",
       "Domain": "llnl.gov",
-      "HTTPS Enabled?": 2,
-      "HTTPS Enforced?": 3,
+      "Enforces HTTPS": 3,
       "SSL Labs Grade": 0,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 2
     },
     {
       "Canonical": "http://lmrcouncil.gov",
       "Domain": "lmrcouncil.gov",
-      "HTTPS Enabled?": 2,
-      "HTTPS Enforced?": 1,
+      "Enforces HTTPS": 1,
       "SSL Labs Grade": 3,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 2
     },
     {
       "Canonical": "http://lmvsci.gov",
       "Domain": "lmvsci.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://loc.gov",
       "Domain": "loc.gov",
-      "HTTPS Enabled?": 2,
-      "HTTPS Enforced?": 1,
+      "Enforces HTTPS": 1,
       "SSL Labs Grade": 3,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 2
     },
     {
       "Canonical": "http://locatorplus.gov",
       "Domain": "locatorplus.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.locimages.gov",
       "Domain": "locimages.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.locstore.gov",
       "Domain": "locstore.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.loctps.gov",
       "Domain": "loctps.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://longtermcare.gov",
       "Domain": "longtermcare.gov",
-      "HTTPS Enabled?": 1,
-      "HTTPS Enforced?": 1,
+      "Enforces HTTPS": 1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 1
     },
     {
       "Canonical": "http://www.lookstoogoodtobetrue.gov",
       "Domain": "lookstoogoodtobetrue.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.lowermississippivalleyscience.gov",
       "Domain": "lowermississippivalleyscience.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.lps.gov",
       "Domain": "lps.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.lsc.gov",
       "Domain": "lsc.gov",
-      "HTTPS Enabled?": 1,
-      "HTTPS Enforced?": 1,
+      "Enforces HTTPS": 1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 1
     },
     {
       "Canonical": "https://www.macpac.gov",
       "Domain": "macpac.gov",
-      "HTTPS Enabled?": 2,
-      "HTTPS Enforced?": 3,
+      "Enforces HTTPS": 3,
       "SSL Labs Grade": 4,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 2
     },
     {
       "Canonical": "http://www.mail.gov",
       "Domain": "mail.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.majorityleader.gov",
       "Domain": "majorityleader.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.majoritywhip.gov",
       "Domain": "majoritywhip.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.makinghomeaffordable.gov",
       "Domain": "makinghomeaffordable.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://malwareinvestigator.gov",
       "Domain": "malwareinvestigator.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://manufacturing.gov",
       "Domain": "manufacturing.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.mapaplanet.gov",
       "Domain": "mapaplanet.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.mapstats.gov",
       "Domain": "mapstats.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://marine.gov",
       "Domain": "marine.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://marinecadastre.gov",
       "Domain": "marinecadastre.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.marview.gov",
       "Domain": "marview.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "https://www.max.gov",
       "Domain": "max.gov",
-      "HTTPS Enabled?": 2,
-      "HTTPS Enforced?": 3,
+      "Enforces HTTPS": 3,
       "SSL Labs Grade": 0,
-      "Strict Transport Security (HSTS)": 3
+      "Strict Transport Security (HSTS)": 3,
+      "Uses HTTPS": 2
     },
     {
       "Canonical": "http://www.mbda.gov",
       "Domain": "mbda.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "https://mcc.gov",
       "Domain": "mcc.gov",
-      "HTTPS Enabled?": 1,
-      "HTTPS Enforced?": 3,
+      "Enforces HTTPS": 3,
       "SSL Labs Grade": 3,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 1
     },
     {
       "Canonical": "http://www.mcrmc.gov",
       "Domain": "mcrmc.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://mda.gov",
       "Domain": "mda.gov",
-      "HTTPS Enabled?": 1,
-      "HTTPS Enforced?": 1,
+      "Enforces HTTPS": 1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 1
     },
     {
       "Canonical": "https://www.medalofvalor.gov",
       "Domain": "medalofvalor.gov",
-      "HTTPS Enabled?": 2,
-      "HTTPS Enforced?": 3,
+      "Enforces HTTPS": 3,
       "SSL Labs Grade": 2,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 2
     },
     {
       "Canonical": "http://medicaid.gov",
       "Domain": "medicaid.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.medicalcountermeasures.gov",
       "Domain": "medicalcountermeasures.gov",
-      "HTTPS Enabled?": 1,
-      "HTTPS Enforced?": 1,
+      "Enforces HTTPS": 1,
       "SSL Labs Grade": 2,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 1
     },
     {
       "Canonical": "https://www.medicalreservecorps.gov",
       "Domain": "medicalreservecorps.gov",
-      "HTTPS Enabled?": 2,
-      "HTTPS Enforced?": 3,
+      "Enforces HTTPS": 3,
       "SSL Labs Grade": 5,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 2
     },
     {
       "Canonical": "http://medicare.gov",
       "Domain": "medicare.gov",
-      "HTTPS Enabled?": 2,
-      "HTTPS Enforced?": 1,
+      "Enforces HTTPS": 1,
       "SSL Labs Grade": 4,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 2
     },
     {
       "Canonical": "http://www.medline.gov",
       "Domain": "medline.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.medlineplus.gov",
       "Domain": "medlineplus.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://medpac.gov",
       "Domain": "medpac.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.mentalhealth.gov",
       "Domain": "mentalhealth.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.mesh.gov",
       "Domain": "mesh.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.mha.gov",
       "Domain": "mha.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "https://www.mimedicare.gov",
       "Domain": "mimedicare.gov",
-      "HTTPS Enabled?": 2,
-      "HTTPS Enforced?": 3,
+      "Enforces HTTPS": 3,
       "SSL Labs Grade": 4,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 2
     },
     {
       "Canonical": "http://www.mitigationcommission.gov",
       "Domain": "mitigationcommission.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.mlkday.gov",
       "Domain": "mlkday.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://mmc.gov",
       "Domain": "mmc.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://mms.gov",
       "Domain": "mms.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://moneyfactory.gov",
       "Domain": "moneyfactory.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.moneyfactorystore.gov",
       "Domain": "moneyfactorystore.gov",
-      "HTTPS Enabled?": 2,
-      "HTTPS Enforced?": 0,
+      "Enforces HTTPS": 0,
       "SSL Labs Grade": 3,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 2
     },
     {
       "Canonical": "http://www.mrgo.gov",
       "Domain": "mrgo.gov",
-      "HTTPS Enabled?": 2,
-      "HTTPS Enforced?": 1,
+      "Enforces HTTPS": 1,
       "SSL Labs Grade": 3,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 2
     },
     {
       "Canonical": "http://www.mrlc.gov",
       "Domain": "mrlc.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://msb.gov",
       "Domain": "msb.gov",
-      "HTTPS Enabled?": 1,
-      "HTTPS Enforced?": 1,
+      "Enforces HTTPS": 1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 1
     },
     {
       "Canonical": "http://www.msha.gov",
       "Domain": "msha.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://mspb.gov",
       "Domain": "mspb.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://mtbs.gov",
       "Domain": "mtbs.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.mycreditunion.gov",
       "Domain": "mycreditunion.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.myfdic.gov",
       "Domain": "myfdic.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://myfdicinsurance.gov",
       "Domain": "myfdicinsurance.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.myloc.gov",
       "Domain": "myloc.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "https://mymedicare.gov",
       "Domain": "mymedicare.gov",
-      "HTTPS Enabled?": 2,
-      "HTTPS Enforced?": 3,
+      "Enforces HTTPS": 3,
       "SSL Labs Grade": 4,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 2
     },
     {
       "Canonical": "http://www.mymoney.gov",
       "Domain": "mymoney.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.mynextmove.gov",
       "Domain": "mynextmove.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.myra.gov",
       "Domain": "myra.gov",
-      "HTTPS Enabled?": 1,
-      "HTTPS Enforced?": 1,
+      "Enforces HTTPS": 1,
       "SSL Labs Grade": 3,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 1
     },
     {
       "Canonical": "http://myusa.gov",
       "Domain": "myusa.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://nafri.gov",
       "Domain": "nafri.gov",
-      "HTTPS Enabled?": 1,
-      "HTTPS Enforced?": 1,
+      "Enforces HTTPS": 1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 1
     },
     {
       "Canonical": "http://nagb.gov",
       "Domain": "nagb.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://namus.gov",
       "Domain": "namus.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://nano.gov",
       "Domain": "nano.gov",
-      "HTTPS Enabled?": 1,
-      "HTTPS Enforced?": 0,
+      "Enforces HTTPS": 0,
       "SSL Labs Grade": 2,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 1
     },
     {
       "Canonical": "http://www.nara.gov",
       "Domain": "nara.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.nasa.gov",
       "Domain": "nasa.gov",
-      "HTTPS Enabled?": 2,
-      "HTTPS Enforced?": 1,
+      "Enforces HTTPS": 1,
       "SSL Labs Grade": 5,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 2
     },
     {
       "Canonical": "http://www.nationalatlas.gov",
       "Domain": "nationalatlas.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.nationalbank.gov",
       "Domain": "nationalbank.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://nationalbankhelp.gov",
       "Domain": "nationalbankhelp.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.nationalbanknet.gov",
       "Domain": "nationalbanknet.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.nationalchildrensstudy.gov",
       "Domain": "nationalchildrensstudy.gov",
-      "HTTPS Enabled?": 2,
-      "HTTPS Enforced?": 1,
+      "Enforces HTTPS": 1,
       "SSL Labs Grade": 3,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 2
     },
     {
       "Canonical": "http://www.nationalgangcenter.gov",
       "Domain": "nationalgangcenter.gov",
-      "HTTPS Enabled?": 1,
-      "HTTPS Enforced?": 1,
+      "Enforces HTTPS": 1,
       "SSL Labs Grade": 3,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 1
     },
     {
       "Canonical": "http://nationalhousing.gov",
       "Domain": "nationalhousing.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://nationalhousinglocator.gov",
       "Domain": "nationalhousinglocator.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://nationalmap.gov",
       "Domain": "nationalmap.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.nationalresourcedirectory.gov",
       "Domain": "nationalresourcedirectory.gov",
-      "HTTPS Enabled?": 2,
-      "HTTPS Enforced?": 1,
+      "Enforces HTTPS": 1,
       "SSL Labs Grade": 3,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 2
     },
     {
       "Canonical": "http://www.nationalservice.gov",
       "Domain": "nationalservice.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "https://www.nationalserviceresources.gov",
       "Domain": "nationalserviceresources.gov",
-      "HTTPS Enabled?": 2,
-      "HTTPS Enforced?": 3,
+      "Enforces HTTPS": 3,
       "SSL Labs Grade": 4,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 2
     },
     {
       "Canonical": "http://www.nationsreportcard.gov",
       "Domain": "nationsreportcard.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://nativeamericanheritagemonth.gov",
       "Domain": "nativeamericanheritagemonth.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.navycash.gov",
       "Domain": "navycash.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.nbc.gov",
       "Domain": "nbc.gov",
-      "HTTPS Enabled?": 2,
-      "HTTPS Enforced?": 1,
+      "Enforces HTTPS": 1,
       "SSL Labs Grade": 3,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 2
     },
     {
       "Canonical": "http://www.nbm.gov",
       "Domain": "nbm.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://nccrc.gov",
       "Domain": "nccrc.gov",
-      "HTTPS Enabled?": 1,
-      "HTTPS Enforced?": 1,
+      "Enforces HTTPS": 1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 1
     },
     {
       "Canonical": "http://www.nccs.gov",
       "Domain": "nccs.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.ncd.gov",
       "Domain": "ncd.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.ncifcrf.gov",
       "Domain": "ncifcrf.gov",
-      "HTTPS Enabled?": 2,
-      "HTTPS Enforced?": 1,
+      "Enforces HTTPS": 1,
       "SSL Labs Grade": 2,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 2
     },
     {
       "Canonical": "https://ncirc.gov",
       "Domain": "ncirc.gov",
-      "HTTPS Enabled?": 2,
-      "HTTPS Enforced?": 3,
+      "Enforces HTTPS": 3,
       "SSL Labs Grade": 3,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 2
     },
     {
       "Canonical": "http://ncix.gov",
       "Domain": "ncix.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "https://ncjrs.gov",
       "Domain": "ncjrs.gov",
-      "HTTPS Enabled?": 2,
-      "HTTPS Enforced?": 3,
+      "Enforces HTTPS": 3,
       "SSL Labs Grade": 2,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 2
     },
     {
       "Canonical": "http://www.ncpc.gov",
       "Domain": "ncpc.gov",
-      "HTTPS Enabled?": 2,
-      "HTTPS Enforced?": 1,
+      "Enforces HTTPS": 1,
       "SSL Labs Grade": 5,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 2
     },
     {
       "Canonical": "http://www.ncpw.gov",
       "Domain": "ncpw.gov",
-      "HTTPS Enabled?": 2,
-      "HTTPS Enforced?": 1,
+      "Enforces HTTPS": 1,
       "SSL Labs Grade": 3,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 2
     },
     {
       "Canonical": "http://www.ncrc.gov",
       "Domain": "ncrc.gov",
-      "HTTPS Enabled?": 2,
-      "HTTPS Enforced?": 1,
+      "Enforces HTTPS": 1,
       "SSL Labs Grade": 3,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 2
     },
     {
       "Canonical": "http://www.nctc.gov",
       "Domain": "nctc.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.ncua.gov",
       "Domain": "ncua.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.ndep.gov",
       "Domain": "ndep.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.ndop.gov",
       "Domain": "ndop.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.ndsa.gov",
       "Domain": "ndsa.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.nea.gov",
       "Domain": "nea.gov",
-      "HTTPS Enabled?": 1,
-      "HTTPS Enforced?": 1,
+      "Enforces HTTPS": 1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 1
     },
     {
       "Canonical": "http://neglecteddiseases.gov",
       "Domain": "neglecteddiseases.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.neh.gov",
       "Domain": "neh.gov",
-      "HTTPS Enabled?": 1,
-      "HTTPS Enforced?": 1,
+      "Enforces HTTPS": 1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 1
     },
     {
       "Canonical": "http://nehrp.gov",
       "Domain": "nehrp.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.nel.gov",
       "Domain": "nel.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.nemi.gov",
       "Domain": "nemi.gov",
-      "HTTPS Enabled?": 2,
-      "HTTPS Enforced?": 1,
+      "Enforces HTTPS": 1,
       "SSL Labs Grade": 3,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 2
     },
     {
       "Canonical": "http://www.nepa.gov",
       "Domain": "nepa.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.nersc.gov",
       "Domain": "nersc.gov",
-      "HTTPS Enabled?": 2,
-      "HTTPS Enforced?": 1,
+      "Enforces HTTPS": 1,
       "SSL Labs Grade": 3,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 2
     },
     {
       "Canonical": "http://www.neup.gov",
       "Domain": "neup.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.newmoney.gov",
       "Domain": "newmoney.gov",
-      "HTTPS Enabled?": 2,
-      "HTTPS Enforced?": 0,
+      "Enforces HTTPS": 0,
       "SSL Labs Grade": 3,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 2
     },
     {
       "Canonical": "https://nfpors.gov",
       "Domain": "nfpors.gov",
-      "HTTPS Enabled?": 2,
-      "HTTPS Enforced?": 2,
+      "Enforces HTTPS": 2,
       "SSL Labs Grade": 3,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 2
     },
     {
       "Canonical": "http://www.nga.gov",
       "Domain": "nga.gov",
-      "HTTPS Enabled?": 2,
-      "HTTPS Enforced?": 1,
+      "Enforces HTTPS": 1,
       "SSL Labs Grade": 3,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 2
     },
     {
       "Canonical": "http://www.ngc.gov",
       "Domain": "ngc.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://nhl.gov",
       "Domain": "nhl.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.nhtsa.gov",
       "Domain": "nhtsa.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.nibin.gov",
       "Domain": "nibin.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.nic.gov",
       "Domain": "nic.gov",
-      "HTTPS Enabled?": 2,
-      "HTTPS Enforced?": 1,
+      "Enforces HTTPS": 1,
       "SSL Labs Grade": 3,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 2
     },
     {
       "Canonical": "http://nicic.gov",
       "Domain": "nicic.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "https://www.niem.gov",
       "Domain": "niem.gov",
-      "HTTPS Enabled?": 2,
-      "HTTPS Enforced?": 3,
+      "Enforces HTTPS": 3,
       "SSL Labs Grade": 0,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 2
     },
     {
       "Canonical": "http://www.nifc.gov",
       "Domain": "nifc.gov",
-      "HTTPS Enabled?": 1,
-      "HTTPS Enforced?": 1,
+      "Enforces HTTPS": 1,
       "SSL Labs Grade": 3,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 1
     },
     {
       "Canonical": "http://niftt.gov",
       "Domain": "niftt.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://nigc.gov",
       "Domain": "nigc.gov",
-      "HTTPS Enabled?": 1,
-      "HTTPS Enforced?": 1,
+      "Enforces HTTPS": 1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 1
     },
     {
       "Canonical": "http://nih.gov",
       "Domain": "nih.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://nihseniorhealth.gov",
       "Domain": "nihseniorhealth.gov",
-      "HTTPS Enabled?": 2,
-      "HTTPS Enforced?": 1,
+      "Enforces HTTPS": 1,
       "SSL Labs Grade": 3,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 2
     },
     {
       "Canonical": "http://www.nij.gov",
       "Domain": "nij.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.niosh.gov",
       "Domain": "niosh.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://nist.gov",
       "Domain": "nist.gov",
-      "HTTPS Enabled?": 2,
-      "HTTPS Enforced?": 1,
+      "Enforces HTTPS": 1,
       "SSL Labs Grade": 3,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 2
     },
     {
       "Canonical": "https://www.nitrd.gov",
       "Domain": "nitrd.gov",
-      "HTTPS Enabled?": 2,
-      "HTTPS Enforced?": 3,
+      "Enforces HTTPS": 3,
       "SSL Labs Grade": 4,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 2
     },
     {
       "Canonical": "http://nixonlibrary.gov",
       "Domain": "nixonlibrary.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.nlm.gov",
       "Domain": "nlm.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://nlrb.gov",
       "Domain": "nlrb.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://nls.gov",
       "Domain": "nls.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.nmb.gov",
       "Domain": "nmb.gov",
-      "HTTPS Enabled?": 1,
-      "HTTPS Enforced?": 0,
+      "Enforces HTTPS": 0,
       "SSL Labs Grade": 1,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 1
     },
     {
       "Canonical": "http://nmcourt.fed.us",
       "Domain": "nmcourt.fed.us",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.nmic.gov",
       "Domain": "nmic.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.nmvtis.gov",
       "Domain": "nmvtis.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://nnlm.gov",
       "Domain": "nnlm.gov",
-      "HTTPS Enabled?": 1,
-      "HTTPS Enforced?": 1,
+      "Enforces HTTPS": 1,
       "SSL Labs Grade": 2,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 1
     },
     {
       "Canonical": "http://www.noaa.gov",
       "Domain": "noaa.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.noaawatch.gov",
       "Domain": "noaawatch.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.nolaenvironmental.gov",
       "Domain": "nolaenvironmental.gov",
-      "HTTPS Enabled?": 2,
-      "HTTPS Enforced?": 1,
+      "Enforces HTTPS": 1,
       "SSL Labs Grade": 3,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 2
     },
     {
       "Canonical": "http://www.nonprofit.gov",
       "Domain": "nonprofit.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "https://www.notalone.gov",
       "Domain": "notalone.gov",
-      "HTTPS Enabled?": 2,
-      "HTTPS Enforced?": 3,
+      "Enforces HTTPS": 3,
       "SSL Labs Grade": 3,
-      "Strict Transport Security (HSTS)": 3
+      "Strict Transport Security (HSTS)": 3,
+      "Uses HTTPS": 2
     },
     {
       "Canonical": "http://www.nps.gov",
       "Domain": "nps.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.nrc.gov",
       "Domain": "nrc.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "https://www.nrd.gov",
       "Domain": "nrd.gov",
-      "HTTPS Enabled?": 2,
-      "HTTPS Enforced?": 3,
+      "Enforces HTTPS": 3,
       "SSL Labs Grade": 3,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 2
     },
     {
       "Canonical": "http://www.nrel.gov",
       "Domain": "nrel.gov",
-      "HTTPS Enabled?": 2,
-      "HTTPS Enforced?": 0,
+      "Enforces HTTPS": 0,
       "SSL Labs Grade": 3,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 2
     },
     {
       "Canonical": "http://nro.gov",
       "Domain": "nro.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://nrojr.gov",
       "Domain": "nrojr.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "https://www.nsa.gov",
       "Domain": "nsa.gov",
-      "HTTPS Enabled?": 2,
-      "HTTPS Enforced?": 3,
+      "Enforces HTTPS": 3,
       "SSL Labs Grade": 5,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 2
     },
     {
       "Canonical": "http://nsep.gov",
       "Domain": "nsep.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.nsf.gov",
       "Domain": "nsf.gov",
-      "HTTPS Enabled?": 2,
-      "HTTPS Enforced?": 0,
+      "Enforces HTTPS": 0,
       "SSL Labs Grade": 0,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 2
     },
     {
       "Canonical": "http://www.nsopw.gov",
       "Domain": "nsopw.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.nstic.gov",
       "Domain": "nstic.gov",
-      "HTTPS Enabled?": 1,
-      "HTTPS Enforced?": 1,
+      "Enforces HTTPS": 1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 1
     },
     {
       "Canonical": "http://nswp.gov",
       "Domain": "nswp.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.ntdprogram.gov",
       "Domain": "ntdprogram.gov",
-      "HTTPS Enabled?": 2,
-      "HTTPS Enforced?": 1,
+      "Enforces HTTPS": 1,
       "SSL Labs Grade": 4,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 2
     },
     {
       "Canonical": "http://www.ntis.gov",
       "Domain": "ntis.gov",
-      "HTTPS Enabled?": 2,
-      "HTTPS Enforced?": 1,
+      "Enforces HTTPS": 1,
       "SSL Labs Grade": 0,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 2
     },
     {
       "Canonical": "http://www.ntrc.gov",
       "Domain": "ntrc.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.ntsb.gov",
       "Domain": "ntsb.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.nutrition.gov",
       "Domain": "nutrition.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.nutritionevidencelibrary.gov",
       "Domain": "nutritionevidencelibrary.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.nvtc.gov",
       "Domain": "nvtc.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "https://www.nwbc.gov",
       "Domain": "nwbc.gov",
-      "HTTPS Enabled?": 2,
-      "HTTPS Enforced?": 3,
+      "Enforces HTTPS": 3,
       "SSL Labs Grade": 3,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 2
     },
     {
       "Canonical": "http://www.nwcg.gov",
       "Domain": "nwcg.gov",
-      "HTTPS Enabled?": 1,
-      "HTTPS Enforced?": 1,
+      "Enforces HTTPS": 1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 1
     },
     {
       "Canonical": "http://occ.gov",
       "Domain": "occ.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://occhelps.gov",
       "Domain": "occhelps.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.odni.gov",
       "Domain": "odni.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.oea.gov",
       "Domain": "oea.gov",
-      "HTTPS Enabled?": 1,
-      "HTTPS Enforced?": 1,
+      "Enforces HTTPS": 1,
       "SSL Labs Grade": 0,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 1
     },
     {
       "Canonical": "http://www.ofcm.gov",
       "Domain": "ofcm.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "https://www.ofda.gov",
       "Domain": "ofda.gov",
-      "HTTPS Enabled?": 2,
-      "HTTPS Enforced?": 2,
+      "Enforces HTTPS": 2,
       "SSL Labs Grade": 0,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 2
     },
     {
       "Canonical": "http://ofee.gov",
       "Domain": "ofee.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.ofr.gov",
       "Domain": "ofr.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://oge.gov",
       "Domain": "oge.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.ogis.gov",
       "Domain": "ogis.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://ojjdp.gov",
       "Domain": "ojjdp.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://ojp.gov",
       "Domain": "ojp.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.omb.gov",
       "Domain": "omb.gov",
-      "HTTPS Enabled?": 2,
-      "HTTPS Enforced?": 1,
+      "Enforces HTTPS": 1,
       "SSL Labs Grade": 5,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 2
     },
     {
       "Canonical": "http://www.omblog.gov",
       "Domain": "omblog.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.ondcp.gov",
       "Domain": "ondcp.gov",
-      "HTTPS Enabled?": 2,
-      "HTTPS Enforced?": 1,
+      "Enforces HTTPS": 1,
       "SSL Labs Grade": 5,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 2
     },
     {
       "Canonical": "http://www.onguardonline.gov",
       "Domain": "onguardonline.gov",
-      "HTTPS Enabled?": 2,
-      "HTTPS Enforced?": 1,
+      "Enforces HTTPS": 1,
       "SSL Labs Grade": 3,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 2
     },
     {
       "Canonical": "http://onhir.gov",
       "Domain": "onhir.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.onlineonguard.gov",
       "Domain": "onlineonguard.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://onlinewbc.gov",
       "Domain": "onlinewbc.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://onrr.gov",
       "Domain": "onrr.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.openinternet.gov",
       "Domain": "openinternet.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "https://www.opensource.gov",
       "Domain": "opensource.gov",
-      "HTTPS Enabled?": 2,
-      "HTTPS Enforced?": 3,
+      "Enforces HTTPS": 3,
       "SSL Labs Grade": 0,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 2
     },
     {
       "Canonical": "http://openworld.gov",
       "Domain": "openworld.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "https://www.opic.gov",
       "Domain": "opic.gov",
-      "HTTPS Enabled?": 2,
-      "HTTPS Enforced?": 3,
+      "Enforces HTTPS": 3,
       "SSL Labs Grade": 4,
-      "Strict Transport Security (HSTS)": 1
+      "Strict Transport Security (HSTS)": 1,
+      "Uses HTTPS": 2
     },
     {
       "Canonical": "http://www.opm.gov",
       "Domain": "opm.gov",
-      "HTTPS Enabled?": 2,
-      "HTTPS Enforced?": 1,
+      "Enforces HTTPS": 1,
       "SSL Labs Grade": 3,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 2
     },
     {
       "Canonical": "http://www.opportunity.gov",
       "Domain": "opportunity.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.orau.gov",
       "Domain": "orau.gov",
-      "HTTPS Enabled?": 2,
-      "HTTPS Enforced?": 0,
+      "Enforces HTTPS": 0,
       "SSL Labs Grade": 3,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 2
     },
     {
       "Canonical": "http://www.organdonor.gov",
       "Domain": "organdonor.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.ornl.gov",
       "Domain": "ornl.gov",
-      "HTTPS Enabled?": 2,
-      "HTTPS Enforced?": 1,
+      "Enforces HTTPS": 1,
       "SSL Labs Grade": 4,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 2
     },
     {
       "Canonical": "https://www.osac.gov",
       "Domain": "osac.gov",
-      "HTTPS Enabled?": 2,
-      "HTTPS Enforced?": 3,
+      "Enforces HTTPS": 3,
       "SSL Labs Grade": 3,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 2
     },
     {
       "Canonical": "https://osc.gov",
       "Domain": "osc.gov",
-      "HTTPS Enabled?": 2,
-      "HTTPS Enforced?": 3,
+      "Enforces HTTPS": 3,
       "SSL Labs Grade": 5,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 2
     },
     {
       "Canonical": "http://osdbu.gov",
       "Domain": "osdbu.gov",
-      "HTTPS Enabled?": 1,
-      "HTTPS Enforced?": 1,
+      "Enforces HTTPS": 1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 1
     },
     {
       "Canonical": "https://www.osha.gov",
       "Domain": "osha.gov",
-      "HTTPS Enabled?": 2,
-      "HTTPS Enforced?": 2,
+      "Enforces HTTPS": 2,
       "SSL Labs Grade": 3,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 2
     },
     {
       "Canonical": "http://oshrc.gov",
       "Domain": "oshrc.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.osm.gov",
       "Domain": "osm.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.osmre.gov",
       "Domain": "osmre.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.osti.gov",
       "Domain": "osti.gov",
-      "HTTPS Enabled?": 2,
-      "HTTPS Enforced?": 0,
+      "Enforces HTTPS": 0,
       "SSL Labs Grade": 3,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 2
     },
     {
       "Canonical": "http://www.ostp.gov",
       "Domain": "ostp.gov",
-      "HTTPS Enabled?": 2,
-      "HTTPS Enforced?": 1,
+      "Enforces HTTPS": 1,
       "SSL Labs Grade": 5,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 2
     },
     {
       "Canonical": "http://oti.gov",
       "Domain": "oti.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://ots.gov",
       "Domain": "ots.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://ourdocuments.gov",
       "Domain": "ourdocuments.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://ovc.gov",
       "Domain": "ovc.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "https://www.ovcttac.gov",
       "Domain": "ovcttac.gov",
-      "HTTPS Enabled?": 2,
-      "HTTPS Enforced?": 3,
+      "Enforces HTTPS": 3,
       "SSL Labs Grade": 3,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 2
     },
     {
       "Canonical": "https://www.pacer.gov",
       "Domain": "pacer.gov",
-      "HTTPS Enabled?": 2,
-      "HTTPS Enforced?": 3,
+      "Enforces HTTPS": 3,
       "SSL Labs Grade": 5,
-      "Strict Transport Security (HSTS)": 1
+      "Strict Transport Security (HSTS)": 1,
+      "Uses HTTPS": 2
     },
     {
       "Canonical": "http://www.pandemicflu.gov",
       "Domain": "pandemicflu.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.papahanaumokuakea.gov",
       "Domain": "papahanaumokuakea.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.partner4solutions.gov",
       "Domain": "partner4solutions.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://patriotbonds.gov",
       "Domain": "patriotbonds.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "https://pay.gov",
       "Domain": "pay.gov",
-      "HTTPS Enabled?": 1,
-      "HTTPS Enforced?": 3,
+      "Enforces HTTPS": 3,
       "SSL Labs Grade": 0,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 1
     },
     {
       "Canonical": "https://paymentaccuracy.gov",
       "Domain": "paymentaccuracy.gov",
-      "HTTPS Enabled?": 2,
-      "HTTPS Enforced?": 3,
+      "Enforces HTTPS": 3,
       "SSL Labs Grade": 0,
-      "Strict Transport Security (HSTS)": 3
+      "Strict Transport Security (HSTS)": 3,
+      "Uses HTTPS": 2
     },
     {
       "Canonical": "http://pbgc.gov",
       "Domain": "pbgc.gov",
-      "HTTPS Enabled?": 2,
-      "HTTPS Enforced?": 1,
+      "Enforces HTTPS": 1,
       "SSL Labs Grade": 3,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 2
     },
     {
       "Canonical": "http://pcah.gov",
       "Domain": "pcah.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.pcip.gov",
       "Domain": "pcip.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "https://pclob.gov",
       "Domain": "pclob.gov",
-      "HTTPS Enabled?": 2,
-      "HTTPS Enforced?": 3,
+      "Enforces HTTPS": 3,
       "SSL Labs Grade": 3,
-      "Strict Transport Security (HSTS)": 3
+      "Strict Transport Security (HSTS)": 3,
+      "Uses HTTPS": 2
     },
     {
       "Canonical": "http://www.pdbcecc.gov",
       "Domain": "pdbcecc.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://peacecore.gov",
       "Domain": "peacecore.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://peacecorp.gov",
       "Domain": "peacecorp.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.peacecorps.gov",
       "Domain": "peacecorps.gov",
-      "HTTPS Enabled?": 2,
-      "HTTPS Enforced?": 0,
+      "Enforces HTTPS": 0,
       "SSL Labs Grade": 2,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 2
     },
     {
       "Canonical": "http://www.pentagon.gov",
       "Domain": "pentagon.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.pepfar.gov",
       "Domain": "pepfar.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.performance.gov",
       "Domain": "performance.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.phe.gov",
       "Domain": "phe.gov",
-      "HTTPS Enabled?": 1,
-      "HTTPS Enforced?": 1,
+      "Enforces HTTPS": 1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 1
     },
     {
       "Canonical": "https://pic.gov",
       "Domain": "pic.gov",
-      "HTTPS Enabled?": 2,
-      "HTTPS Enforced?": 3,
+      "Enforces HTTPS": 3,
       "SSL Labs Grade": 0,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 2
     },
     {
       "Canonical": "http://www.piedrasblancas.gov",
       "Domain": "piedrasblancas.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.plainlanguage.gov",
       "Domain": "plainlanguage.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://pmf.gov",
       "Domain": "pmf.gov",
-      "HTTPS Enabled?": 2,
-      "HTTPS Enforced?": 1,
+      "Enforces HTTPS": 1,
       "SSL Labs Grade": 3,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 2
     },
     {
       "Canonical": "http://pmi.gov",
       "Domain": "pmi.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.pnl.gov",
       "Domain": "pnl.gov",
-      "HTTPS Enabled?": 2,
-      "HTTPS Enforced?": 1,
+      "Enforces HTTPS": 1,
       "SSL Labs Grade": 4,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 2
     },
     {
       "Canonical": "http://www.pnnl.gov",
       "Domain": "pnnl.gov",
-      "HTTPS Enabled?": 2,
-      "HTTPS Enforced?": 1,
+      "Enforces HTTPS": 1,
       "SSL Labs Grade": 5,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 2
     },
     {
       "Canonical": "http://www.poolsafely.gov",
       "Domain": "poolsafely.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.poolsafety.gov",
       "Domain": "poolsafety.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.postoffice.gov",
       "Domain": "postoffice.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://ppdcecc.gov",
       "Domain": "ppdcecc.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "https://www.ppirs.gov",
       "Domain": "ppirs.gov",
-      "HTTPS Enabled?": 1,
-      "HTTPS Enforced?": 3,
+      "Enforces HTTPS": 3,
       "SSL Labs Grade": 3,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 1
     },
     {
       "Canonical": "http://www.pracomment.gov",
       "Domain": "pracomment.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.prc.gov",
       "Domain": "prc.gov",
-      "HTTPS Enabled?": 2,
-      "HTTPS Enforced?": 0,
+      "Enforces HTTPS": 0,
       "SSL Labs Grade": 3,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 2
     },
     {
       "Canonical": "http://www.pregunteleakaren.gov",
       "Domain": "pregunteleakaren.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://preserveamerica.gov",
       "Domain": "preserveamerica.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.presidentialdocuments.gov",
       "Domain": "presidentialdocuments.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.presidentialserviceawards.gov",
       "Domain": "presidentialserviceawards.gov",
-      "HTTPS Enabled?": 2,
-      "HTTPS Enforced?": 0,
+      "Enforces HTTPS": 0,
       "SSL Labs Grade": 3,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 2
     },
     {
       "Canonical": "http://www.presidio.gov",
       "Domain": "presidio.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.presidiotrust.gov",
       "Domain": "presidiotrust.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://pretrialservices.gov",
       "Domain": "pretrialservices.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.primarysources.gov",
       "Domain": "primarysources.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.projectsafechildhood.gov",
       "Domain": "projectsafechildhood.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.projectsafeneighborhoods.gov",
       "Domain": "projectsafeneighborhoods.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.protecciondelconsumidor.gov",
       "Domain": "protecciondelconsumidor.gov",
-      "HTTPS Enabled?": 2,
-      "HTTPS Enforced?": 1,
+      "Enforces HTTPS": 1,
       "SSL Labs Grade": 3,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 2
     },
     {
       "Canonical": "https://www.protectyourmove.gov",
       "Domain": "protectyourmove.gov",
-      "HTTPS Enabled?": 2,
-      "HTTPS Enforced?": 3,
+      "Enforces HTTPS": 3,
       "SSL Labs Grade": 3,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 2
     },
     {
       "Canonical": "http://psa.gov",
       "Domain": "psa.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.psc.gov",
       "Domain": "psc.gov",
-      "HTTPS Enabled?": 1,
-      "HTTPS Enforced?": 1,
+      "Enforces HTTPS": 1,
       "SSL Labs Grade": 1,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 1
     },
     {
       "Canonical": "http://pscr.gov",
       "Domain": "pscr.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "https://psob.gov",
       "Domain": "psob.gov",
-      "HTTPS Enabled?": 2,
-      "HTTPS Enforced?": 3,
+      "Enforces HTTPS": 3,
       "SSL Labs Grade": 2,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 2
     },
     {
       "Canonical": "http://www.ptf.gov",
       "Domain": "ptf.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.pubmed.gov",
       "Domain": "pubmed.gov",
-      "HTTPS Enabled?": 2,
-      "HTTPS Enforced?": 1,
+      "Enforces HTTPS": 1,
       "SSL Labs Grade": 3,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 2
     },
     {
       "Canonical": "http://www.pubmedcentral.gov",
       "Domain": "pubmedcentral.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "https://www.qatesttwai.gov",
       "Domain": "qatesttwai.gov",
-      "HTTPS Enabled?": 1,
-      "HTTPS Enforced?": 3,
+      "Enforces HTTPS": 3,
       "SSL Labs Grade": 1,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 1
     },
     {
       "Canonical": "http://www.quic.gov",
       "Domain": "quic.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.quick.gov",
       "Domain": "quick.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.rcfl.gov",
       "Domain": "rcfl.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.reachhigher.gov",
       "Domain": "reachhigher.gov",
-      "HTTPS Enabled?": 2,
-      "HTTPS Enforced?": 1,
+      "Enforces HTTPS": 1,
       "SSL Labs Grade": 5,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 2
     },
     {
       "Canonical": "http://www.read.gov",
       "Domain": "read.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.ready.gov",
       "Domain": "ready.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.readybusiness.gov",
       "Domain": "readybusiness.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://reaganlibrary.gov",
       "Domain": "reaganlibrary.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://realestatesales.gov",
       "Domain": "realestatesales.gov",
-      "HTTPS Enabled?": 2,
-      "HTTPS Enforced?": 1,
+      "Enforces HTTPS": 1,
       "SSL Labs Grade": 4,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 2
     },
     {
       "Canonical": "https://www.realpropertyprofile.gov",
       "Domain": "realpropertyprofile.gov",
-      "HTTPS Enabled?": 2,
-      "HTTPS Enforced?": 2,
+      "Enforces HTTPS": 2,
       "SSL Labs Grade": 0,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 2
     },
     {
       "Canonical": "http://www.recalls.gov",
       "Domain": "recalls.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.recovery.gov",
       "Domain": "recovery.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://recoverymonth.gov",
       "Domain": "recoverymonth.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.recreation.gov",
       "Domain": "recreation.gov",
-      "HTTPS Enabled?": 2,
-      "HTTPS Enforced?": 0,
+      "Enforces HTTPS": 0,
       "SSL Labs Grade": 3,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 2
     },
     {
       "Canonical": "http://www.reentry.gov",
       "Domain": "reentry.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://reginfo.gov",
       "Domain": "reginfo.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.regulation.gov",
       "Domain": "regulation.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.regulations.gov",
       "Domain": "regulations.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://relocatefeds.gov",
       "Domain": "relocatefeds.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://reo.gov",
       "Domain": "reo.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.reportband.gov",
       "Domain": "reportband.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.republicans.gov",
       "Domain": "republicans.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.research.gov",
       "Domain": "research.gov",
-      "HTTPS Enabled?": 2,
-      "HTTPS Enforced?": 1,
+      "Enforces HTTPS": 1,
       "SSL Labs Grade": 0,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 2
     },
     {
       "Canonical": "http://restorethegulf.gov",
       "Domain": "restorethegulf.gov",
-      "HTTPS Enabled?": 2,
-      "HTTPS Enforced?": 1,
+      "Enforces HTTPS": 1,
       "SSL Labs Grade": 3,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 2
     },
     {
       "Canonical": "http://rivers.gov",
       "Domain": "rivers.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://rocis.gov",
       "Domain": "rocis.gov",
-      "HTTPS Enabled?": 1,
-      "HTTPS Enforced?": 1,
+      "Enforces HTTPS": 1,
       "SSL Labs Grade": 3,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 1
     },
     {
       "Canonical": "http://www.rrb.gov",
       "Domain": "rrb.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://sac.gov",
       "Domain": "sac.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.safecom.gov",
       "Domain": "safecom.gov",
-      "HTTPS Enabled?": 2,
-      "HTTPS Enforced?": 1,
+      "Enforces HTTPS": 1,
       "SSL Labs Grade": 2,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 2
     },
     {
       "Canonical": "http://www.safecomprogram.gov",
       "Domain": "safecomprogram.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.safercar.gov",
       "Domain": "safercar.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.saferproduct.gov",
       "Domain": "saferproduct.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.saferproducts.gov",
       "Domain": "saferproducts.gov",
-      "HTTPS Enabled?": 2,
-      "HTTPS Enforced?": 0,
+      "Enforces HTTPS": 0,
       "SSL Labs Grade": 3,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 2
     },
     {
       "Canonical": "http://safertruck.gov",
       "Domain": "safertruck.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "https://safetyact.gov",
       "Domain": "safetyact.gov",
-      "HTTPS Enabled?": 1,
-      "HTTPS Enforced?": 3,
+      "Enforces HTTPS": 3,
       "SSL Labs Grade": 1,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 1
     },
     {
       "Canonical": "http://www.safetyvideos.gov",
       "Domain": "safetyvideos.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.safeyouth.gov",
       "Domain": "safeyouth.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.salmonrecovery.gov",
       "Domain": "salmonrecovery.gov",
-      "HTTPS Enabled?": 2,
-      "HTTPS Enforced?": 1,
+      "Enforces HTTPS": 1,
       "SSL Labs Grade": 2,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 2
     },
     {
       "Canonical": "https://www.sam.gov",
       "Domain": "sam.gov",
-      "HTTPS Enabled?": 1,
-      "HTTPS Enforced?": 3,
+      "Enforces HTTPS": 3,
       "SSL Labs Grade": 3,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 1
     },
     {
       "Canonical": "http://www.samhsa.gov",
       "Domain": "samhsa.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.sandia.gov",
       "Domain": "sandia.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.save.gov",
       "Domain": "save.gov",
-      "HTTPS Enabled?": 2,
-      "HTTPS Enforced?": 1,
+      "Enforces HTTPS": 1,
       "SSL Labs Grade": 0,
-      "Strict Transport Security (HSTS)": 3
+      "Strict Transport Security (HSTS)": 3,
+      "Uses HTTPS": 2
     },
     {
       "Canonical": "http://www.saveaward.gov",
       "Domain": "saveaward.gov",
-      "HTTPS Enabled?": 2,
-      "HTTPS Enforced?": 1,
+      "Enforces HTTPS": 1,
       "SSL Labs Grade": 0,
-      "Strict Transport Security (HSTS)": 3
+      "Strict Transport Security (HSTS)": 3,
+      "Uses HTTPS": 2
     },
     {
       "Canonical": "http://savingsbond.gov",
       "Domain": "savingsbond.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://savingsbonds.gov",
       "Domain": "savingsbonds.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://savingsbondwizard.gov",
       "Domain": "savingsbondwizard.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "https://www.sba.gov",
       "Domain": "sba.gov",
-      "HTTPS Enabled?": 2,
-      "HTTPS Enforced?": 3,
+      "Enforces HTTPS": 3,
       "SSL Labs Grade": 3,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 2
     },
     {
       "Canonical": "http://www.sbir.gov",
       "Domain": "sbir.gov",
-      "HTTPS Enabled?": 1,
-      "HTTPS Enforced?": 1,
+      "Enforces HTTPS": 1,
       "SSL Labs Grade": 3,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 1
     },
     {
       "Canonical": "http://www.scidac.gov",
       "Domain": "scidac.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.science.gov",
       "Domain": "science.gov",
-      "HTTPS Enabled?": 2,
-      "HTTPS Enforced?": 1,
+      "Enforces HTTPS": 1,
       "SSL Labs Grade": 3,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 2
     },
     {
       "Canonical": "http://www.science360.gov",
       "Domain": "science360.gov",
-      "HTTPS Enabled?": 1,
-      "HTTPS Enforced?": 1,
+      "Enforces HTTPS": 1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 1
     },
     {
       "Canonical": "http://www.scienceaccelerator.gov",
       "Domain": "scienceaccelerator.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "https://www.sciencebase.gov",
       "Domain": "sciencebase.gov",
-      "HTTPS Enabled?": 2,
-      "HTTPS Enforced?": 3,
+      "Enforces HTTPS": 3,
       "SSL Labs Grade": 3,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 2
     },
     {
       "Canonical": "http://www.scienceeducation.gov",
       "Domain": "scienceeducation.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.scijinks.gov",
       "Domain": "scijinks.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.scra.gov",
       "Domain": "scra.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.sdr.gov",
       "Domain": "sdr.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.sec.gov",
       "Domain": "sec.gov",
-      "HTTPS Enabled?": 2,
-      "HTTPS Enforced?": 1,
+      "Enforces HTTPS": 1,
       "SSL Labs Grade": 3,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 2
     },
     {
       "Canonical": "http://www.secretservice.gov",
       "Domain": "secretservice.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://section108.gov",
       "Domain": "section108.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://section508.gov",
       "Domain": "section508.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.seguridadconsumidor.gov",
       "Domain": "seguridadconsumidor.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://segurosocial.gov",
       "Domain": "segurosocial.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.selectagents.gov",
       "Domain": "selectagents.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.selectusa.gov",
       "Domain": "selectusa.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.senate.gov",
       "Domain": "senate.gov",
-      "HTTPS Enabled?": 2,
-      "HTTPS Enforced?": 0,
+      "Enforces HTTPS": 0,
       "SSL Labs Grade": 3,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 2
     },
     {
       "Canonical": "http://www.senatecalendar.gov",
       "Domain": "senatecalendar.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.senaterestaurants.gov",
       "Domain": "senaterestaurants.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.seniorcorps.gov",
       "Domain": "seniorcorps.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.seniors.gov",
       "Domain": "seniors.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.sentinel.gov",
       "Domain": "sentinel.gov",
-      "HTTPS Enabled?": 2,
-      "HTTPS Enforced?": 1,
+      "Enforces HTTPS": 1,
       "SSL Labs Grade": 4,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 2
     },
     {
       "Canonical": "http://www.serve.gov",
       "Domain": "serve.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.service.gov",
       "Domain": "service.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.servicelearning.gov",
       "Domain": "servicelearning.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.servicemembers.gov",
       "Domain": "servicemembers.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "https://sftool.gov",
       "Domain": "sftool.gov",
-      "HTTPS Enabled?": 2,
-      "HTTPS Enforced?": 3,
+      "Enforces HTTPS": 3,
       "SSL Labs Grade": 5,
-      "Strict Transport Security (HSTS)": 3
+      "Strict Transport Security (HSTS)": 3,
+      "Uses HTTPS": 2
     },
     {
       "Canonical": "http://www.sharetheroadsafely.gov",
       "Domain": "sharetheroadsafely.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://sierrawild.gov",
       "Domain": "sierrawild.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.sigtarp.gov",
       "Domain": "sigtarp.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.siteidiq.gov",
       "Domain": "siteidiq.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://slgs.gov",
       "Domain": "slgs.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.smallbusiness.gov",
       "Domain": "smallbusiness.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://smart.gov",
       "Domain": "smart.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.smartcheck.gov",
       "Domain": "smartcheck.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "https://www.smartgrid.gov",
       "Domain": "smartgrid.gov",
-      "HTTPS Enabled?": 2,
-      "HTTPS Enforced?": 3,
+      "Enforces HTTPS": 3,
       "SSL Labs Grade": 3,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 2
     },
     {
       "Canonical": "http://smokefree.gov",
       "Domain": "smokefree.gov",
-      "HTTPS Enabled?": 1,
-      "HTTPS Enforced?": 1,
+      "Enforces HTTPS": 1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 1
     },
     {
       "Canonical": "http://snap.gov",
       "Domain": "snap.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://sns.gov",
       "Domain": "sns.gov",
-      "HTTPS Enabled?": 1,
-      "HTTPS Enforced?": 1,
+      "Enforces HTTPS": 1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 1
     },
     {
       "Canonical": "http://socialsecurity.gov",
       "Domain": "socialsecurity.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.solardecathlon.gov",
       "Domain": "solardecathlon.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.spaceweather.gov",
       "Domain": "spaceweather.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.speaker.gov",
       "Domain": "speaker.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.spectrum.gov",
       "Domain": "spectrum.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.srs.gov",
       "Domain": "srs.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://ssa.gov",
       "Domain": "ssa.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://ssab.gov",
       "Domain": "ssab.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.sss.gov",
       "Domain": "sss.gov",
-      "HTTPS Enabled?": 1,
-      "HTTPS Enforced?": 1,
+      "Enforces HTTPS": 1,
       "SSL Labs Grade": 3,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 1
     },
     {
       "Canonical": "https://www.standards.gov",
       "Domain": "standards.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://start2farm.gov",
       "Domain": "start2farm.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.state.gov",
       "Domain": "state.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://stennis.gov",
       "Domain": "stennis.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.steroidabuse.gov",
       "Domain": "steroidabuse.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://stopalcoholabuse.gov",
       "Domain": "stopalcoholabuse.gov",
-      "HTTPS Enabled?": 2,
-      "HTTPS Enforced?": 1,
+      "Enforces HTTPS": 1,
       "SSL Labs Grade": 5,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 2
     },
     {
       "Canonical": "http://www.stopbullying.gov",
       "Domain": "stopbullying.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.stopfakes.gov",
       "Domain": "stopfakes.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.stopfraud.gov",
       "Domain": "stopfraud.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.stopmedicarefraud.gov",
       "Domain": "stopmedicarefraud.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "https://strategicsourcing.gov",
       "Domain": "strategicsourcing.gov",
-      "HTTPS Enabled?": 2,
-      "HTTPS Enforced?": 2,
+      "Enforces HTTPS": 2,
       "SSL Labs Grade": 2,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 2
     },
     {
       "Canonical": "http://www.strongmiddleclass.gov",
       "Domain": "strongmiddleclass.gov",
-      "HTTPS Enabled?": 2,
-      "HTTPS Enforced?": 1,
+      "Enforces HTTPS": 1,
       "SSL Labs Grade": 5,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 2
     },
     {
       "Canonical": "http://www.strongports.gov",
       "Domain": "strongports.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "https://www.studentaid.gov",
       "Domain": "studentaid.gov",
-      "HTTPS Enabled?": 2,
-      "HTTPS Enforced?": 2,
+      "Enforces HTTPS": 2,
       "SSL Labs Grade": 3,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 2
     },
     {
       "Canonical": "https://www.studentloans.gov",
       "Domain": "studentloans.gov",
-      "HTTPS Enabled?": 2,
-      "HTTPS Enforced?": 3,
+      "Enforces HTTPS": 3,
       "SSL Labs Grade": 0,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 2
     },
     {
       "Canonical": "http://www.supportthevoter.gov",
       "Domain": "supportthevoter.gov",
-      "HTTPS Enabled?": 2,
-      "HTTPS Enforced?": 1,
+      "Enforces HTTPS": 1,
       "SSL Labs Grade": 3,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 2
     },
     {
       "Canonical": "http://www.supremecourt.gov",
       "Domain": "supremecourt.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.supremecourtus.gov",
       "Domain": "supremecourtus.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.surgeongeneral.gov",
       "Domain": "surgeongeneral.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://sustainability.gov",
       "Domain": "sustainability.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.sustainablecommunities.gov",
       "Domain": "sustainablecommunities.gov",
-      "HTTPS Enabled?": 2,
-      "HTTPS Enforced?": 0,
+      "Enforces HTTPS": 0,
       "SSL Labs Grade": 3,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 2
     },
     {
       "Canonical": "http://swpa.gov",
       "Domain": "swpa.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "https://www.symbols.gov",
       "Domain": "symbols.gov",
-      "HTTPS Enabled?": 2,
-      "HTTPS Enforced?": 3,
+      "Enforces HTTPS": 3,
       "SSL Labs Grade": 3,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 2
     },
     {
       "Canonical": "http://taaps.gov",
       "Domain": "taaps.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.tax.gov",
       "Domain": "tax.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "https://taxreform.gov",
       "Domain": "taxreform.gov",
-      "HTTPS Enabled?": 2,
-      "HTTPS Enforced?": 2,
+      "Enforces HTTPS": 2,
       "SSL Labs Grade": 0,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 2
     },
     {
       "Canonical": "http://www.teachingprimarysources.gov",
       "Domain": "teachingprimarysources.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.teachingwithprimarysources.gov",
       "Domain": "teachingwithprimarysources.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://telework.gov",
       "Domain": "telework.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.tfhrc.gov",
       "Domain": "tfhrc.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://thecoolspot.gov",
       "Domain": "thecoolspot.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://thepeoplesgarden.gov",
       "Domain": "thepeoplesgarden.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.therealcost.gov",
       "Domain": "therealcost.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.thesecondthing.gov",
       "Domain": "thesecondthing.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.thomas.gov",
       "Domain": "thomas.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.tigta.gov",
       "Domain": "tigta.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://time.gov",
       "Domain": "time.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://tissueengineering.gov",
       "Domain": "tissueengineering.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.tobacco.gov",
       "Domain": "tobacco.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.tps.gov",
       "Domain": "tps.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://trade.gov",
       "Domain": "trade.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.trafficsafetymarketing.gov",
       "Domain": "trafficsafetymarketing.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.transparency.gov",
       "Domain": "transparency.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.transportation.gov",
       "Domain": "transportation.gov",
-      "HTTPS Enabled?": 2,
-      "HTTPS Enforced?": 0,
+      "Enforces HTTPS": 0,
       "SSL Labs Grade": 3,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 2
     },
     {
       "Canonical": "http://www.transportationresearch.gov",
       "Domain": "transportationresearch.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.treas.gov",
       "Domain": "treas.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "https://www.treaslockbox.gov",
       "Domain": "treaslockbox.gov",
-      "HTTPS Enabled?": 1,
-      "HTTPS Enforced?": 3,
+      "Enforces HTTPS": 3,
       "SSL Labs Grade": 0,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 1
     },
     {
       "Canonical": "http://treasury.fed.us",
       "Domain": "treasury.fed.us",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.treasury.gov",
       "Domain": "treasury.gov",
-      "HTTPS Enabled?": 2,
-      "HTTPS Enforced?": 0,
+      "Enforces HTTPS": 0,
       "SSL Labs Grade": 3,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 2
     },
     {
       "Canonical": "http://treasuryauctions.gov",
       "Domain": "treasuryauctions.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://treasurydirect.gov",
       "Domain": "treasurydirect.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://treasuryhunt.gov",
       "Domain": "treasuryhunt.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://treasuryscams.gov",
       "Domain": "treasuryscams.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.tribaljusticeandsafety.gov",
       "Domain": "tribaljusticeandsafety.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.truman.gov",
       "Domain": "truman.gov",
-      "HTTPS Enabled?": 1,
-      "HTTPS Enforced?": 1,
+      "Enforces HTTPS": 1,
       "SSL Labs Grade": 1,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 1
     },
     {
       "Canonical": "http://www.tsa.gov",
       "Domain": "tsa.gov",
-      "HTTPS Enabled?": 2,
-      "HTTPS Enforced?": 1,
+      "Enforces HTTPS": 1,
       "SSL Labs Grade": 3,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 2
     },
     {
       "Canonical": "http://www.tsc.gov",
       "Domain": "tsc.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "https://www.tsp.gov",
       "Domain": "tsp.gov",
-      "HTTPS Enabled?": 2,
-      "HTTPS Enforced?": 3,
+      "Enforces HTTPS": 3,
       "SSL Labs Grade": 3,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 2
     },
     {
       "Canonical": "http://www.tsunami.gov",
       "Domain": "tsunami.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://tswg.gov",
       "Domain": "tswg.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://ttb.gov",
       "Domain": "ttb.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.ttbonline.gov",
       "Domain": "ttbonline.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://tva.gov",
       "Domain": "tva.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://ucrdatatool.gov",
       "Domain": "ucrdatatool.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://udall.gov",
       "Domain": "udall.gov",
-      "HTTPS Enabled?": 2,
-      "HTTPS Enforced?": 1,
+      "Enforces HTTPS": 1,
       "SSL Labs Grade": 3,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 2
     },
     {
       "Canonical": "http://www.unicor.gov",
       "Domain": "unicor.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.unionreports.gov",
       "Domain": "unionreports.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.unitedstates.gov",
       "Domain": "unitedstates.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.unitedstatescongress.gov",
       "Domain": "unitedstatescongress.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.unitedweride.gov",
       "Domain": "unitedweride.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "https://unlocktalent.gov",
       "Domain": "unlocktalent.gov",
-      "HTTPS Enabled?": 2,
-      "HTTPS Enforced?": 3,
+      "Enforces HTTPS": 3,
       "SSL Labs Grade": 3,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 2
     },
     {
       "Canonical": "http://urbanwaters.gov",
       "Domain": "urbanwaters.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "https://www.us-cert.gov",
       "Domain": "us-cert.gov",
-      "HTTPS Enabled?": 2,
-      "HTTPS Enforced?": 2,
+      "Enforces HTTPS": 2,
       "SSL Labs Grade": 3,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 2
     },
     {
       "Canonical": "http://www.us.gov",
       "Domain": "us.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.usa.gov",
       "Domain": "usa.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.usability.gov",
       "Domain": "usability.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.usagov.gov",
       "Domain": "usagov.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.usaid.gov",
       "Domain": "usaid.gov",
-      "HTTPS Enabled?": 2,
-      "HTTPS Enforced?": 0,
+      "Enforces HTTPS": 0,
       "SSL Labs Grade": 0,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 2
     },
     {
       "Canonical": "http://www.usaidallnet.gov",
       "Domain": "usaidallnet.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "https://www.usajobs.gov",
       "Domain": "usajobs.gov",
-      "HTTPS Enabled?": 2,
-      "HTTPS Enforced?": 2,
+      "Enforces HTTPS": 2,
       "SSL Labs Grade": 3,
-      "Strict Transport Security (HSTS)": 1
+      "Strict Transport Security (HSTS)": 1,
+      "Uses HTTPS": 2
     },
     {
       "Canonical": "https://usalearning.gov",
       "Domain": "usalearning.gov",
-      "HTTPS Enabled?": 2,
-      "HTTPS Enforced?": 2,
+      "Enforces HTTPS": 2,
       "SSL Labs Grade": 2,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 2
     },
     {
       "Canonical": "http://www.usandc.gov",
       "Domain": "usandc.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://usap.gov",
       "Domain": "usap.gov",
-      "HTTPS Enabled?": 2,
-      "HTTPS Enforced?": 1,
+      "Enforces HTTPS": 1,
       "SSL Labs Grade": 3,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 2
     },
     {
       "Canonical": "http://www.usaperformance.gov",
       "Domain": "usaperformance.gov",
-      "HTTPS Enabled?": 1,
-      "HTTPS Enforced?": 1,
+      "Enforces HTTPS": 1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 1
     },
     {
       "Canonical": "https://www.usaspending.gov",
       "Domain": "usaspending.gov",
-      "HTTPS Enabled?": 2,
-      "HTTPS Enforced?": 3,
+      "Enforces HTTPS": 3,
       "SSL Labs Grade": 3,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 2
     },
     {
       "Canonical": "http://www.usastaffing.gov",
       "Domain": "usastaffing.gov",
-      "HTTPS Enabled?": 2,
-      "HTTPS Enforced?": 1,
+      "Enforces HTTPS": 1,
       "SSL Labs Grade": 3,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 2
     },
     {
       "Canonical": "http://www.usbankruptcy.gov",
       "Domain": "usbankruptcy.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://usbg.gov",
       "Domain": "usbg.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.usbr.gov",
       "Domain": "usbr.gov",
-      "HTTPS Enabled?": 2,
-      "HTTPS Enforced?": 1,
+      "Enforces HTTPS": 1,
       "SSL Labs Grade": 4,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 2
     },
     {
       "Canonical": "http://uscapital.gov",
       "Domain": "uscapital.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://uscapitol.gov",
       "Domain": "uscapitol.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.uscapitolpolice.gov",
       "Domain": "uscapitolpolice.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://uscapitolvisitorcenter.gov",
       "Domain": "uscapitolvisitorcenter.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.uscc.gov",
       "Domain": "uscc.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.usccr.gov",
       "Domain": "usccr.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.uscirf.gov",
       "Domain": "uscirf.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.uscis.gov",
       "Domain": "uscis.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.uscode.gov",
       "Domain": "uscode.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.uscongress.gov",
       "Domain": "uscongress.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.usconsulate.gov",
       "Domain": "usconsulate.gov",
-      "HTTPS Enabled?": 1,
-      "HTTPS Enforced?": 1,
+      "Enforces HTTPS": 1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 1
     },
     {
       "Canonical": "http://www.uscourts.gov",
       "Domain": "uscourts.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://uscvc.gov",
       "Domain": "uscvc.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.usda.gov",
       "Domain": "usda.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.usdapii.gov",
       "Domain": "usdapii.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://usdebitcard.gov",
       "Domain": "usdebitcard.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.usdoj.gov",
       "Domain": "usdoj.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://usembassy-mexico.gov",
       "Domain": "usembassy-mexico.gov",
-      "HTTPS Enabled?": 1,
-      "HTTPS Enforced?": 1,
+      "Enforces HTTPS": 1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 1
     },
     {
       "Canonical": "http://www.usembassy.gov",
       "Domain": "usembassy.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.userra.gov",
       "Domain": "userra.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.usgcrp.gov",
       "Domain": "usgcrp.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.usgeo.gov",
       "Domain": "usgeo.gov",
-      "HTTPS Enabled?": 1,
-      "HTTPS Enforced?": 1,
+      "Enforces HTTPS": 1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 1
     },
     {
       "Canonical": "http://www.usgovernment.gov",
       "Domain": "usgovernment.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.usgovernmentmanual.gov",
       "Domain": "usgovernmentmanual.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://usgs.gov",
       "Domain": "usgs.gov",
-      "HTTPS Enabled?": 2,
-      "HTTPS Enforced?": 1,
+      "Enforces HTTPS": 1,
       "SSL Labs Grade": 3,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 2
     },
     {
       "Canonical": "http://www.ushmm.gov",
       "Domain": "ushmm.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://usich.gov",
       "Domain": "usich.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.usicn.gov",
       "Domain": "usicn.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://usint.gov",
       "Domain": "usint.gov",
-      "HTTPS Enabled?": 1,
-      "HTTPS Enforced?": 1,
+      "Enforces HTTPS": 1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 1
     },
     {
       "Canonical": "http://www.usip.gov",
       "Domain": "usip.gov",
-      "HTTPS Enabled?": 1,
-      "HTTPS Enforced?": 1,
+      "Enforces HTTPS": 1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 1
     },
     {
       "Canonical": "http://usitc.gov",
       "Domain": "usitc.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.usmarshals.gov",
       "Domain": "usmarshals.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.usmint.gov",
       "Domain": "usmint.gov",
-      "HTTPS Enabled?": 2,
-      "HTTPS Enforced?": 1,
+      "Enforces HTTPS": 1,
       "SSL Labs Grade": 3,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 2
     },
     {
       "Canonical": "http://usmission.gov",
       "Domain": "usmission.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.usoge.gov",
       "Domain": "usoge.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://usphs.gov",
       "Domain": "usphs.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.uspis.gov",
       "Domain": "uspis.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.usprobation.gov",
       "Domain": "usprobation.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "https://www.usps.gov",
       "Domain": "usps.gov",
-      "HTTPS Enabled?": 2,
-      "HTTPS Enforced?": 3,
+      "Enforces HTTPS": 3,
       "SSL Labs Grade": 5,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 2
     },
     {
       "Canonical": "https://uspsoig.gov",
       "Domain": "uspsoig.gov",
-      "HTTPS Enabled?": 2,
-      "HTTPS Enforced?": 3,
+      "Enforces HTTPS": 3,
       "SSL Labs Grade": 5,
-      "Strict Transport Security (HSTS)": 3
+      "Strict Transport Security (HSTS)": 3,
+      "Uses HTTPS": 2
     },
     {
       "Canonical": "http://www.uspto.gov",
       "Domain": "uspto.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.ussc.gov",
       "Domain": "ussc.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://ustaxcourt.gov",
       "Domain": "ustaxcourt.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://ustda.gov",
       "Domain": "ustda.gov",
-      "HTTPS Enabled?": 1,
-      "HTTPS Enforced?": 1,
+      "Enforces HTTPS": 1,
       "SSL Labs Grade": 0,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 1
     },
     {
       "Canonical": "https://ustr.gov",
       "Domain": "ustr.gov",
-      "HTTPS Enabled?": 2,
-      "HTTPS Enforced?": 3,
+      "Enforces HTTPS": 3,
       "SSL Labs Grade": 0,
-      "Strict Transport Security (HSTS)": 1
+      "Strict Transport Security (HSTS)": 1,
+      "Uses HTTPS": 2
     },
     {
       "Canonical": "http://www.ustreas.gov",
       "Domain": "ustreas.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.usvpp.gov",
       "Domain": "usvpp.gov",
-      "HTTPS Enabled?": 1,
-      "HTTPS Enforced?": 1,
+      "Enforces HTTPS": 1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 1
     },
     {
       "Canonical": "http://www.utahfireinfo.gov",
       "Domain": "utahfireinfo.gov",
-      "HTTPS Enabled?": 1,
-      "HTTPS Enforced?": 1,
+      "Enforces HTTPS": 1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 1
     },
     {
       "Canonical": "http://va.gov",
       "Domain": "va.gov",
-      "HTTPS Enabled?": 1,
-      "HTTPS Enforced?": 1,
+      "Enforces HTTPS": 1,
       "SSL Labs Grade": 1,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 1
     },
     {
       "Canonical": "http://www.vaccines.gov",
       "Domain": "vaccines.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://vallescaldera.gov",
       "Domain": "vallescaldera.gov",
-      "HTTPS Enabled?": 2,
-      "HTTPS Enforced?": 1,
+      "Enforces HTTPS": 1,
       "SSL Labs Grade": 0,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 2
     },
     {
       "Canonical": "http://www.vcf.gov",
       "Domain": "vcf.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://vef.gov",
       "Domain": "vef.gov",
-      "HTTPS Enabled?": 2,
-      "HTTPS Enforced?": 1,
+      "Enforces HTTPS": 1,
       "SSL Labs Grade": 0,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 2
     },
     {
       "Canonical": "http://www.vehiclehistory.gov",
       "Domain": "vehiclehistory.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.vetbiz.gov",
       "Domain": "vetbiz.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.veterans.gov",
       "Domain": "veterans.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://visitthecapital.gov",
       "Domain": "visitthecapital.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.visitthecapitol.gov",
       "Domain": "visitthecapitol.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.vista.gov",
       "Domain": "vista.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.vistacampus.gov",
       "Domain": "vistacampus.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.voa.gov",
       "Domain": "voa.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://volunteer.gov",
       "Domain": "volunteer.gov",
-      "HTTPS Enabled?": 2,
-      "HTTPS Enforced?": 1,
+      "Enforces HTTPS": 1,
       "SSL Labs Grade": 3,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 2
     },
     {
       "Canonical": "http://www.volunteeringinamerica.gov",
       "Domain": "volunteeringinamerica.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.wapa.gov",
       "Domain": "wapa.gov",
-      "HTTPS Enabled?": 2,
-      "HTTPS Enforced?": 1,
+      "Enforces HTTPS": 1,
       "SSL Labs Grade": 0,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 2
     },
     {
       "Canonical": "http://www.wartimecontracting.gov",
       "Domain": "wartimecontracting.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://watermonitor.gov",
       "Domain": "watermonitor.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.wdl.gov",
       "Domain": "wdl.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://wdol.gov",
       "Domain": "wdol.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.weather.gov",
       "Domain": "weather.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://webharvest.gov",
       "Domain": "webharvest.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.welcometousa.gov",
       "Domain": "welcometousa.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://wethepeople.gov",
       "Domain": "wethepeople.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.wh.gov",
       "Domain": "wh.gov",
-      "HTTPS Enabled?": 2,
-      "HTTPS Enforced?": 1,
+      "Enforces HTTPS": 1,
       "SSL Labs Grade": 5,
-      "Strict Transport Security (HSTS)": 2
+      "Strict Transport Security (HSTS)": 2,
+      "Uses HTTPS": 2
     },
     {
       "Canonical": "http://www.whistleblowers.gov",
       "Domain": "whistleblowers.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "https://www.whitehouse.gov",
       "Domain": "whitehouse.gov",
-      "HTTPS Enabled?": 2,
-      "HTTPS Enforced?": 3,
+      "Enforces HTTPS": 3,
       "SSL Labs Grade": 5,
-      "Strict Transport Security (HSTS)": 2
+      "Strict Transport Security (HSTS)": 2,
+      "Uses HTTPS": 2
     },
     {
       "Canonical": "http://whitehouseconferenceonaging.gov",
       "Domain": "whitehouseconferenceonaging.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.whitehousedrugpolicy.gov",
       "Domain": "whitehousedrugpolicy.gov",
-      "HTTPS Enabled?": 2,
-      "HTTPS Enforced?": 1,
+      "Enforces HTTPS": 1,
       "SSL Labs Grade": 5,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 2
     },
     {
       "Canonical": "http://www.wildfire.gov",
       "Domain": "wildfire.gov",
-      "HTTPS Enabled?": 1,
-      "HTTPS Enforced?": 1,
+      "Enforces HTTPS": 1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 1
     },
     {
       "Canonical": "http://www.wildlifeadaptationstrategy.gov",
       "Domain": "wildlifeadaptationstrategy.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.windpoweringamerica.gov",
       "Domain": "windpoweringamerica.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://wizard.gov",
       "Domain": "wizard.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "https://www.wlci.gov",
       "Domain": "wlci.gov",
-      "HTTPS Enabled?": 2,
-      "HTTPS Enforced?": 2,
+      "Enforces HTTPS": 2,
       "SSL Labs Grade": 3,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 2
     },
     {
       "Canonical": "http://www.womenbiz.gov",
       "Domain": "womenbiz.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "https://www.womenfarmerclaims.gov",
       "Domain": "womenfarmerclaims.gov",
-      "HTTPS Enabled?": 1,
-      "HTTPS Enforced?": 3,
+      "Enforces HTTPS": 3,
       "SSL Labs Grade": 2,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 1
     },
     {
       "Canonical": "http://womenshealth.gov",
       "Domain": "womenshealth.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://womenshistorymonth.gov",
       "Domain": "womenshistorymonth.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "https://www.workplace.gov",
       "Domain": "workplace.gov",
-      "HTTPS Enabled?": 2,
-      "HTTPS Enforced?": 3,
+      "Enforces HTTPS": 3,
       "SSL Labs Grade": 4,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 2
     },
     {
       "Canonical": "http://www.worlddigitallibrary.gov",
       "Domain": "worlddigitallibrary.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://worldwar1centennial.gov",
       "Domain": "worldwar1centennial.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "https://www.wrp.gov",
       "Domain": "wrp.gov",
-      "HTTPS Enabled?": 2,
-      "HTTPS Enforced?": 3,
+      "Enforces HTTPS": 3,
       "SSL Labs Grade": 0,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 2
     },
     {
       "Canonical": "http://ymp.gov",
       "Domain": "ymp.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "https://youthgo.gov",
       "Domain": "youthgo.gov",
-      "HTTPS Enabled?": 2,
-      "HTTPS Enforced?": 3,
+      "Enforces HTTPS": 3,
       "SSL Labs Grade": 2,
-      "Strict Transport Security (HSTS)": 0
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 2
     },
     {
       "Canonical": "http://www.youthrules.gov",
       "Domain": "youthrules.gov",
-      "HTTPS Enabled?": 0,
-      "HTTPS Enforced?": -1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     }
   ]
 }

--- a/assets/data/tables/https/domains.json
+++ b/assets/data/tables/https/domains.json
@@ -14,7 +14,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://9-11commission.gov",
@@ -22,7 +22,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://911.gov",
@@ -30,7 +30,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://911commission.gov",
@@ -38,7 +38,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.aapi.gov",
@@ -46,7 +46,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.abandonedmines.gov",
@@ -62,7 +62,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://abmc.gov",
@@ -86,7 +86,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://achp.gov",
@@ -94,7 +94,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://acl.gov",
@@ -102,7 +102,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "https://www.acquisition.gov",
@@ -126,7 +126,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.ada.gov",
@@ -134,7 +134,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://adlnet.gov",
@@ -142,7 +142,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.admongo.gov",
@@ -150,7 +150,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.adr.gov",
@@ -158,7 +158,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.advantage.gov",
@@ -166,7 +166,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "https://afadvantage.gov",
@@ -198,7 +198,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.afterschool.gov",
@@ -206,7 +206,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.agingstats.gov",
@@ -214,7 +214,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.ahcpr.gov",
@@ -222,7 +222,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.ahrq.gov",
@@ -230,7 +230,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "https://aids.gov",
@@ -254,7 +254,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.alertaenlinea.gov",
@@ -270,7 +270,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://alzheimers.gov",
@@ -278,7 +278,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "https://www.ama.gov",
@@ -294,7 +294,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.america.gov",
@@ -310,7 +310,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://americanlatinomuseum.gov",
@@ -318,7 +318,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.americanmemory.gov",
@@ -326,7 +326,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.americasgreatoutdoors.gov",
@@ -334,7 +334,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.americasheroesatwork.gov",
@@ -342,7 +342,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.americaslibrary.gov",
@@ -350,7 +350,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.americasstory.gov",
@@ -358,7 +358,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.americastory.gov",
@@ -366,7 +366,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.americathebeautifulquarters.gov",
@@ -374,7 +374,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.americore.gov",
@@ -382,7 +382,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.americorp.gov",
@@ -390,7 +390,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.americorps.gov",
@@ -398,7 +398,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.americorpsconnect.gov",
@@ -406,7 +406,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.americorpsweek.gov",
@@ -414,7 +414,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "https://www.ameslab.gov",
@@ -435,10 +435,10 @@
     {
       "Canonical": "http://www.anl.gov",
       "Domain": "anl.gov",
-      "Enforces HTTPS": 0,
-      "SSL Labs Grade": 2,
-      "Strict Transport Security (HSTS)": 0,
-      "Uses HTTPS": 2
+      "Enforces HTTPS": -1,
+      "SSL Labs Grade": -1,
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.annualcreditreport.gov",
@@ -446,7 +446,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.anstaskforce.gov",
@@ -462,15 +462,15 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.aoc.gov",
       "Domain": "aoc.gov",
-      "Enforces HTTPS": 0,
-      "SSL Labs Grade": 5,
-      "Strict Transport Security (HSTS)": 0,
-      "Uses HTTPS": 2
+      "Enforces HTTPS": -1,
+      "SSL Labs Grade": -1,
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.ap.gov",
@@ -478,7 +478,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "https://www.applicationmanager.gov",
@@ -502,7 +502,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://archives.gov",
@@ -510,7 +510,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://arctic.gov",
@@ -534,7 +534,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.ars-grin.gov",
@@ -542,7 +542,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://arts.gov",
@@ -574,7 +574,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.askkaren.gov",
@@ -582,7 +582,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.astrongmiddleclass.gov",
@@ -606,7 +606,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.autocommunities.gov",
@@ -614,7 +614,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://aviationweather.gov",
@@ -630,7 +630,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.bam.gov",
@@ -638,7 +638,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://bankanswers.gov",
@@ -646,7 +646,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://bankcustomer.gov",
@@ -654,7 +654,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://bankcustomerassistance.gov",
@@ -662,7 +662,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://bankhelp.gov",
@@ -670,7 +670,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://banknet.gov",
@@ -678,7 +678,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.bankruptcy.gov",
@@ -686,7 +686,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.bbg.gov",
@@ -694,7 +694,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.bcfp.gov",
@@ -702,7 +702,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://bea.gov",
@@ -718,7 +718,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.benefits.gov",
@@ -726,7 +726,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://bep.gov",
@@ -734,7 +734,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.bestbonesforever.gov",
@@ -742,7 +742,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.betobaccofree.gov",
@@ -750,7 +750,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.bfelob.gov",
@@ -774,7 +774,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.bioeco.gov",
@@ -782,7 +782,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://bioethics.gov",
@@ -798,7 +798,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.biometriccoe.gov",
@@ -806,7 +806,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://biometrics.gov",
@@ -814,7 +814,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://biopreferred.gov",
@@ -838,7 +838,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.bldrdoc.gov",
@@ -846,15 +846,15 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.blm.gov",
       "Domain": "blm.gov",
-      "Enforces HTTPS": 0,
-      "SSL Labs Grade": 3,
-      "Strict Transport Security (HSTS)": 0,
-      "Uses HTTPS": 2
+      "Enforces HTTPS": -1,
+      "SSL Labs Grade": -1,
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://blmntl.gov",
@@ -862,7 +862,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.bls.gov",
@@ -870,15 +870,15 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.bnl.gov",
       "Domain": "bnl.gov",
-      "Enforces HTTPS": 0,
-      "SSL Labs Grade": 3,
-      "Strict Transport Security (HSTS)": 0,
-      "Uses HTTPS": 2
+      "Enforces HTTPS": -1,
+      "SSL Labs Grade": -1,
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.boem.gov",
@@ -886,7 +886,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://boemre.gov",
@@ -894,7 +894,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://bondpro.gov",
@@ -902,7 +902,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.bop.gov",
@@ -910,7 +910,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.bpa.gov",
@@ -926,7 +926,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.broadband.gov",
@@ -934,7 +934,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://broadbandmap.gov",
@@ -942,7 +942,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.browsetopics.gov",
@@ -950,7 +950,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.bsee.gov",
@@ -958,7 +958,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.bts.gov",
@@ -966,7 +966,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.budget.gov",
@@ -982,7 +982,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.business.gov",
@@ -990,7 +990,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.businessusa.gov",
@@ -1006,7 +1006,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://buyusa.gov",
@@ -1014,7 +1014,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.c3.gov",
@@ -1022,7 +1022,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.cancer.gov",
@@ -1030,7 +1030,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.cancernet.gov",
@@ -1038,7 +1038,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "https://cao.gov",
@@ -1054,7 +1054,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.capitolflags.gov",
@@ -1062,7 +1062,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.capitolhill.gov",
@@ -1070,7 +1070,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.capnhq.gov",
@@ -1086,7 +1086,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.casl.gov",
@@ -1094,7 +1094,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://cbca.gov",
@@ -1102,7 +1102,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.cbo.gov",
@@ -1118,7 +1118,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.cbp.gov",
@@ -1126,7 +1126,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://ccac.gov",
@@ -1134,7 +1134,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.ccr.gov",
@@ -1150,7 +1150,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.cdco.gov",
@@ -1158,7 +1158,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://cdfifund.gov",
@@ -1174,7 +1174,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.cecc.gov",
@@ -1182,7 +1182,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://cendi.gov",
@@ -1190,7 +1190,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://census.gov",
@@ -1198,7 +1198,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://cfa.gov",
@@ -1238,7 +1238,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.cfpb.gov",
@@ -1246,15 +1246,15 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.cftc.gov",
       "Domain": "cftc.gov",
-      "Enforces HTTPS": 0,
-      "SSL Labs Grade": 5,
-      "Strict Transport Security (HSTS)": 0,
-      "Uses HTTPS": 1
+      "Enforces HTTPS": -1,
+      "SSL Labs Grade": -1,
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.challenge.gov",
@@ -1270,7 +1270,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://change.gov",
@@ -1278,7 +1278,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://chcoc.gov",
@@ -1294,7 +1294,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.childreninadversity.gov",
@@ -1302,7 +1302,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.childstats.gov",
@@ -1310,7 +1310,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "https://childwelfare.gov",
@@ -1374,7 +1374,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://civilianresponsecorps.gov",
@@ -1382,7 +1382,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://civilrightsusa.gov",
@@ -1406,7 +1406,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "https://clinicaltrials.gov",
@@ -1422,7 +1422,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.clubdrugs.gov",
@@ -1430,7 +1430,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://cms.gov",
@@ -1446,7 +1446,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.cncs.gov",
@@ -1454,7 +1454,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://cncsoig.gov",
@@ -1462,7 +1462,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.cns.gov",
@@ -1470,7 +1470,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "https://www.cnss.gov",
@@ -1486,7 +1486,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://coastalamerica.gov",
@@ -1494,7 +1494,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.college.gov",
@@ -1502,7 +1502,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://collegedrinkingprevention.gov",
@@ -1510,7 +1510,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.collegenavigator.gov",
@@ -1518,15 +1518,15 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.commerce.gov",
       "Domain": "commerce.gov",
-      "Enforces HTTPS": 0,
-      "SSL Labs Grade": 2,
-      "Strict Transport Security (HSTS)": 0,
-      "Uses HTTPS": 2
+      "Enforces HTTPS": -1,
+      "SSL Labs Grade": -1,
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.complaintreferralexpress.gov",
@@ -1542,7 +1542,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://comptrollerofthecurrency.gov",
@@ -1550,7 +1550,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.computers4learning.gov",
@@ -1558,7 +1558,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://computersforlearning.gov",
@@ -1582,7 +1582,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.congressionalrecord.gov",
@@ -1590,7 +1590,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.connect.gov",
@@ -1614,7 +1614,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.consumerbureau.gov",
@@ -1622,7 +1622,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.consumerfinance.gov",
@@ -1630,7 +1630,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.consumerfinancial.gov",
@@ -1638,7 +1638,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.consumerfinancialbureau.gov",
@@ -1646,7 +1646,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.consumerfinancialprotectionbureau.gov",
@@ -1654,7 +1654,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.consumerprotection.gov",
@@ -1662,7 +1662,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.consumerprotectionbureau.gov",
@@ -1670,7 +1670,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "https://consumersentinel.gov",
@@ -1694,7 +1694,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "https://www.contractdirectory.gov",
@@ -1710,7 +1710,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://copyright.gov",
@@ -1718,7 +1718,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.coralreef.gov",
@@ -1726,7 +1726,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.cosponsor.gov",
@@ -1734,7 +1734,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.counterwmd.gov",
@@ -1742,7 +1742,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "https://www.cpars.gov",
@@ -1774,7 +1774,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://crimevictims.gov",
@@ -1782,7 +1782,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.crt2014-2024review.gov",
@@ -1790,7 +1790,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.csb.gov",
@@ -1798,7 +1798,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://csce.gov",
@@ -1806,7 +1806,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.csosa.fed.us",
@@ -1814,7 +1814,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://csosa.gov",
@@ -1822,7 +1822,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://cttso.gov",
@@ -1830,7 +1830,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "https://www.cuidadodesalud.gov",
@@ -1846,7 +1846,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://cwc.gov",
@@ -1854,7 +1854,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.cybercrime.gov",
@@ -1862,7 +1862,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.data.gov",
@@ -1878,7 +1878,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.dea.gov",
@@ -1886,7 +1886,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://deadiversion.gov",
@@ -1894,7 +1894,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.defense.gov",
@@ -1902,7 +1902,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.democraticleader.gov",
@@ -1910,7 +1910,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.democraticwhip.gov",
@@ -1918,7 +1918,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.dems.gov",
@@ -1926,7 +1926,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://denali.gov",
@@ -1950,15 +1950,15 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.dhs.gov",
       "Domain": "dhs.gov",
-      "Enforces HTTPS": 0,
-      "SSL Labs Grade": 3,
-      "Strict Transport Security (HSTS)": 0,
-      "Uses HTTPS": 2
+      "Enforces HTTPS": -1,
+      "SSL Labs Grade": -1,
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.diabetescommittee.gov",
@@ -1966,7 +1966,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.dietaryguidelines.gov",
@@ -1974,7 +1974,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.digitalgov.gov",
@@ -1990,7 +1990,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://digitalpreservation.gov",
@@ -1998,7 +1998,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.digitalstewardship.gov",
@@ -2006,7 +2006,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://digitizationguidelines.gov",
@@ -2014,7 +2014,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "https://www.directoasucuenta.gov",
@@ -2035,10 +2035,10 @@
     {
       "Canonical": "http://www.disasterassistance.gov",
       "Domain": "disasterassistance.gov",
-      "Enforces HTTPS": 0,
-      "SSL Labs Grade": 3,
-      "Strict Transport Security (HSTS)": 0,
-      "Uses HTTPS": 2
+      "Enforces HTTPS": -1,
+      "SSL Labs Grade": -1,
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://disasterhousing.gov",
@@ -2046,7 +2046,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://distracteddriving.gov",
@@ -2054,7 +2054,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.distraction.gov",
@@ -2062,7 +2062,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.dna.gov",
@@ -2070,7 +2070,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.dnfsb.gov",
@@ -2078,7 +2078,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.dni.gov",
@@ -2086,7 +2086,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.dnsops.gov",
@@ -2102,15 +2102,15 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "https://www.docline.gov",
       "Domain": "docline.gov",
-      "Enforces HTTPS": 0,
-      "SSL Labs Grade": 3,
-      "Strict Transport Security (HSTS)": 0,
-      "Uses HTTPS": 2
+      "Enforces HTTPS": -1,
+      "SSL Labs Grade": -1,
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.dod.gov",
@@ -2118,7 +2118,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.doe.gov",
@@ -2126,7 +2126,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.doeal.gov",
@@ -2134,7 +2134,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.doi.gov",
@@ -2142,7 +2142,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.doioig.gov",
@@ -2158,7 +2158,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://dol.gov",
@@ -2174,7 +2174,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "https://donotcall.gov",
@@ -2190,15 +2190,15 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.dot.gov",
       "Domain": "dot.gov",
-      "Enforces HTTPS": 0,
-      "SSL Labs Grade": 3,
-      "Strict Transport Security (HSTS)": 0,
-      "Uses HTTPS": 2
+      "Enforces HTTPS": -1,
+      "SSL Labs Grade": -1,
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "https://www.dotgov.gov",
@@ -2222,7 +2222,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://dottrcc.gov",
@@ -2230,7 +2230,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://dra.gov",
@@ -2238,7 +2238,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.drought.gov",
@@ -2262,7 +2262,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.drywallresponse.gov",
@@ -2270,7 +2270,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "https://www.dsac.gov",
@@ -2286,7 +2286,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.e-qip.gov",
@@ -2294,7 +2294,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://e3.gov",
@@ -2302,7 +2302,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.eac.gov",
@@ -2310,7 +2310,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.earmarks.gov",
@@ -2326,7 +2326,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.ecfr.gov",
@@ -2334,7 +2334,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "https://economicinclusion.gov",
@@ -2350,7 +2350,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://ecopartnerships.gov",
@@ -2358,7 +2358,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "https://www.ecpic.gov",
@@ -2390,7 +2390,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.edison.gov",
@@ -2398,15 +2398,15 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.edpubs.gov",
       "Domain": "edpubs.gov",
-      "Enforces HTTPS": 0,
-      "SSL Labs Grade": 0,
-      "Strict Transport Security (HSTS)": 0,
-      "Uses HTTPS": 2
+      "Enforces HTTPS": -1,
+      "SSL Labs Grade": -1,
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.education.gov",
@@ -2414,7 +2414,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.educationjobsfund.gov",
@@ -2422,7 +2422,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://eeoc.gov",
@@ -2430,7 +2430,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.eforms.gov",
@@ -2438,7 +2438,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "https://www.eftps.gov",
@@ -2462,7 +2462,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://eisenhowermemorial.gov",
@@ -2470,7 +2470,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.eldercare.gov",
@@ -2486,7 +2486,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "https://www.employeeexpress.gov",
@@ -2510,7 +2510,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://endingthedocumentgame.gov",
@@ -2518,7 +2518,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://energy.gov",
@@ -2526,7 +2526,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.energycodes.gov",
@@ -2542,7 +2542,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.energysaver.gov",
@@ -2550,7 +2550,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.energysavers.gov",
@@ -2558,7 +2558,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.energystar.gov",
@@ -2582,7 +2582,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.epa-otis.gov",
@@ -2590,7 +2590,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://epa.gov",
@@ -2598,7 +2598,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.epls.gov",
@@ -2614,7 +2614,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://esa.gov",
@@ -2638,7 +2638,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://espanolforlawenforcement.gov",
@@ -2646,7 +2646,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "https://www.esrs.gov",
@@ -2678,7 +2678,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.evergladesrestoration.gov",
@@ -2686,7 +2686,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.execsec.gov",
@@ -2694,7 +2694,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.exim.gov",
@@ -2702,7 +2702,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.exploretsp.gov",
@@ -2710,7 +2710,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://export.gov",
@@ -2718,7 +2718,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://eyenote.gov",
@@ -2726,7 +2726,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.faa.gov",
@@ -2739,10 +2739,10 @@
     {
       "Canonical": "http://www.faasafety.gov",
       "Domain": "faasafety.gov",
-      "Enforces HTTPS": 0,
-      "SSL Labs Grade": 3,
-      "Strict Transport Security (HSTS)": 0,
-      "Uses HTTPS": 2
+      "Enforces HTTPS": -1,
+      "SSL Labs Grade": -1,
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://faca.gov",
@@ -2758,7 +2758,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://fafsa.gov",
@@ -2771,10 +2771,10 @@
     {
       "Canonical": "http://www.fai.gov",
       "Domain": "fai.gov",
-      "Enforces HTTPS": 0,
-      "SSL Labs Grade": 0,
-      "Strict Transport Security (HSTS)": 0,
-      "Uses HTTPS": 1
+      "Enforces HTTPS": -1,
+      "SSL Labs Grade": -1,
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "https://www.fan.gov",
@@ -2798,7 +2798,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.fara.gov",
@@ -2806,7 +2806,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "https://www.farmerclaims.gov",
@@ -2822,7 +2822,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "https://fatherhood.gov",
@@ -2835,10 +2835,10 @@
     {
       "Canonical": "http://www.fbi.gov",
       "Domain": "fbi.gov",
-      "Enforces HTTPS": 0,
-      "SSL Labs Grade": 4,
-      "Strict Transport Security (HSTS)": 0,
-      "Uses HTTPS": 2
+      "Enforces HTTPS": -1,
+      "SSL Labs Grade": -1,
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.fbiic.gov",
@@ -2886,7 +2886,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.fcg.gov",
@@ -2894,7 +2894,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.fcic.gov",
@@ -2902,7 +2902,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://fcsic.gov",
@@ -2910,7 +2910,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://fcsm.gov",
@@ -2918,7 +2918,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.fda.gov",
@@ -2926,7 +2926,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "https://fdic.gov",
@@ -2942,7 +2942,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.fdicconnect.gov",
@@ -2950,7 +2950,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://fdicig.gov",
@@ -2958,7 +2958,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://fdicoig.gov",
@@ -2966,7 +2966,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://fdicseguro.gov",
@@ -2974,7 +2974,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.fdlp.gov",
@@ -2982,7 +2982,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.fdms.gov",
@@ -2990,7 +2990,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "https://www.fdr.gov",
@@ -2998,7 +2998,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.fdsys.gov",
@@ -3006,7 +3006,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://feb.gov",
@@ -3014,7 +3014,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://fec.gov",
@@ -3022,7 +3022,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.fedbizopps.gov",
@@ -3046,7 +3046,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.federalcourts.gov",
@@ -3054,7 +3054,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://federalinvestments.gov",
@@ -3062,7 +3062,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.federaljobs.gov",
@@ -3070,7 +3070,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.federalprobation.gov",
@@ -3078,7 +3078,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "https://www.federalregister.gov",
@@ -3094,7 +3094,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://federalreserve.gov",
@@ -3102,7 +3102,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://federalreserveconsumerhelp.gov",
@@ -3118,7 +3118,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.federaltransparency.gov",
@@ -3126,7 +3126,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.fedforms.gov",
@@ -3134,7 +3134,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://fedidcard.gov",
@@ -3142,7 +3142,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://fedinvest.gov",
@@ -3150,7 +3150,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.fedjobs.gov",
@@ -3158,7 +3158,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "https://fedpartnership.gov",
@@ -3182,7 +3182,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.fedreg.gov",
@@ -3198,7 +3198,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://fedshirevets.gov",
@@ -3206,7 +3206,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://fedstats.gov",
@@ -3214,15 +3214,15 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://feedthefuture.gov",
       "Domain": "feedthefuture.gov",
-      "Enforces HTTPS": 0,
-      "SSL Labs Grade": 5,
-      "Strict Transport Security (HSTS)": 0,
-      "Uses HTTPS": 2
+      "Enforces HTTPS": -1,
+      "SSL Labs Grade": -1,
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.fegli.gov",
@@ -3254,7 +3254,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://fercalt.gov",
@@ -3262,7 +3262,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.ffiec.gov",
@@ -3286,15 +3286,15 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.fhfa.gov",
       "Domain": "fhfa.gov",
-      "Enforces HTTPS": 0,
-      "SSL Labs Grade": 3,
-      "Strict Transport Security (HSTS)": 0,
-      "Uses HTTPS": 1
+      "Enforces HTTPS": -1,
+      "SSL Labs Grade": -1,
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.fhfaoig.gov",
@@ -3302,7 +3302,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://fido.gov",
@@ -3310,7 +3310,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://fightingmalaria.gov",
@@ -3318,7 +3318,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://financialresearch.gov",
@@ -3326,7 +3326,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.financialstability.gov",
@@ -3334,7 +3334,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://fincen.gov",
@@ -3374,7 +3374,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.firescience.gov",
@@ -3390,7 +3390,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.firstgov.gov",
@@ -3398,7 +3398,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://firstnet.gov",
@@ -3406,7 +3406,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.firstresponder.gov",
@@ -3414,15 +3414,15 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "https://www.firstrespondertraining.gov",
       "Domain": "firstrespondertraining.gov",
-      "Enforces HTTPS": 0,
-      "SSL Labs Grade": 3,
-      "Strict Transport Security (HSTS)": 0,
-      "Uses HTTPS": 2
+      "Enforces HTTPS": -1,
+      "SSL Labs Grade": -1,
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.fiscalcommission.gov",
@@ -3430,7 +3430,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.fishwatch.gov",
@@ -3438,7 +3438,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://fitness.gov",
@@ -3446,7 +3446,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.fjc.gov",
@@ -3454,7 +3454,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "https://www.fleta.gov",
@@ -3483,10 +3483,10 @@
     {
       "Canonical": "https://www.floodsmart.gov",
       "Domain": "floodsmart.gov",
-      "Enforces HTTPS": 0,
-      "SSL Labs Grade": 4,
-      "Strict Transport Security (HSTS)": 0,
-      "Uses HTTPS": 2
+      "Enforces HTTPS": -1,
+      "SSL Labs Grade": -1,
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://flra.gov",
@@ -3494,7 +3494,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.flu.gov",
@@ -3502,7 +3502,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.fmc.gov",
@@ -3510,15 +3510,15 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.fmcs.gov",
       "Domain": "fmcs.gov",
-      "Enforces HTTPS": 0,
-      "SSL Labs Grade": 0,
-      "Strict Transport Security (HSTS)": 0,
-      "Uses HTTPS": 2
+      "Enforces HTTPS": -1,
+      "SSL Labs Grade": -1,
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://fmi.gov",
@@ -3526,7 +3526,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.fmip.gov",
@@ -3534,7 +3534,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://fmshrc.gov",
@@ -3558,7 +3558,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.foodsafety.gov",
@@ -3566,7 +3566,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.foodsafetyjobs.gov",
@@ -3574,7 +3574,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.foodsafetyworkinggroup.gov",
@@ -3582,7 +3582,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://fordlibrarymuseum.gov",
@@ -3590,7 +3590,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://foreignassistance.gov",
@@ -3598,7 +3598,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://forestsandrangelands.gov",
@@ -3606,7 +3606,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.forfeiture.gov",
@@ -3614,7 +3614,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.forms.gov",
@@ -3622,7 +3622,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.fpds.gov",
@@ -3638,7 +3638,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.freecreditreport.gov",
@@ -3646,7 +3646,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://frtib.gov",
@@ -3654,7 +3654,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://frtr.gov",
@@ -3662,7 +3662,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.fruitsandveggiesmatter.gov",
@@ -3670,7 +3670,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.fs.fed.us",
@@ -3678,7 +3678,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.fsafeds.gov",
@@ -3686,7 +3686,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.fsapubs.gov",
@@ -3694,7 +3694,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "https://www.fsd.gov",
@@ -3718,7 +3718,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "https://www.fsrs.gov",
@@ -3734,7 +3734,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "https://www.ftc.gov",
@@ -3774,15 +3774,15 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.fvap.gov",
       "Domain": "fvap.gov",
-      "Enforces HTTPS": 0,
-      "SSL Labs Grade": 5,
-      "Strict Transport Security (HSTS)": 0,
-      "Uses HTTPS": 2
+      "Enforces HTTPS": -1,
+      "SSL Labs Grade": -1,
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.fws.gov",
@@ -3822,7 +3822,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.gcmrc.gov",
@@ -3830,7 +3830,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.genbank.gov",
@@ -3838,7 +3838,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.genome.gov",
@@ -3854,7 +3854,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.geomac.gov",
@@ -3862,7 +3862,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://geoplatform.gov",
@@ -3878,7 +3878,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.getinvolved.gov",
@@ -3886,7 +3886,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://getsmartaboutdrugs.gov",
@@ -3894,7 +3894,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.getyouhome.gov",
@@ -3902,7 +3902,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://ghi.gov",
@@ -3910,7 +3910,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.ginniemae.gov",
@@ -3918,7 +3918,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://girlshealth.gov",
@@ -3926,15 +3926,15 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.globalchange.gov",
       "Domain": "globalchange.gov",
-      "Enforces HTTPS": 0,
-      "SSL Labs Grade": 5,
-      "Strict Transport Security (HSTS)": 0,
-      "Uses HTTPS": 2
+      "Enforces HTTPS": -1,
+      "SSL Labs Grade": -1,
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.globalentry.gov",
@@ -3942,7 +3942,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.globalhealth.gov",
@@ -3950,7 +3950,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.globe.gov",
@@ -3966,7 +3966,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.gobiernousa.gov",
@@ -3974,7 +3974,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "https://www.godirect.gov",
@@ -3990,7 +3990,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://golearn.gov",
@@ -3998,7 +3998,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.gop.gov",
@@ -4006,7 +4006,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.gopconference.gov",
@@ -4014,7 +4014,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.gopleader.gov",
@@ -4022,7 +4022,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.govbenefits.gov",
@@ -4030,7 +4030,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.governmentjobs.gov",
@@ -4038,7 +4038,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.govloans.gov",
@@ -4046,7 +4046,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.govsales.gov",
@@ -4054,7 +4054,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://gpo.gov",
@@ -4062,7 +4062,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.gpoaccess.gov",
@@ -4070,7 +4070,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.gps.gov",
@@ -4078,7 +4078,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.grants.gov",
@@ -4086,7 +4086,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "https://grantsolutions.gov",
@@ -4102,7 +4102,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://greengov.gov",
@@ -4110,7 +4110,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.gsa.gov",
@@ -4118,7 +4118,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "https://gsaadvantage.gov",
@@ -4142,7 +4142,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "https://www.gsaig.gov",
@@ -4174,7 +4174,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "https://www.gwa.gov",
@@ -4190,7 +4190,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://harp.gov",
@@ -4198,7 +4198,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://hc.gov",
@@ -4206,7 +4206,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.hcqualitycommission.gov",
@@ -4214,7 +4214,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://health.gov",
@@ -4222,7 +4222,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "https://www.healthcare.gov",
@@ -4254,7 +4254,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://healthit.gov",
@@ -4270,7 +4270,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.healthypeople.gov",
@@ -4286,7 +4286,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.helpingamericasyouth.gov",
@@ -4294,7 +4294,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://helpwithmybank.gov",
@@ -4302,7 +4302,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://helpwithmycheckingaccount.gov",
@@ -4310,7 +4310,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://helpwithmycreditcard.gov",
@@ -4318,7 +4318,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://helpwithmycreditcardbank.gov",
@@ -4326,7 +4326,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://helpwithmymortgage.gov",
@@ -4334,7 +4334,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://helpwithmymortgagebank.gov",
@@ -4342,7 +4342,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.hhs.gov",
@@ -4350,7 +4350,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.hhsoig.gov",
@@ -4366,7 +4366,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.hill.gov",
@@ -4374,7 +4374,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "https://www.hispanicfarmerclaims.gov",
@@ -4390,7 +4390,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.hiv.gov",
@@ -4406,7 +4406,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.homelandsecurity.gov",
@@ -4414,7 +4414,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://homesales.gov",
@@ -4422,7 +4422,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.house.gov",
@@ -4438,7 +4438,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.housecommunications.gov",
@@ -4446,7 +4446,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.housedemocrats.gov",
@@ -4454,7 +4454,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.housedems.gov",
@@ -4462,7 +4462,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://houselive.gov",
@@ -4470,7 +4470,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.howto.gov",
@@ -4486,7 +4486,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "https://hru.gov",
@@ -4502,7 +4502,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "https://hsr.gov",
@@ -4518,7 +4518,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.hudoig.gov",
@@ -4542,7 +4542,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.hurricanes.gov",
@@ -4550,7 +4550,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://hydrogen.gov",
@@ -4558,7 +4558,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "https://www.iad.gov",
@@ -4574,7 +4574,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://iarpa-ideas.gov",
@@ -4590,7 +4590,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.iat.gov",
@@ -4614,7 +4614,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://ibwc.gov",
@@ -4622,7 +4622,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.ic3.gov",
@@ -4646,7 +4646,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.ice.gov",
@@ -4662,7 +4662,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://icjointduty.gov",
@@ -4670,7 +4670,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.identitytheft.gov",
@@ -4678,7 +4678,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://idmanagement.gov",
@@ -4694,7 +4694,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.iedison.gov",
@@ -4702,7 +4702,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "https://www.ignet.gov",
@@ -4734,7 +4734,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://indianaffairs.gov",
@@ -4742,7 +4742,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.inel.gov",
@@ -4750,7 +4750,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.info.gov",
@@ -4758,7 +4758,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "https://inl.gov",
@@ -4774,7 +4774,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "https://www.integrity.gov",
@@ -4798,7 +4798,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.interior.gov",
@@ -4806,7 +4806,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.interpol.gov",
@@ -4814,7 +4814,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://invasivespecies.gov",
@@ -4822,7 +4822,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.invasivespeciesinfo.gov",
@@ -4830,15 +4830,15 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://investor.gov",
       "Domain": "investor.gov",
-      "Enforces HTTPS": 0,
-      "SSL Labs Grade": 5,
-      "Strict Transport Security (HSTS)": 0,
-      "Uses HTTPS": 2
+      "Enforces HTTPS": -1,
+      "SSL Labs Grade": -1,
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "https://www.ioss.gov",
@@ -4870,7 +4870,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.ipp.gov",
@@ -4886,7 +4886,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.irs.gov",
@@ -4894,7 +4894,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.irsauctions.gov",
@@ -4902,7 +4902,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.irssales.gov",
@@ -4910,7 +4910,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.irsvideos.gov",
@@ -4918,7 +4918,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://ise.gov",
@@ -4926,7 +4926,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.isitdoneyet.gov",
@@ -4934,7 +4934,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "https://isotope.gov",
@@ -4966,7 +4966,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "https://itdashboard.gov",
@@ -4982,15 +4982,15 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.itis.gov",
       "Domain": "itis.gov",
-      "Enforces HTTPS": 0,
-      "SSL Labs Grade": 3,
-      "Strict Transport Security (HSTS)": 0,
-      "Uses HTTPS": 2
+      "Enforces HTTPS": -1,
+      "SSL Labs Grade": -1,
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.itrd.gov",
@@ -4998,7 +4998,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "https://www.its.gov",
@@ -5014,7 +5014,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.jccs.gov",
@@ -5046,7 +5046,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://jewishheritagemonth.gov",
@@ -5054,7 +5054,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.jimmycarterlibrary.gov",
@@ -5062,7 +5062,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.jmc.gov",
@@ -5070,7 +5070,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.jobcenter.gov",
@@ -5078,7 +5078,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.jobcorps.gov",
@@ -5102,7 +5102,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.justice.gov",
@@ -5110,7 +5110,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://justthinktwice.gov",
@@ -5118,7 +5118,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://juvenilecouncil.gov",
@@ -5126,7 +5126,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://jwod.gov",
@@ -5134,7 +5134,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.kids.gov",
@@ -5142,7 +5142,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://klamathrestoration.gov",
@@ -5158,7 +5158,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.lacoast.gov",
@@ -5174,7 +5174,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.landimaging.gov",
@@ -5182,7 +5182,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://lanl.gov",
@@ -5206,7 +5206,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.lbl.gov",
@@ -5219,18 +5219,18 @@
     {
       "Canonical": "http://lca.gov",
       "Domain": "lca.gov",
-      "Enforces HTTPS": 0,
-      "SSL Labs Grade": 3,
-      "Strict Transport Security (HSTS)": 0,
-      "Uses HTTPS": 2
+      "Enforces HTTPS": -1,
+      "SSL Labs Grade": -1,
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.lcacommons.gov",
       "Domain": "lcacommons.gov",
-      "Enforces HTTPS": 0,
-      "SSL Labs Grade": 2,
-      "Strict Transport Security (HSTS)": 0,
-      "Uses HTTPS": 2
+      "Enforces HTTPS": -1,
+      "SSL Labs Grade": -1,
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.lcrmscp.gov",
@@ -5238,7 +5238,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.learnandserve.gov",
@@ -5246,7 +5246,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "https://www.learnperformance.gov",
@@ -5262,7 +5262,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.legislativebranch.gov",
@@ -5270,7 +5270,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.lep.gov",
@@ -5278,7 +5278,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.letsmove.gov",
@@ -5286,7 +5286,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.library-of-congress.gov",
@@ -5294,7 +5294,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.libraryofcongress.gov",
@@ -5302,7 +5302,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.lifeline.gov",
@@ -5310,7 +5310,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.lis.gov",
@@ -5318,7 +5318,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.listo.gov",
@@ -5334,7 +5334,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.llis.gov",
@@ -5366,7 +5366,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://loc.gov",
@@ -5382,7 +5382,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.locimages.gov",
@@ -5390,7 +5390,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.locstore.gov",
@@ -5398,7 +5398,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.loctps.gov",
@@ -5406,7 +5406,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://longtermcare.gov",
@@ -5422,7 +5422,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.lowermississippivalleyscience.gov",
@@ -5430,7 +5430,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.lps.gov",
@@ -5438,7 +5438,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.lsc.gov",
@@ -5462,7 +5462,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.majorityleader.gov",
@@ -5470,7 +5470,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.majoritywhip.gov",
@@ -5478,7 +5478,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.makinghomeaffordable.gov",
@@ -5486,7 +5486,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://malwareinvestigator.gov",
@@ -5494,7 +5494,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://manufacturing.gov",
@@ -5502,7 +5502,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.mapaplanet.gov",
@@ -5510,7 +5510,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.mapstats.gov",
@@ -5518,7 +5518,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://marine.gov",
@@ -5526,7 +5526,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://marinecadastre.gov",
@@ -5534,7 +5534,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.marview.gov",
@@ -5542,7 +5542,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "https://www.max.gov",
@@ -5558,7 +5558,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "https://mcc.gov",
@@ -5574,7 +5574,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://mda.gov",
@@ -5598,7 +5598,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.medicalcountermeasures.gov",
@@ -5630,7 +5630,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.medlineplus.gov",
@@ -5638,7 +5638,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://medpac.gov",
@@ -5646,7 +5646,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.mentalhealth.gov",
@@ -5654,7 +5654,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.mesh.gov",
@@ -5662,7 +5662,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.mha.gov",
@@ -5670,7 +5670,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "https://www.mimedicare.gov",
@@ -5686,7 +5686,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.mlkday.gov",
@@ -5694,7 +5694,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://mmc.gov",
@@ -5702,7 +5702,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://mms.gov",
@@ -5710,7 +5710,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://moneyfactory.gov",
@@ -5718,15 +5718,15 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.moneyfactorystore.gov",
       "Domain": "moneyfactorystore.gov",
-      "Enforces HTTPS": 0,
-      "SSL Labs Grade": 3,
-      "Strict Transport Security (HSTS)": 0,
-      "Uses HTTPS": 2
+      "Enforces HTTPS": -1,
+      "SSL Labs Grade": -1,
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.mrgo.gov",
@@ -5742,7 +5742,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://msb.gov",
@@ -5758,7 +5758,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://mspb.gov",
@@ -5766,7 +5766,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://mtbs.gov",
@@ -5774,7 +5774,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.mycreditunion.gov",
@@ -5782,7 +5782,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.myfdic.gov",
@@ -5790,7 +5790,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://myfdicinsurance.gov",
@@ -5798,7 +5798,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.myloc.gov",
@@ -5806,7 +5806,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "https://mymedicare.gov",
@@ -5822,7 +5822,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.mynextmove.gov",
@@ -5830,7 +5830,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.myra.gov",
@@ -5846,7 +5846,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://nafri.gov",
@@ -5862,7 +5862,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://namus.gov",
@@ -5870,15 +5870,15 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://nano.gov",
       "Domain": "nano.gov",
-      "Enforces HTTPS": 0,
-      "SSL Labs Grade": 2,
-      "Strict Transport Security (HSTS)": 0,
-      "Uses HTTPS": 1
+      "Enforces HTTPS": -1,
+      "SSL Labs Grade": -1,
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.nara.gov",
@@ -5886,7 +5886,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.nasa.gov",
@@ -5902,7 +5902,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.nationalbank.gov",
@@ -5910,7 +5910,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://nationalbankhelp.gov",
@@ -5918,7 +5918,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.nationalbanknet.gov",
@@ -5926,7 +5926,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.nationalchildrensstudy.gov",
@@ -5950,7 +5950,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://nationalhousinglocator.gov",
@@ -5958,7 +5958,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://nationalmap.gov",
@@ -5966,7 +5966,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.nationalresourcedirectory.gov",
@@ -5982,7 +5982,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "https://www.nationalserviceresources.gov",
@@ -5998,7 +5998,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://nativeamericanheritagemonth.gov",
@@ -6006,7 +6006,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.navycash.gov",
@@ -6014,7 +6014,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.nbc.gov",
@@ -6030,7 +6030,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://nccrc.gov",
@@ -6046,7 +6046,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.ncd.gov",
@@ -6054,7 +6054,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.ncifcrf.gov",
@@ -6078,7 +6078,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "https://ncjrs.gov",
@@ -6118,7 +6118,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.ncua.gov",
@@ -6126,7 +6126,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.ndep.gov",
@@ -6134,7 +6134,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.ndop.gov",
@@ -6142,7 +6142,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.ndsa.gov",
@@ -6150,7 +6150,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.nea.gov",
@@ -6166,7 +6166,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.neh.gov",
@@ -6182,7 +6182,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.nel.gov",
@@ -6190,7 +6190,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.nemi.gov",
@@ -6206,7 +6206,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.nersc.gov",
@@ -6222,15 +6222,15 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.newmoney.gov",
       "Domain": "newmoney.gov",
-      "Enforces HTTPS": 0,
-      "SSL Labs Grade": 3,
-      "Strict Transport Security (HSTS)": 0,
-      "Uses HTTPS": 2
+      "Enforces HTTPS": -1,
+      "SSL Labs Grade": -1,
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "https://nfpors.gov",
@@ -6254,7 +6254,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://nhl.gov",
@@ -6262,7 +6262,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.nhtsa.gov",
@@ -6270,7 +6270,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.nibin.gov",
@@ -6278,7 +6278,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.nic.gov",
@@ -6294,7 +6294,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "https://www.niem.gov",
@@ -6318,7 +6318,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://nigc.gov",
@@ -6334,7 +6334,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://nihseniorhealth.gov",
@@ -6350,7 +6350,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.niosh.gov",
@@ -6358,7 +6358,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://nist.gov",
@@ -6382,7 +6382,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.nlm.gov",
@@ -6390,7 +6390,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://nlrb.gov",
@@ -6406,15 +6406,15 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.nmb.gov",
       "Domain": "nmb.gov",
-      "Enforces HTTPS": 0,
-      "SSL Labs Grade": 1,
-      "Strict Transport Security (HSTS)": 0,
-      "Uses HTTPS": 1
+      "Enforces HTTPS": -1,
+      "SSL Labs Grade": -1,
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://nmcourt.fed.us",
@@ -6422,7 +6422,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.nmic.gov",
@@ -6430,7 +6430,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.nmvtis.gov",
@@ -6438,7 +6438,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://nnlm.gov",
@@ -6454,7 +6454,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.noaawatch.gov",
@@ -6462,7 +6462,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.nolaenvironmental.gov",
@@ -6478,7 +6478,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "https://www.notalone.gov",
@@ -6494,7 +6494,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.nrc.gov",
@@ -6502,7 +6502,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "https://www.nrd.gov",
@@ -6515,10 +6515,10 @@
     {
       "Canonical": "http://www.nrel.gov",
       "Domain": "nrel.gov",
-      "Enforces HTTPS": 0,
-      "SSL Labs Grade": 3,
-      "Strict Transport Security (HSTS)": 0,
-      "Uses HTTPS": 2
+      "Enforces HTTPS": -1,
+      "SSL Labs Grade": -1,
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://nro.gov",
@@ -6526,7 +6526,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://nrojr.gov",
@@ -6534,7 +6534,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "https://www.nsa.gov",
@@ -6550,15 +6550,15 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.nsf.gov",
       "Domain": "nsf.gov",
-      "Enforces HTTPS": 0,
-      "SSL Labs Grade": 0,
-      "Strict Transport Security (HSTS)": 0,
-      "Uses HTTPS": 2
+      "Enforces HTTPS": -1,
+      "SSL Labs Grade": -1,
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.nsopw.gov",
@@ -6566,7 +6566,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.nstic.gov",
@@ -6582,7 +6582,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.ntdprogram.gov",
@@ -6606,7 +6606,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.ntsb.gov",
@@ -6614,7 +6614,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.nutrition.gov",
@@ -6622,7 +6622,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.nutritionevidencelibrary.gov",
@@ -6630,7 +6630,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.nvtc.gov",
@@ -6638,7 +6638,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "https://www.nwbc.gov",
@@ -6662,7 +6662,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://occhelps.gov",
@@ -6670,7 +6670,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.odni.gov",
@@ -6678,7 +6678,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.oea.gov",
@@ -6694,7 +6694,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "https://www.ofda.gov",
@@ -6710,7 +6710,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.ofr.gov",
@@ -6718,7 +6718,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://oge.gov",
@@ -6726,7 +6726,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.ogis.gov",
@@ -6734,7 +6734,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://ojjdp.gov",
@@ -6742,7 +6742,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://ojp.gov",
@@ -6750,7 +6750,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.omb.gov",
@@ -6766,7 +6766,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.ondcp.gov",
@@ -6790,7 +6790,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.onlineonguard.gov",
@@ -6798,7 +6798,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://onlinewbc.gov",
@@ -6806,7 +6806,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://onrr.gov",
@@ -6814,7 +6814,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.openinternet.gov",
@@ -6822,7 +6822,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "https://www.opensource.gov",
@@ -6838,7 +6838,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "https://www.opic.gov",
@@ -6862,15 +6862,15 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.orau.gov",
       "Domain": "orau.gov",
-      "Enforces HTTPS": 0,
-      "SSL Labs Grade": 3,
-      "Strict Transport Security (HSTS)": 0,
-      "Uses HTTPS": 2
+      "Enforces HTTPS": -1,
+      "SSL Labs Grade": -1,
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.organdonor.gov",
@@ -6878,7 +6878,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.ornl.gov",
@@ -6926,7 +6926,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.osm.gov",
@@ -6934,7 +6934,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.osmre.gov",
@@ -6942,15 +6942,15 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.osti.gov",
       "Domain": "osti.gov",
-      "Enforces HTTPS": 0,
-      "SSL Labs Grade": 3,
-      "Strict Transport Security (HSTS)": 0,
-      "Uses HTTPS": 2
+      "Enforces HTTPS": -1,
+      "SSL Labs Grade": -1,
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.ostp.gov",
@@ -6966,7 +6966,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://ots.gov",
@@ -6974,7 +6974,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://ourdocuments.gov",
@@ -6982,7 +6982,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://ovc.gov",
@@ -6990,7 +6990,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "https://www.ovcttac.gov",
@@ -7014,7 +7014,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.papahanaumokuakea.gov",
@@ -7022,7 +7022,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.partner4solutions.gov",
@@ -7030,7 +7030,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://patriotbonds.gov",
@@ -7038,7 +7038,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "https://pay.gov",
@@ -7070,7 +7070,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.pcip.gov",
@@ -7078,7 +7078,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "https://pclob.gov",
@@ -7094,7 +7094,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://peacecore.gov",
@@ -7102,7 +7102,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://peacecorp.gov",
@@ -7110,15 +7110,15 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.peacecorps.gov",
       "Domain": "peacecorps.gov",
-      "Enforces HTTPS": 0,
-      "SSL Labs Grade": 2,
-      "Strict Transport Security (HSTS)": 0,
-      "Uses HTTPS": 2
+      "Enforces HTTPS": -1,
+      "SSL Labs Grade": -1,
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.pentagon.gov",
@@ -7126,7 +7126,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.pepfar.gov",
@@ -7134,7 +7134,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.performance.gov",
@@ -7142,7 +7142,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.phe.gov",
@@ -7166,7 +7166,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.plainlanguage.gov",
@@ -7174,7 +7174,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://pmf.gov",
@@ -7190,7 +7190,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.pnl.gov",
@@ -7214,7 +7214,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.poolsafety.gov",
@@ -7222,7 +7222,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.postoffice.gov",
@@ -7230,7 +7230,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://ppdcecc.gov",
@@ -7238,7 +7238,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "https://www.ppirs.gov",
@@ -7254,15 +7254,15 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.prc.gov",
       "Domain": "prc.gov",
-      "Enforces HTTPS": 0,
-      "SSL Labs Grade": 3,
-      "Strict Transport Security (HSTS)": 0,
-      "Uses HTTPS": 2
+      "Enforces HTTPS": -1,
+      "SSL Labs Grade": -1,
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.pregunteleakaren.gov",
@@ -7270,7 +7270,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://preserveamerica.gov",
@@ -7278,7 +7278,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.presidentialdocuments.gov",
@@ -7286,15 +7286,15 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.presidentialserviceawards.gov",
       "Domain": "presidentialserviceawards.gov",
-      "Enforces HTTPS": 0,
-      "SSL Labs Grade": 3,
-      "Strict Transport Security (HSTS)": 0,
-      "Uses HTTPS": 2
+      "Enforces HTTPS": -1,
+      "SSL Labs Grade": -1,
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.presidio.gov",
@@ -7302,7 +7302,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.presidiotrust.gov",
@@ -7310,7 +7310,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://pretrialservices.gov",
@@ -7318,7 +7318,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.primarysources.gov",
@@ -7326,7 +7326,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.projectsafechildhood.gov",
@@ -7334,7 +7334,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.projectsafeneighborhoods.gov",
@@ -7342,7 +7342,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.protecciondelconsumidor.gov",
@@ -7366,7 +7366,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.psc.gov",
@@ -7382,7 +7382,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "https://psob.gov",
@@ -7398,7 +7398,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.pubmed.gov",
@@ -7414,7 +7414,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "https://www.qatesttwai.gov",
@@ -7430,7 +7430,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.quick.gov",
@@ -7438,7 +7438,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.rcfl.gov",
@@ -7446,7 +7446,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.reachhigher.gov",
@@ -7462,7 +7462,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.ready.gov",
@@ -7486,7 +7486,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://realestatesales.gov",
@@ -7510,7 +7510,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.recovery.gov",
@@ -7518,7 +7518,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://recoverymonth.gov",
@@ -7526,15 +7526,15 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.recreation.gov",
       "Domain": "recreation.gov",
-      "Enforces HTTPS": 0,
-      "SSL Labs Grade": 3,
-      "Strict Transport Security (HSTS)": 0,
-      "Uses HTTPS": 2
+      "Enforces HTTPS": -1,
+      "SSL Labs Grade": -1,
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.reentry.gov",
@@ -7542,7 +7542,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://reginfo.gov",
@@ -7550,7 +7550,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.regulation.gov",
@@ -7558,7 +7558,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.regulations.gov",
@@ -7566,7 +7566,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://relocatefeds.gov",
@@ -7574,7 +7574,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://reo.gov",
@@ -7582,7 +7582,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.reportband.gov",
@@ -7590,7 +7590,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.republicans.gov",
@@ -7598,7 +7598,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.research.gov",
@@ -7622,7 +7622,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://rocis.gov",
@@ -7638,7 +7638,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://sac.gov",
@@ -7646,7 +7646,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.safecom.gov",
@@ -7662,7 +7662,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.safercar.gov",
@@ -7670,7 +7670,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.saferproduct.gov",
@@ -7678,15 +7678,15 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.saferproducts.gov",
       "Domain": "saferproducts.gov",
-      "Enforces HTTPS": 0,
-      "SSL Labs Grade": 3,
-      "Strict Transport Security (HSTS)": 0,
-      "Uses HTTPS": 2
+      "Enforces HTTPS": -1,
+      "SSL Labs Grade": -1,
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://safertruck.gov",
@@ -7694,7 +7694,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "https://safetyact.gov",
@@ -7710,7 +7710,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.safeyouth.gov",
@@ -7718,7 +7718,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.salmonrecovery.gov",
@@ -7742,7 +7742,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.sandia.gov",
@@ -7750,7 +7750,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.save.gov",
@@ -7774,7 +7774,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://savingsbonds.gov",
@@ -7782,7 +7782,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://savingsbondwizard.gov",
@@ -7790,7 +7790,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "https://www.sba.gov",
@@ -7814,7 +7814,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.science.gov",
@@ -7838,7 +7838,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "https://www.sciencebase.gov",
@@ -7854,7 +7854,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.scijinks.gov",
@@ -7862,7 +7862,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.scra.gov",
@@ -7870,7 +7870,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.sdr.gov",
@@ -7878,7 +7878,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.sec.gov",
@@ -7894,7 +7894,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://section108.gov",
@@ -7902,7 +7902,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://section508.gov",
@@ -7918,7 +7918,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://segurosocial.gov",
@@ -7926,7 +7926,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.selectagents.gov",
@@ -7934,7 +7934,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.selectusa.gov",
@@ -7942,15 +7942,15 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.senate.gov",
       "Domain": "senate.gov",
-      "Enforces HTTPS": 0,
-      "SSL Labs Grade": 3,
-      "Strict Transport Security (HSTS)": 0,
-      "Uses HTTPS": 2
+      "Enforces HTTPS": -1,
+      "SSL Labs Grade": -1,
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.senatecalendar.gov",
@@ -7958,7 +7958,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.senaterestaurants.gov",
@@ -7966,7 +7966,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.seniorcorps.gov",
@@ -7974,7 +7974,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.seniors.gov",
@@ -7982,7 +7982,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.sentinel.gov",
@@ -7998,7 +7998,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.service.gov",
@@ -8006,7 +8006,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.servicelearning.gov",
@@ -8014,7 +8014,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.servicemembers.gov",
@@ -8022,7 +8022,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "https://sftool.gov",
@@ -8038,7 +8038,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://sierrawild.gov",
@@ -8046,7 +8046,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.sigtarp.gov",
@@ -8054,7 +8054,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.siteidiq.gov",
@@ -8062,7 +8062,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://slgs.gov",
@@ -8070,7 +8070,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.smallbusiness.gov",
@@ -8078,7 +8078,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://smart.gov",
@@ -8086,7 +8086,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.smartcheck.gov",
@@ -8094,7 +8094,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "https://www.smartgrid.gov",
@@ -8118,7 +8118,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://sns.gov",
@@ -8134,7 +8134,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.solardecathlon.gov",
@@ -8142,7 +8142,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.spaceweather.gov",
@@ -8150,7 +8150,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.speaker.gov",
@@ -8158,7 +8158,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.spectrum.gov",
@@ -8166,7 +8166,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.srs.gov",
@@ -8174,7 +8174,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://ssa.gov",
@@ -8182,7 +8182,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://ssab.gov",
@@ -8190,7 +8190,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.sss.gov",
@@ -8206,7 +8206,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://start2farm.gov",
@@ -8214,7 +8214,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.state.gov",
@@ -8222,7 +8222,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://stennis.gov",
@@ -8230,7 +8230,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.steroidabuse.gov",
@@ -8238,7 +8238,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://stopalcoholabuse.gov",
@@ -8254,7 +8254,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.stopfakes.gov",
@@ -8262,7 +8262,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.stopfraud.gov",
@@ -8270,7 +8270,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.stopmedicarefraud.gov",
@@ -8278,7 +8278,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "https://strategicsourcing.gov",
@@ -8302,7 +8302,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "https://www.studentaid.gov",
@@ -8334,7 +8334,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.supremecourtus.gov",
@@ -8342,7 +8342,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.surgeongeneral.gov",
@@ -8350,7 +8350,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://sustainability.gov",
@@ -8358,15 +8358,15 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.sustainablecommunities.gov",
       "Domain": "sustainablecommunities.gov",
-      "Enforces HTTPS": 0,
-      "SSL Labs Grade": 3,
-      "Strict Transport Security (HSTS)": 0,
-      "Uses HTTPS": 2
+      "Enforces HTTPS": -1,
+      "SSL Labs Grade": -1,
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://swpa.gov",
@@ -8374,7 +8374,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "https://www.symbols.gov",
@@ -8390,7 +8390,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.tax.gov",
@@ -8398,7 +8398,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "https://taxreform.gov",
@@ -8414,7 +8414,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.teachingwithprimarysources.gov",
@@ -8422,7 +8422,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://telework.gov",
@@ -8430,7 +8430,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.tfhrc.gov",
@@ -8438,7 +8438,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://thecoolspot.gov",
@@ -8446,7 +8446,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://thepeoplesgarden.gov",
@@ -8454,7 +8454,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.therealcost.gov",
@@ -8462,7 +8462,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.thesecondthing.gov",
@@ -8470,7 +8470,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.thomas.gov",
@@ -8478,7 +8478,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.tigta.gov",
@@ -8486,7 +8486,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://time.gov",
@@ -8494,7 +8494,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://tissueengineering.gov",
@@ -8502,7 +8502,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.tobacco.gov",
@@ -8510,7 +8510,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.tps.gov",
@@ -8518,7 +8518,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://trade.gov",
@@ -8526,7 +8526,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.trafficsafetymarketing.gov",
@@ -8534,7 +8534,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.transparency.gov",
@@ -8542,15 +8542,15 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.transportation.gov",
       "Domain": "transportation.gov",
-      "Enforces HTTPS": 0,
-      "SSL Labs Grade": 3,
-      "Strict Transport Security (HSTS)": 0,
-      "Uses HTTPS": 2
+      "Enforces HTTPS": -1,
+      "SSL Labs Grade": -1,
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.transportationresearch.gov",
@@ -8558,7 +8558,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.treas.gov",
@@ -8566,7 +8566,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "https://www.treaslockbox.gov",
@@ -8582,15 +8582,15 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.treasury.gov",
       "Domain": "treasury.gov",
-      "Enforces HTTPS": 0,
-      "SSL Labs Grade": 3,
-      "Strict Transport Security (HSTS)": 0,
-      "Uses HTTPS": 2
+      "Enforces HTTPS": -1,
+      "SSL Labs Grade": -1,
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://treasuryauctions.gov",
@@ -8598,7 +8598,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://treasurydirect.gov",
@@ -8606,7 +8606,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://treasuryhunt.gov",
@@ -8614,7 +8614,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://treasuryscams.gov",
@@ -8622,7 +8622,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.tribaljusticeandsafety.gov",
@@ -8630,7 +8630,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.truman.gov",
@@ -8654,7 +8654,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "https://www.tsp.gov",
@@ -8670,7 +8670,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://tswg.gov",
@@ -8678,7 +8678,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://ttb.gov",
@@ -8686,7 +8686,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.ttbonline.gov",
@@ -8694,7 +8694,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://tva.gov",
@@ -8702,7 +8702,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://ucrdatatool.gov",
@@ -8710,7 +8710,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://udall.gov",
@@ -8726,7 +8726,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.unionreports.gov",
@@ -8734,7 +8734,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.unitedstates.gov",
@@ -8742,7 +8742,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.unitedstatescongress.gov",
@@ -8750,7 +8750,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.unitedweride.gov",
@@ -8758,7 +8758,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "https://unlocktalent.gov",
@@ -8774,7 +8774,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "https://www.us-cert.gov",
@@ -8790,7 +8790,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.usa.gov",
@@ -8806,7 +8806,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.usagov.gov",
@@ -8814,15 +8814,15 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.usaid.gov",
       "Domain": "usaid.gov",
-      "Enforces HTTPS": 0,
-      "SSL Labs Grade": 0,
-      "Strict Transport Security (HSTS)": 0,
-      "Uses HTTPS": 2
+      "Enforces HTTPS": -1,
+      "SSL Labs Grade": -1,
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Canonical": "http://www.usaidallnet.gov",
@@ -8830,7 +8830,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "https://www.usajobs.gov",
@@ -8854,7 +8854,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://usap.gov",
@@ -8894,7 +8894,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://usbg.gov",
@@ -8918,7 +8918,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://uscapitol.gov",
@@ -8926,7 +8926,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.uscapitolpolice.gov",
@@ -8934,7 +8934,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://uscapitolvisitorcenter.gov",
@@ -8942,7 +8942,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.uscc.gov",
@@ -8950,7 +8950,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.usccr.gov",
@@ -8958,7 +8958,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.uscirf.gov",
@@ -8966,7 +8966,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.uscis.gov",
@@ -8974,7 +8974,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.uscode.gov",
@@ -8982,7 +8982,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.uscongress.gov",
@@ -8990,7 +8990,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.usconsulate.gov",
@@ -9006,7 +9006,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://uscvc.gov",
@@ -9014,7 +9014,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.usda.gov",
@@ -9022,7 +9022,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.usdapii.gov",
@@ -9030,7 +9030,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://usdebitcard.gov",
@@ -9038,7 +9038,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.usdoj.gov",
@@ -9046,7 +9046,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://usembassy-mexico.gov",
@@ -9062,7 +9062,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.userra.gov",
@@ -9070,7 +9070,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.usgcrp.gov",
@@ -9078,7 +9078,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.usgeo.gov",
@@ -9094,7 +9094,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.usgovernmentmanual.gov",
@@ -9102,7 +9102,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://usgs.gov",
@@ -9118,7 +9118,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://usich.gov",
@@ -9126,7 +9126,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.usicn.gov",
@@ -9134,7 +9134,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://usint.gov",
@@ -9158,7 +9158,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.usmarshals.gov",
@@ -9166,7 +9166,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.usmint.gov",
@@ -9182,7 +9182,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.usoge.gov",
@@ -9190,7 +9190,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://usphs.gov",
@@ -9198,7 +9198,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.uspis.gov",
@@ -9206,7 +9206,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.usprobation.gov",
@@ -9214,7 +9214,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "https://www.usps.gov",
@@ -9238,7 +9238,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.ussc.gov",
@@ -9246,7 +9246,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://ustaxcourt.gov",
@@ -9254,7 +9254,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://ustda.gov",
@@ -9278,7 +9278,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.usvpp.gov",
@@ -9310,7 +9310,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://vallescaldera.gov",
@@ -9326,7 +9326,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://vef.gov",
@@ -9342,7 +9342,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.vetbiz.gov",
@@ -9350,7 +9350,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.veterans.gov",
@@ -9358,7 +9358,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://visitthecapital.gov",
@@ -9366,7 +9366,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.visitthecapitol.gov",
@@ -9374,7 +9374,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.vista.gov",
@@ -9382,7 +9382,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.vistacampus.gov",
@@ -9390,7 +9390,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.voa.gov",
@@ -9398,7 +9398,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://volunteer.gov",
@@ -9414,7 +9414,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.wapa.gov",
@@ -9430,7 +9430,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://watermonitor.gov",
@@ -9438,7 +9438,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.wdl.gov",
@@ -9446,7 +9446,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://wdol.gov",
@@ -9454,7 +9454,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.weather.gov",
@@ -9462,7 +9462,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://webharvest.gov",
@@ -9470,7 +9470,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.welcometousa.gov",
@@ -9478,7 +9478,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://wethepeople.gov",
@@ -9486,7 +9486,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.wh.gov",
@@ -9502,7 +9502,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "https://www.whitehouse.gov",
@@ -9518,7 +9518,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.whitehousedrugpolicy.gov",
@@ -9542,7 +9542,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://www.windpoweringamerica.gov",
@@ -9550,7 +9550,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://wizard.gov",
@@ -9558,7 +9558,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "https://www.wlci.gov",
@@ -9574,7 +9574,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "https://www.womenfarmerclaims.gov",
@@ -9590,7 +9590,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://womenshistorymonth.gov",
@@ -9598,7 +9598,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "https://www.workplace.gov",
@@ -9614,7 +9614,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "http://worldwar1centennial.gov",
@@ -9622,7 +9622,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "https://www.wrp.gov",
@@ -9638,7 +9638,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Canonical": "https://youthgo.gov",
@@ -9654,7 +9654,7 @@
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     }
   ]
 }

--- a/assets/js/https/agencies.js
+++ b/assets/js/https/agencies.js
@@ -13,8 +13,8 @@ $(document).ready(function () {
       columns: [
         {data: "Agency"},
         {data: "Number of Domains"},
-        {data: "HTTPS Enabled?"},
-        {data: "HTTPS Enforced?"},
+        {data: "Uses HTTPS"},
+        {data: "Enforces HTTPS"},
         {data: "Strict Transport Security (HSTS)"},
         {data: "SSL Labs (A- or higher)"}
       ],

--- a/assets/js/https/domains.js
+++ b/assets/js/https/domains.js
@@ -73,8 +73,8 @@ $(document).ready(function () {
       columns: [
         {data: "Domain", width: "210px"},
         {data: "Canonical"},
-        {data: "HTTPS Enabled?"},
-        {data: "HTTPS Enforced?"},
+        {data: "Uses HTTPS"},
+        {data: "Enforces HTTPS"},
         {data: "Strict Transport Security (HSTS)"},
         {data: "SSL Labs Grade"},
         // {data: "More details"}

--- a/assets/js/https/domains.js
+++ b/assets/js/https/domains.js
@@ -6,6 +6,7 @@ $(document).ready(function () {
 
   var names = {
     https: {
+      "-1": "No",
       0: "No",
       1: "Yes", // (with certificate chain issues)
       2: "Yes"

--- a/data/data.py
+++ b/data/data.py
@@ -289,12 +289,16 @@ def https_row_for(domain):
   ###
   # Is it there? There for most clients? Not there?
 
-  if (inspect["Valid HTTPS"] == "True"):
-    https = 2 # Yes
-  elif (inspect["HTTPS Bad Chain"] == "True"):
-    https = 1 # Yes (with issues) - Considered 'Yes'
-  else:
+  # assumes that HTTPS would be technically present, with or without issues
+  if (inspect["Downgrades HTTPS"] == "True"):
     https = 0 # No
+  else:
+    if (inspect["Valid HTTPS"] == "True"):
+      https = 2 # Yes
+    elif (inspect["HTTPS Bad Chain"] == "True"):
+      https = 1 # Yes
+    else:
+      https = -1 # No
 
   row[LABELS['https']] = https;
 
@@ -302,7 +306,7 @@ def https_row_for(domain):
   ###
   # Is HTTPS enforced?
 
-  if (https == 0):
+  if (https <= 0):
     behavior = -1 # N/A (considered 'No')
 
   else:
@@ -338,7 +342,7 @@ def https_row_for(domain):
   # Characterize the presence and completeness of HSTS.
 
   # Without HTTPS there can be no HSTS.
-  if (https == 0):
+  if (https <= 0):
     hsts = -1 # N/A (considered 'No')
 
   else:
@@ -368,7 +372,7 @@ def https_row_for(domain):
   tls = domain_data[domain].get('tls')
 
   # Not relevant if no HTTPS
-  if (https == 0):
+  if (https <= 0):
     grade = -1 # N/A
 
   elif tls is None:

--- a/data/data.py
+++ b/data/data.py
@@ -415,9 +415,15 @@ def process_stats():
   total = len(https_domains)
   enabled = 0
   for row in https_domains:
-    # Needs to be enabled, with issues is allowed
-    if row[LABELS['https']] >= 1:
+    # HTTPS needs to be enabled.
+    # It's okay if it has a bad chain.
+    # However, it's not okay if HTTPS is downgraded.
+    if (
+      (row[LABELS['https']] >= 1) and
+      (row[LABELS['https_forced']] >= 1)
+    ):
       enabled += 1
+
   pct = percent(enabled, total)
 
   https_stats = [

--- a/data/data.py
+++ b/data/data.py
@@ -27,8 +27,8 @@ STATS_DATA = "../assets/data"
 
 
 LABELS = {
-  'https': 'HTTPS Enabled?',
-  'https_forced': 'HTTPS Enforced?',
+  'https': 'Uses HTTPS',
+  'https_forced': 'Enforces HTTPS',
   'hsts': 'Strict Transport Security (HSTS)',
   'grade': 'SSL Labs Grade',
   'grade_agencies': 'SSL Labs (A- or higher)',
@@ -268,10 +268,10 @@ Given the data we have about a domain, what's the HTTPS row?
 
 {
   "Domain": [domain],
-  "HTTPS Enabled?": [
+  "Uses HTTPS": [
     "No" | "Yes (with issues)" | "Yes"
   ],
-  "HTTPS Enforced?": [
+  "Enforces HTTPS": [
     "No" | "Yes" | "Yes (Strict)"
   ],
   "HSTS": [
@@ -296,7 +296,7 @@ def https_row_for(domain):
   else:
     https = 0 # No
 
-  row["HTTPS Enabled?"] = https;
+  row[LABELS['https']] = https;
 
 
   ###

--- a/pages/https/agencies.html
+++ b/pages/https/agencies.html
@@ -20,8 +20,8 @@ description: "How federal government domains are doing at deploying HTTPS."
           <tr>
             <th class="all">Agency</th>
             <th class="all">No. of Domains</th>
-            <th class="min-tablet">HTTPS Enabled?</th>
-            <th class="min-tablet">HTTPS Enforced?</th>
+            <th class="min-tablet">Uses HTTPS</th>
+            <th class="min-tablet">Enforces HTTPS</th>
             <th class="desktop">Strict Transport Security (HSTS)</th>
             <th class="desktop">SSL Labs (A- or higher)</th>
           </tr>

--- a/pages/https/domains.html
+++ b/pages/https/domains.html
@@ -20,8 +20,8 @@ description: "How federal government domains are doing at deploying HTTPS."
           <tr>
             <th class="all">Domain</th>
             <th class="never">Canonical</th>
-            <th class="min-tablet">HTTPS Enabled?</th>
-            <th class="min-tablet">HTTPS Enforced?</th>
+            <th class="min-tablet">Uses HTTPS</th>
+            <th class="min-tablet">Enforces HTTPS</th>
             <th class="min-tablet-l">Strict Transport Security (HSTS)</th>
             <th class="min-tablet-l">SSL Labs Grade</th>
             <!-- <th class="none">More details</th> -->

--- a/pages/https/guide.html
+++ b/pages/https/guide.html
@@ -69,20 +69,20 @@ description: "How federal government domains are doing at deploying HTTPS."
         <h3>Fields</h3>
 
         <ul>
-          <li><strong>HTTPS Enabled?</strong></li>
-          <li><strong>Values:</strong> No,Yes</li>
-          <li>Whether a valid HTTPS connection can be established to a domain, on either its bare domain or its <code>www</code> subdomain.</li>
+          <li><strong>Uses HTTPS</strong></li>
+          <li><strong>Values:</strong> No, Yes</li>
+          <li>Whether a site can be used over HTTPS, on either its bare domain or its <code>www</code> subdomain. Sites that appear to redirect "down" from HTTPS to HTTP are considered a "No".</li>
         </ul>
 
         <ul>
-          <li><strong>HTTPS Enforced?</strong></li>
-          <li><strong>Values:</strong> No,Yes</li>
+          <li><strong>Enforces HTTPS</strong></li>
+          <li><strong>Values:</strong> No, Yes</li>
           <li>Whether a domain appears to "default" to using HTTPS. This can be done either by redirecting its HTTP endpoints to HTTPS, or by only being available over HTTPS.</li>
         </ul>
 
         <ul>
           <li><strong>Strict Transport Security (HSTS)</strong></li>
-          <li><strong>Values:</strong> No,Yes,"Yes, and preloaded"</li>
+          <li><strong>Values:</strong> No, Yes, "Yes, and preloaded"</li>
           <li>Whether a domain has implemented <a href="https://https.cio.gov/hsts/">HTTP Strict Transport Security</a>, which ensures that <a href="http://caniuse.com/#search=hsts">supporting browsers</a> will only ever communicate with a domain over HTTPS (even if the user clicks or types in a plain HTTP link).</li>
           <li>"Yes" means that a valid <code>Strict-Transport-Security</code> header with a non-zero <code>max-age</code> is present on the domain's default endpoint.</li>
           <li>"Yes, and preloaded" means that the domain has implemented a strong HSTS header on its <strong>bare domain</strong> whose policy covers all subdomains, and has indicated consent to <a href="https://hstspreload.appspot.com">preloading by all major browsers</a> as HTTPS-only. This effectively means that a domain's namespace is permanently and fully committed to HTTPS.</li>
@@ -90,7 +90,7 @@ description: "How federal government domains are doing at deploying HTTPS."
 
         <ul>
           <li><strong>SSL Labs Grade</strong></li>
-          <li><strong>Values:</strong> T,F,C,B,A-,A,A+</li>
+          <li><strong>Values:</strong> T, F, C, B, A-, A, A+</li>
           <li>A grade measuring the <em>quality</em> of HTTPS configuration, as calculated by <a href="https://www.ssllabs.com">SSL Labs</a>. SSL Labs operates a free and universally referenced benchmarking service.</li>
           <li>Grades are calculated using a <a href="https://www.ssllabs.com/downloads/SSL_Server_Rating_Guide.pdf">detailed methodology</a> that looks at the strength of cryptographic keys, choices of ciphers, supported protocols, and other relevant standards (such as HSTS).</li>
           <li>Grades are hyperlinked to detailed reports for each domain on SSL Labs. As an example, view the <a href="https://www.ssllabs.com/ssltest/analyze.html?d=pulse.cio.gov">SSL Labs report for Pulse itself</a>.</li>


### PR DESCRIPTION
This now excludes domains which "downgrade" HTTPS (redirect from `https://` to `http://`) from the calculation of "uses HTTPS" that we make our big % out of.

It drops the % from 34% to 31%. However, it is a more honest assessment of whether a domain Uses HTTPS.

I'm still working on this, to sync the language and guidance on the table. Will update when ready for merge.