### PR TITLE
Link number of agency domains to a filtered list of their domains

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -63,4 +63,5 @@ http://updates.html5rocks.com/2014/11/Support-for-theme-color-in-Chrome-39-for-A
 <script src="/assets/js/vendor/DataTables-1.10.6/media/js/jquery.dataTables.min.js"></script>
 <script src="/assets/js/vendor/DataTables-1.10.6/media/js/dataTables.responsive.js"></script>
 <script src="/assets/js/vendor/d3.min.js"></script>
+<script src="/assets/js/vendor/querystring.js"></script>
 <script src="/assets/js/utils.js?{{ site.time | date: "%Y%m%j%H%M%S" }}"></script>

--- a/assets/js/analytics/agencies.js
+++ b/assets/js/analytics/agencies.js
@@ -16,7 +16,7 @@ $(document).ready(function () {
         {data: "Agency"},
         {
           data: "Number of Domains",
-          render: Utils.linkAgency("analytics")
+          render: Utils.filterAgency("analytics")
         },
         {data: "Participates in DAP?"}
       ],

--- a/assets/js/analytics/agencies.js
+++ b/assets/js/analytics/agencies.js
@@ -10,10 +10,15 @@ $(document).ready(function () {
 
       data: data,
 
+      initComplete: Utils.searchLinks,
+
       columns: [
-        {"data": "Agency"},
-        {"data": "Number of Domains"},
-        {"data": "Participates in DAP?"}
+        {data: "Agency"},
+        {
+          data: "Number of Domains",
+          render: Utils.linkAgency("analytics")
+        },
+        {data: "Participates in DAP?"}
       ],
 
       // order by number of domains

--- a/assets/js/analytics/domains.js
+++ b/assets/js/analytics/domains.js
@@ -27,6 +27,8 @@ $(document).ready(function () {
 
       data: data,
 
+      initComplete: Utils.searchLinks,
+
       columns: [
         {
           data: "Domain",

--- a/assets/js/https/agencies.js
+++ b/assets/js/https/agencies.js
@@ -7,6 +7,7 @@ $(document).ready(function () {
   var renderTable = function(data) {
     $("table").DataTable({
       responsive: true,
+      initComplete: Utils.searchLinks,
 
       data: data,
 

--- a/assets/js/https/agencies.js
+++ b/assets/js/https/agencies.js
@@ -13,7 +13,10 @@ $(document).ready(function () {
 
       columns: [
         {data: "Agency"},
-        {data: "Number of Domains"},
+        {
+          data: "Number of Domains",
+          render: Utils.linkAgency("https")
+        },
         {data: "Uses HTTPS"},
         {data: "Enforces HTTPS"},
         {data: "Strict Transport Security (HSTS)"},

--- a/assets/js/https/domains.js
+++ b/assets/js/https/domains.js
@@ -71,13 +71,7 @@ $(document).ready(function () {
 
       data: data,
 
-      initComplete: function() {
-        var api = this.api();
-
-        var query = QueryString.parse(location.hash).q;
-        $("input[type=search]").val(query);
-        api.search(query).draw();
-      },
+      initComplete: Utils.searchLinks,
 
       columns: [
         {
@@ -115,10 +109,7 @@ $(document).ready(function () {
 
     });
 
-    $("table").on('search.dt', function(e, settings) {
-      var query = $("input[type=search]").val();
-      location.hash = QueryString.stringify({q: query});
-    });
+
   }
 
 })

--- a/assets/js/https/domains.js
+++ b/assets/js/https/domains.js
@@ -71,6 +71,14 @@ $(document).ready(function () {
 
       data: data,
 
+      initComplete: function() {
+        var api = this.api();
+
+        var query = QueryString.parse(location.hash).q;
+        $("input[type=search]").val(query);
+        api.search(query).draw();
+      },
+
       columns: [
         {
           data: "Domain",
@@ -106,6 +114,11 @@ $(document).ready(function () {
       },
 
     });
-  };
+
+    $("table").on('search.dt', function(e, settings) {
+      var query = $("input[type=search]").val();
+      location.hash = QueryString.stringify({q: query});
+    });
+  }
 
 })

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -1,7 +1,7 @@
 $(function(){
 
-  $('#menu-btn,.overlay,.sliding-panel-close').on('click touchstart',function (e) {
-    $('#menu-content,.overlay').toggleClass('is-visible');
+  $('#menu-btn, .overlay, .sliding-panel-close').on('click touchstart',function (e) {
+    $('#menu-content, .overlay').toggleClass('is-visible');
     e.preventDefault();
   });
 
@@ -10,6 +10,8 @@ $(function(){
     var query = $("input[type=search]").val();
     if (query)
       location.hash = QueryString.stringify({q: query});
+    // TODO: Disabled because this callback runs on table init,
+    // and zeroes out the location hash. Should be addressed.
     // else
     //   location.hash = '';
   });

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -1,6 +1,16 @@
 $(function(){
+
   $('#menu-btn,.overlay,.sliding-panel-close').on('click touchstart',function (e) {
     $('#menu-content,.overlay').toggleClass('is-visible');
     e.preventDefault();
+  });
+
+  // if a datatable is searched, sync it to the URL hash
+  $("table").on('search.dt', function(e, settings) {
+    var query = $("input[type=search]").val();
+    if (query)
+      location.hash = QueryString.stringify({q: query});
+    // else
+    //   location.hash = '';
   });
 });

--- a/assets/js/utils.js
+++ b/assets/js/utils.js
@@ -24,7 +24,7 @@ var Utils = {
   },
 
   // used to make "71" say "71 domains" and link to filtered domains
-  linkAgency: function(page) {
+  filterAgency: function(page) {
     return function(data, type, row) {
       if (type == "sort")
         return data;

--- a/assets/js/utils.js
+++ b/assets/js/utils.js
@@ -21,5 +21,15 @@ var Utils = {
         "<a href=\"" + row['Canonical'] + "\" target=\"blank\">" +
           data +
         "</a>";
+  },
+
+  searchLinks: function() {
+    var api = this.api();
+    var query = QueryString.parse(location.hash).q;
+
+    if (query) {
+      $("input[type=search]").val(query);
+      api.search(query).draw();
+    }
   }
 };

--- a/assets/js/utils.js
+++ b/assets/js/utils.js
@@ -23,6 +23,20 @@ var Utils = {
         "</a>";
   },
 
+  // used to make "71" say "71 domains" and link to filtered domains
+  linkAgency: function(page) {
+    return function(data, type, row) {
+      if (type == "sort")
+        return data;
+      else
+        return "" +
+          "<a href=\"/" + page + "/domains/#" +
+            QueryString.stringify({q: row["Agency"]}) + "\">" +
+            data +
+          "</a>";
+    }
+  },
+
   searchLinks: function() {
     var api = this.api();
     var query = QueryString.parse(location.hash).q;

--- a/assets/js/vendor/querystring.js
+++ b/assets/js/vendor/querystring.js
@@ -40,5 +40,18 @@ var QueryString = {
 
       return ret;
     }, {});
+  },
+  stringify: function (obj) {
+    return obj ? Object.keys(obj).sort().map(function (key) {
+      var val = obj[key];
+
+      if (Array.isArray(val)) {
+        return val.sort().map(function (val2) {
+          return encodeURIComponent(key) + '=' + encodeURIComponent(val2);
+        }).join('&');
+      }
+
+      return encodeURIComponent(key) + '=' + encodeURIComponent(val);
+    }).join('&') : '';
   }
 };

--- a/data/domains.csv
+++ b/data/domains.csv
@@ -1,5385 +1,1358 @@
-Domain Name,Domain Type,Agency,City,State,Status,Last Payment Date,Expiration Date
-18F.GOV,Federal Agency,General Services Administration,,,,,
-ABERDEENWA.GOV,City,Non-Federal Agency,Aberdeen,WA,ACTIVE,15-Jul-13,27-Oct-13
-ABINGDON-VA.GOV,City,Non-Federal Agency,Abingdon,VA,ACTIVE,3-Sep-14,14-Sep-15
-ABINGTONMA.GOV,City,Non-Federal Agency,Abington,MA,ACTIVE,11-Mar-15,15-Mar-16
-ABSECONNJ.GOV,City,Non-Federal Agency,Absecon,NJ,ACTIVE,21-Nov-14,18-Dec-15
-ACCESSPRINCETONNJ.GOV,City,Non-Federal Agency,Princeton,NJ,ACTIVE,8-Aug-14,8-Aug-15
-ACTON-MA.GOV,City,Non-Federal Agency,Acton,MA,ACTIVE,29-Sep-14,30-Sep-15
-ACTONMA.GOV,City,Non-Federal Agency,Acton,MA,ACTIVE,29-Sep-14,30-Sep-15
-ADAK-AK.GOV,City,Non-Federal Agency,Adak,AK,ACTIVE,29-Oct-14,12-Jan-16
-ADAMN.GOV,City,Non-Federal Agency,Ada,MN,ACTIVE,25-Aug-14,25-Aug-15
-ADDISONTX.GOV,City,Non-Federal Agency,Addison,TX,ACTIVE,26-Jan-15,26-Apr-16
-ADRIANMI.GOV,City,Non-Federal Agency,Adrian,MI,ACTIVE,6-Mar-15,4-May-16
-AFTONWYOMING.GOV,City,Non-Federal Agency,AFTON,WY,ACTIVE,2-Sep-14,30-Oct-15
-AKRONOHIO.GOV,City,Non-Federal Agency,Akron,OH,ACTIVE,4-Aug-14,28-Jul-15
-ALAMEDACA.GOV,City,Non-Federal Agency,Alameda,CA,ACTIVE,7-Jul-14,3-Oct-15
-ALAMOHEIGHTSTX.GOV,City,Non-Federal Agency,Alamo Heights,TX,ACTIVE,12-Aug-14,26-Aug-15
-ALBANYNY.GOV,City,Non-Federal Agency,Albany,NY,ACTIVE,9-Feb-15,8-Feb-16
-ALEXANDERCITYAL.GOV,City,Non-Federal Agency,Alexander City,AL,ACTIVE,18-Jun-14,12-Sep-15
-ALEXANDRIAVA.GOV,City,Non-Federal Agency,Alexandria,VA,ACTIVE,22-Jul-14,30-Sep-15
-ALGONAWA.GOV,City,Non-Federal Agency,Algona,WA,ACTIVE,3-Mar-15,26-Mar-16
-ALGOODTN.GOV,City,Non-Federal Agency,Algood,TN,ACTIVE,25-Feb-15,25-Feb-16
-ALIQUIPPAPA.GOV,City,Non-Federal Agency,Aliquippa,PA,ACTIVE,14-Aug-14,10-Nov-14
-ALLENSTOWNNH.GOV,City,Non-Federal Agency,Allenstown,NH,ACTIVE,2-Mar-15,15-Apr-16
-ALLENTOWNPA.GOV,City,Non-Federal Agency,Allentown,PA,ACTIVE,27-May-14,26-Jul-15
-ALLIANCEOH.GOV,City,Non-Federal Agency,Alliance,OH,ACTIVE,30-Sep-14,30-Sep-15
-ALMONTMICHIGAN.GOV,City,Non-Federal Agency,Almont,MI,ACTIVE,12-Nov-14,30-Jan-16
-ALSTEADNH.GOV,City,Non-Federal Agency,Alstead,NH,ACTIVE,9-Dec-14,9-Dec-15
-ALTAVISTAVA.GOV,City,Non-Federal Agency,Altavista,VA,ACTIVE,5-Feb-14,4-May-15
-ALTON-TX.GOV,City,Non-Federal Agency,Alton,TX,ACTIVE,26-Nov-14,3-Jan-16
-ALTUSOK.GOV,City,Non-Federal Agency,Altus,OK,ACTIVE,17-Apr-14,2-May-15
-ALVIN-TX.GOV,City,Non-Federal Agency,Alvin,TX,ACTIVE,7-Aug-12,2-Nov-13
-AMARILLO.GOV,City,Non-Federal Agency,Amarillo,TX,ACTIVE,23-Sep-14,30-Sep-15
-AMENIANY.GOV,City,Non-Federal Agency,Amenia,NY,ACTIVE,23-Jun-14,31-Aug-15
-AMERICUSGA.GOV,City,Non-Federal Agency,Americus,GA,ACTIVE,26-Sep-13,26-Sep-14
-AMERYWI.GOV,City,Non-Federal Agency,Amery,WI,ACTIVE,6-Jan-15,4-Apr-16
-AMHERSTMA.GOV,City,Non-Federal Agency,Amherst,MA,ACTIVE,23-Aug-11,23-Aug-12
-AMHERSTNH.GOV,City,Non-Federal Agency,Amherst,NH,ACTIVE,24-Sep-14,30-Sep-15
-AMHERSTVA.GOV,City,Non-Federal Agency,Amherst,VA,ACTIVE,23-Apr-14,22-Jul-15
-AMITYARKANSAS.GOV,City,Non-Federal Agency,Amity,AR,ACTIVE,13-Aug-13,8-Oct-14
-AMSTERDAMNY.GOV,City,Non-Federal Agency,Amsterdam,NY,ACTIVE,19-Sep-12,30-Sep-13
-ANDOVER-NH.GOV,City,Non-Federal Agency,Andover,NH,ACTIVE,28-Jan-15,28-Jan-16
-ANDOVERMA.GOV,City,Non-Federal Agency,Andover,MA,ACTIVE,14-Jul-14,30-Aug-15
-ANDOVERMN.GOV,City,Non-Federal Agency,Andover,MN,ACTIVE,24-Dec-14,10-Jan-16
-ANGELFIRENM.GOV,City,Non-Federal Agency,Angel Fire,NM,ACTIVE,4-Apr-14,9-Jun-15
-ANGELSCAMP.GOV,City,Non-Federal Agency,City of Angels Camp,CA,ACTIVE,7-Nov-14,30-Sep-15
-ANKENYIOWA.GOV,City,Non-Federal Agency,Ankeny,IA,ACTIVE,20-Jan-15,16-Mar-16
-ANNATEXAS.GOV,City,Non-Federal Agency,Anna,TX,ACTIVE,18-Aug-14,1-Nov-15
-ANNETTATX.GOV,City,Non-Federal Agency,Aledo,TX,ACTIVE,3-Feb-15,3-Feb-16
-ANNISTONAL.GOV,City,Non-Federal Agency,Anniston,AL,ACTIVE,5-Aug-13,30-Sep-14
-APPLEVALLEYCA.GOV,City,Non-Federal Agency,Apple Valley,CA,ACTIVE,6-Jan-14,9-Feb-15
-APPLEVALLEYUT.GOV,City,Non-Federal Agency,Apple Valley,UT,ACTIVE,17-Nov-14,30-Jan-16
-APPOMATTOXVA.GOV,City,Non-Federal Agency,Appomattox,VA,ACTIVE,17-Nov-14,16-Dec-15
-AQUINNAH-MA.GOV,City,Non-Federal Agency,Aquinnah,MA,ACTIVE,21-May-13,17-Jun-14
-ARANSASPASSTX.GOV,City,Non-Federal Agency,Aransas Pass,TX,ACTIVE,17-Feb-15,23-Feb-16
-ARCADIA-FL.GOV,City,Non-Federal Agency,Arcadia,FL,ACTIVE,22-Mar-12,22-Mar-13
-ARCADIACA.GOV,City,Non-Federal Agency,Arcadia,CA,ACTIVE,22-Jan-15,12-Feb-16
-ARCHBALDBOROUGHPA.GOV,City,Non-Federal Agency,Archbald,PA,ACTIVE,29-Apr-14,26-Jun-15
-ARKANSASCITYKS.GOV,City,Non-Federal Agency,Arkansas City,KS,ACTIVE,4-Aug-14,30-Sep-15
-ARLINGTON-TX.GOV,City,Non-Federal Agency,Arlington,TX,ACTIVE,2-Jun-14,30-Jun-15
-ARLINGTONMA.GOV,City,Non-Federal Agency,Arlington,MA,ACTIVE,7-Jan-15,31-Mar-16
-ARLINGTONTX.GOV,City,Non-Federal Agency,Arlington,TX,ACTIVE,2-Jun-14,30-Jun-15
-ARLINGTONWA.GOV,City,Non-Federal Agency,Arlington,WA,ACTIVE,17-Mar-14,14-May-15
-ARTESIANM.GOV,City,Non-Federal Agency,Artesia,NM,ACTIVE,21-Jul-14,19-Oct-15
-ARTHUR-IL.GOV,City,Non-Federal Agency,Arthur,IL,ACTIVE,3-Jan-13,20-Mar-14
-ASHBURNHAM-MA.GOV,City,Non-Federal Agency,Ashburnham,MA,ACTIVE,4-Aug-14,24-Aug-15
-ASHBYMA.GOV,City,Non-Federal Agency,Ashby,MA,ACTIVE,7-May-14,5-Jul-15
-ASHEBORONC.GOV,City,Non-Federal Agency,Asheboro,NC,ACTIVE,24-Jul-14,24-Aug-15
-ASHGROVEMO.GOV,City,Non-Federal Agency,Ash Grove,MO,ACTIVE,8-Oct-14,8-Oct-15
-ASHLANDCITYTN.GOV,City,Non-Federal Agency,Ashland City,TN,ACTIVE,22-Jan-15,5-Mar-16
-ASHLANDKY.GOV,City,Non-Federal Agency,Ashland,KY,ACTIVE,17-Jul-14,22-Sep-15
-ASHVILLEOHIO.GOV,City,Non-Federal Agency,Ashville,OH,ACTIVE,9-Apr-13,1-Jun-14
-ATHOL-MA.GOV,City,Non-Federal Agency,Athol,MA,ACTIVE,15-Apr-14,12-May-15
-ATKINSON-NH.GOV,City,Non-Federal Agency,Atkinson,NH,ACTIVE,2-Sep-14,20-Sep-15
-ATLANTAGA.GOV,City,Non-Federal Agency,Atlanta,GA,ACTIVE,23-Jul-14,30-Sep-15
-ATLANTISFL.GOV,City,Non-Federal Agency,Atlantis,FL,ACTIVE,14-Jul-14,20-Jun-15
-ATRISCO-NM.GOV,City,Non-Federal Agency,Atrisco,NM,ACTIVE,12-Aug-13,3-Nov-13
-ATTICA-IN.GOV,City,Non-Federal Agency,Attica,IN,ACTIVE,9-Jul-14,7-Aug-15
-AUBREYTX.GOV,City,Non-Federal Agency,Aubrey,TX,ACTIVE,24-Nov-14,24-Nov-15
-AUBURNMAINE.GOV,City,Non-Federal Agency,Auburn,ME,ACTIVE,3-Sep-13,3-Sep-14
-AUGUSTAMAINE.GOV,City,Non-Federal Agency,Augusta,ME,ACTIVE,3-Mar-15,25-Apr-16
-AUGUSTAME.GOV,City,Non-Federal Agency,Augusta,ME,ACTIVE,3-Mar-15,25-Apr-16
-AUSTELLGA.GOV,City,Non-Federal Agency,Austell,GA,ACTIVE,20-Oct-14,16-Jan-16
-AUSTINTEXAS.GOV,City,Non-Federal Agency,Austin,TX,ACTIVE,8-Sep-14,7-Nov-15
-AUSTINTX.GOV,City,Non-Federal Agency,Austin,TX,ACTIVE,8-Sep-14,7-Nov-15
-AVONCT.GOV,City,Non-Federal Agency,Avon,CT,ACTIVE,3-Nov-14,3-Nov-15
-AVONDALEAZ.GOV,City,Non-Federal Agency,Avondale,AZ,ACTIVE,17-Feb-15,15-Apr-16
-AZTECNM.GOV,City,Non-Federal Agency,Aztec,NM,ACTIVE,31-Mar-14,29-Mar-15
-BADENPA.GOV,City,Non-Federal Agency,Baden,PA,ACTIVE,24-Aug-12,24-Aug-13
-BAINBRIDGEWA.GOV,City,Non-Federal Agency,Bainbridge Island,WA,ACTIVE,17-Dec-14,17-Dec-15
-BALHARBOURFL.GOV,City,Non-Federal Agency,Bal Harbour,FL,ACTIVE,28-May-14,28-May-15
-BALTIMORECITY.GOV,City,Non-Federal Agency,Baltimore,MD,ACTIVE,2-Jul-14,30-Sep-15
-BANGORMAINE.GOV,City,Non-Federal Agency,Bangor,ME,ACTIVE,2-Jul-14,30-Sep-15
-BARRINGTON-IL.GOV,City,Non-Federal Agency,Barrington,IL,ACTIVE,30-Sep-14,30-Sep-15
-BARRINGTONHILLS-IL.GOV,City,Non-Federal Agency,Barrington Hills,IL,ACTIVE,2-Jul-14,30-Sep-15
-BASTROPTX.GOV,City,Non-Federal Agency,Bastrop,TX,ACTIVE,5-Aug-14,5-Aug-15
-BATTLECREEK-MI.GOV,City,Non-Federal Agency,Battle Creek,MI,ACTIVE,14-Apr-14,13-May-15
-BATTLECREEKMI.GOV,City,Non-Federal Agency,Battle Creek,MI,ACTIVE,14-Apr-14,13-May-15
-BAXTERMN.GOV,City,Non-Federal Agency,Baxter,MN,ACTIVE,22-Jul-14,13-Sep-15
-BAYSIDE-WI.GOV,City,Non-Federal Agency,Bayside,WI,ACTIVE,26-Jan-15,25-Apr-16
-BAYSTLOUIS-MS.GOV,City,Non-Federal Agency,Bay St. Louis,MS,ACTIVE,17-Dec-14,6-Jan-16
-BAYVILLENY.GOV,City,Non-Federal Agency,Bayville,NY,ACTIVE,17-Apr-14,1-Jul-14
-BEACHHAVEN-NJ.GOV,City,Non-Federal Agency,Beach Haven,NJ,ACTIVE,2-Jul-14,12-Jul-15
-BEAUMONT-CA.GOV,City,Non-Federal Agency,Beaumont,CA,ACTIVE,10-Sep-14,29-Sep-15
-BEAUMONTTEXAS.GOV,City,Non-Federal Agency,Beaumont,TX,ACTIVE,1-Jul-14,25-Sep-15
-BEAVERCREEKOHIO.GOV,City,Non-Federal Agency,Beavercreek,OH,ACTIVE,5-Jun-14,5-Jun-15
-BEAVERPA.GOV,City,Non-Federal Agency,Beaver,PA,ACTIVE,5-Mar-15,2-Jun-16
-BEAVERTONOREGON.GOV,City,Non-Federal Agency,Beaverton,OR,ACTIVE,6-Jan-15,3-Feb-16
-BEAVERTWP-OH.GOV,City,Non-Federal Agency,North Lima,OH,ACTIVE,15-May-14,15-Jun-15
-BEDFORDHEIGHTS.GOV,City,Non-Federal Agency,Bedford Heights,OH,ACTIVE,3-Oct-14,30-Sep-15
-BEDFORDMA.GOV,City,Non-Federal Agency,Bedford,MA,ACTIVE,31-Dec-14,1-Aug-15
-BEDFORDNY.GOV,City,Non-Federal Agency,Bedford Hills,NY,ACTIVE,8-Jul-14,31-Jul-15
-BEDFORDOH.GOV,City,Non-Federal Agency,Bedford,OH,ACTIVE,18-Jul-14,30-Sep-15
-BEDFORDTX.GOV,City,Non-Federal Agency,Bedford,TX,ACTIVE,7-Jul-14,3-Sep-15
-BEDFORDVA.GOV,City,Non-Federal Agency,Bedford,VA,ACTIVE,11-Aug-14,30-Sep-15
-BEECAVETEXAS.GOV,City,Non-Federal Agency,Bee Cave,TX,ACTIVE,17-Oct-13,16-Nov-14
-BELAIREKS.GOV,City,Non-Federal Agency,Bel Aire,KS,ACTIVE,6-Aug-14,29-Sep-15
-BELEN-NM.GOV,City,Non-Federal Agency,Belen,NM,ACTIVE,5-Nov-14,4-Jan-16
-BELLAIRETX.GOV,City,Non-Federal Agency,Bellaire,TX,ACTIVE,17-Dec-14,17-Dec-15
-BELLEAIRBLUFFS-FL.GOV,City,Non-Federal Agency,Belleair Bluffs,FL,ACTIVE,29-Oct-14,18-Nov-15
-BELLEMEADE-KY.GOV,City,Non-Federal Agency,Louisville,KY,ACTIVE,27-Mar-14,25-Feb-15
-BELLEVUEIA.GOV,City,Non-Federal Agency,Bellevue,IA,ACTIVE,10-Jun-14,2-Aug-15
-BELLEVUEWA.GOV,City,Non-Federal Agency,Bellevue,WA,ACTIVE,29-Jan-15,26-Apr-16
-BELMONT-MA.GOV,City,Non-Federal Agency,Belmont,MA,ACTIVE,21-Jul-14,17-Oct-15
-BELOITWI.GOV,City,Non-Federal Agency,Beloit,WI,ACTIVE,3-Dec-14,19-Feb-16
-BELTONPARKSMO.GOV,City,Non-Federal Agency,Belton,MO,ACTIVE,25-Jul-11,25-Jul-12
-BELTONTEXAS.GOV,City,Non-Federal Agency,Belton,TX,ACTIVE,20-Mar-14,19-Apr-15
-BENDOREGON.GOV,City,Non-Federal Agency,Bend,OR,ACTIVE,24-Sep-14,27-Oct-15
-BENSALEMPA.GOV,City,Non-Federal Agency,Bensalem,PA,ACTIVE,20-May-14,20-May-15
-BENSONAZ.GOV,City,Non-Federal Agency,Benson,AZ,ACTIVE,8-Sep-14,8-Sep-15
-BENTONCHARTERTOWNSHIP-MI.GOV,City,Non-Federal Agency,Benton Harbor,MI,ACTIVE,26-Sep-14,30-Sep-15
-BEREAKY.GOV,City,Non-Federal Agency,Berea,KY,ACTIVE,16-Jul-13,29-Apr-13
-BERLINMD.GOV,City,Non-Federal Agency,Berlin,MD,ACTIVE,6-Feb-15,19-Feb-16
-BERLINNH.GOV,City,Non-Federal Agency,Berlin,NH,ACTIVE,10-Feb-15,11-Apr-16
-BERNCO.GOV,City,Non-Federal Agency,Albuquerque,NM,ACTIVE,14-Aug-14,30-Sep-15
-BERWYN-IL.GOV,City,Non-Federal Agency,Berwyn,IL,ACTIVE,20-Jun-14,3-Sep-15
-BETHANYBEACH-DE.GOV,City,Non-Federal Agency,Bethany Beach,DE,ACTIVE,22-Jan-15,20-Feb-16
-BETHEL-CT.GOV,City,Non-Federal Agency,Bethel,CT,ACTIVE,17-Jun-14,22-Jul-15
-BETHEL-OH.GOV,City,Non-Federal Agency,Bethel,OH,ACTIVE,6-Oct-14,6-Oct-15
-BEVERLYHILLS-CA.GOV,City,Non-Federal Agency,Beverly Hills,CA,ACTIVE,16-Feb-15,13-May-16
-BEVERLYHILLSCA.GOV,City,Non-Federal Agency,Beverly Hills,CA,ACTIVE,16-Feb-15,13-May-16
-BEVERLYMA.GOV,City,Non-Federal Agency,Beverly,MA,ACTIVE,9-Sep-14,30-Sep-15
-BIGGS-CA.GOV,City,Non-Federal Agency,Biggs,CA,ACTIVE,2-Sep-14,30-Sep-15
-BIGSANDYTX.GOV,City,Non-Federal Agency,Big Sandy,TX,ACTIVE,19-Aug-14,16-Sep-15
-BINGHAMTON-NY.GOV,City,Non-Federal Agency,Binghamton,NY,ACTIVE,11-Apr-13,11-Apr-14
-BIRMINGHAMAL.GOV,City,Non-Federal Agency,Birmingham,AL,ACTIVE,24-Jul-13,3-Dec-13
-BISBEEAZ.GOV,City,Non-Federal Agency,Bisbee,AZ,ACTIVE,21-Jan-15,21-Jan-16
-BISCAYNEPARKFL.GOV,City,Non-Federal Agency,Biscayne Park,FL,ACTIVE,1-Aug-14,30-Sep-15
-BISMARCKND.GOV,City,Non-Federal Agency,Bismarck,ND,ACTIVE,10-Dec-14,13-Jan-16
-BIXBYOK.GOV,City,Non-Federal Agency,Bixby,OK,ACTIVE,25-Sep-13,25-Sep-14
-BLAIRSVILLE-GA.GOV,City,Non-Federal Agency,Blairsville,GA,ACTIVE,6-Feb-15,7-Apr-16
-BLANDING-UT.GOV,City,Non-Federal Agency,Blanding,UT,ACTIVE,3-Aug-12,30-Sep-13
-BLENDONTOWNSHIP-MI.GOV,City,Non-Federal Agency,Hudsonville,MI,ACTIVE,14-Aug-14,21-Sep-15
-BLOOMINGDALE-GA.GOV,City,Non-Federal Agency,Bloomingdale,GA,ACTIVE,29-May-14,29-May-15
-BLOOMINGTON-MN.GOV,City,Non-Federal Agency,Bloomington,MN,ACTIVE,13-Aug-14,30-Sep-15
-BLUEASH-OH.GOV,City,Non-Federal Agency,Blue Ash,OH,ACTIVE,18-Nov-14,15-Dec-15
-BOCARATON-FL.GOV,City,Non-Federal Agency,Boca Raton,FL,ACTIVE,10-Dec-14,30-Sep-15
-BOERNE-TX.GOV,City,Non-Federal Agency,BOERNE,TX,ACTIVE,25-Jun-14,25-Jul-15
-BOISEIDAHO.GOV,City,Non-Federal Agency,Boise,ID,ACTIVE,2-Mar-15,28-May-16
-BOLTON-MA.GOV,City,Non-Federal Agency,Bolton,MA,ACTIVE,16-Jul-14,23-Aug-15
-BONNEYTEXAS.GOV,City,Non-Federal Agency,Bonney,TX,ACTIVE,23-Apr-14,23-May-15
-BORGERTX.GOV,City,Non-Federal Agency,Borger,TX,ACTIVE,26-Feb-15,26-Feb-16
-BOSQUEFARMSNM.GOV,City,Non-Federal Agency,Bosque Farms,NM,ACTIVE,8-Jul-14,26-Jul-15
-BOSTON.GOV,City,Non-Federal Agency,Boston,MA,ACTIVE,22-Jul-14,15-Sep-15
-BOULDERCOLORADO.GOV,City,Non-Federal Agency,Boulder,CO,ACTIVE,10-Jun-14,1-Sep-15
-BOURBON-IN.GOV,City,Non-Federal Agency,Bremen,IN,ACTIVE,14-Jan-15,9-Mar-16
-BOWERSDE.GOV,City,Non-Federal Agency,"Frederica,",DE,ACTIVE,11-Mar-15,8-Apr-16
-BOWLINGGREEN-MO.GOV,City,Non-Federal Agency,Bowling Green,MO,ACTIVE,7-Aug-14,25-Aug-15
-BOWLINGGREENKY.GOV,City,Non-Federal Agency,Bowling Green,KY,ACTIVE,7-Nov-14,31-Aug-15
-BOWMAR.GOV,City,Non-Federal Agency,Bow Mar,CO,ACTIVE,9-Sep-14,30-Sep-15
-BOXBOROUGH-MA.GOV,City,Non-Federal Agency,Boxborough,MA,ACTIVE,1-Mar-15,6-Mar-16
-BOYCEVA.GOV,City,Non-Federal Agency,Boyce,VA,ACTIVE,11-Oct-13,11-Oct-14
-BOYLSTON-MA.GOV,City,Non-Federal Agency,Boylston,MA,ACTIVE,4-May-12,12-May-13
-BOZEMAN-MT.GOV,City,Non-Federal Agency,Bozeman,MT,ACTIVE,2-Mar-12,11-May-13
-BRADLEYBEACHNJ.GOV,City,Non-Federal Agency,Bradley Beach,NJ,ACTIVE,13-May-14,12-Jun-15
-BRANFORD-CT.GOV,City,Non-Federal Agency,Branford,CT,ACTIVE,8-Sep-14,10-Sep-15
-BRANSONMO.GOV,City,Non-Federal Agency,Branson,MO,ACTIVE,8-Sep-14,7-Oct-15
-BRASWELLGA.GOV,City,Non-Federal Agency,Rockmart,GA,ACTIVE,14-May-14,14-May-15
-BRAWLEY-CA.GOV,City,Non-Federal Agency,Brawley,CA,ACTIVE,5-Jan-15,4-Feb-16
-BRECKENRIDGETX.GOV,City,Non-Federal Agency,Breckenridge,TX,ACTIVE,3-Jan-13,3-Jan-14
-BREMENGA.GOV,City,Non-Federal Agency,Bremen,GA,ACTIVE,28-Aug-12,17-Sep-13
-BREMERTONWA.GOV,City,Non-Federal Agency,Bremerton,WA,ACTIVE,14-Jan-15,29-Jan-16
-BRENTWOOD-TN.GOV,City,Non-Federal Agency,Brentwood,TN,ACTIVE,25-Apr-14,27-Apr-15
-BRENTWOODCA.GOV,City,Non-Federal Agency,Brentwood,CA,ACTIVE,22-May-14,11-Jun-15
-BRENTWOODMD.GOV,City,Non-Federal Agency,Brentwood,MD,ACTIVE,4-Mar-14,24-May-15
-BRENTWOODNH.GOV,City,Non-Federal Agency,Brentwood,NH,ACTIVE,12-Jan-15,23-Jan-16
-BREWSTER-MA.GOV,City,Non-Federal Agency,Brewster,MA,ACTIVE,5-Sep-14,5-Sep-15
-BREWSTERVILLAGE-NY.GOV,City,Non-Federal Agency,Brewster,NY,ACTIVE,29-Dec-14,24-Feb-16
-BRICKTOWNSHIP-NJ.GOV,City,Non-Federal Agency,Brick,NJ,ACTIVE,11-Apr-14,9-Jul-15
-BRIDGEPORTCT.GOV,City,Non-Federal Agency,Bridgeport,CT,ACTIVE,4-Dec-14,4-Dec-15
-BRIDGEVIEW-IL.GOV,City,Non-Federal Agency,Bridgeview,IL,ACTIVE,9-Mar-15,4-Apr-16
-BRIMFIELDOHIO.GOV,City,Non-Federal Agency,Kent,OH,ACTIVE,24-Mar-14,18-Jun-15
-BRISTOLCT.GOV,City,Non-Federal Agency,Bristol,CT,ACTIVE,21-Jan-15,22-Jan-16
-BRLA.GOV,City,Non-Federal Agency,Baton Rouge,LA,ACTIVE,10-Nov-14,10-Nov-15
-BROADVIEW-IL.GOV,City,Non-Federal Agency,Broadview,IL,ACTIVE,5-Jan-15,5-Jan-16
-BROKENARROWOK.GOV,City,Non-Federal Agency,Broken Arrow,OK,ACTIVE,9-Jul-14,30-Sep-15
-BROOKFIELD-WI.GOV,City,Non-Federal Agency,Brookfield,WI,ACTIVE,25-Aug-14,30-Sep-15
-BROOKFIELDCT.GOV,City,Non-Federal Agency,Brookfield,CT,ACTIVE,28-Jan-15,15-Oct-14
-BROOKFIELDIL.GOV,City,Non-Federal Agency,Brookfield ,IL,ACTIVE,4-Jan-15,4-Jan-16
-BROOKHAVENGA.GOV,City,Non-Federal Agency,Dunwoody,GA,ACTIVE,22-Dec-14,28-Dec-15
-BROOKLINEMA.GOV,City,Non-Federal Agency,Brookline,MA,ACTIVE,10-Oct-14,28-Dec-15
-BROOKLYNOHIO.GOV,City,Non-Federal Agency,Brooklyn,OH,ACTIVE,27-Aug-14,9-Sep-15
-BROOKLYNWI.GOV,City,Non-Federal Agency,Brooklyn,WI,ACTIVE,12-Jan-15,17-Feb-16
-BROWNSVILLETN.GOV,City,Non-Federal Agency,Brownsville,TN,ACTIVE,28-Feb-13,28-Feb-14
-BROWNWOODTEXAS.GOV,City,Non-Federal Agency,Brownwood,TX,ACTIVE,15-Aug-14,15-Aug-15
-BRYCECANYONCITYUT.GOV,City,Non-Federal Agency,Bryce Canyon City,UT,ACTIVE,14-Jan-15,7-Apr-16
-BRYSONCITYNC.GOV,City,Non-Federal Agency,Bryson City,NC,ACTIVE,27-Mar-14,20-Jun-15
-BUCKEYEAZ.GOV,City,Non-Federal Agency,Buckeye,AZ,ACTIVE,2-Jul-14,30-Sep-15
-BUCKSPORTMAINE.GOV,City,Non-Federal Agency,Bucksport,ME,ACTIVE,11-Jul-14,18-Aug-15
-BUENAVISTACO.GOV,City,Non-Federal Agency,Buena Vista,CO,ACTIVE,16-Jun-14,17-May-15
-BULLHEADCITYAZ.GOV,City,Non-Federal Agency,Bullhead City,AZ,ACTIVE,4-Dec-14,4-Dec-15
-BUNKERHILLTX.GOV,City,Non-Federal Agency,HOUSTON,TX,ACTIVE,25-Jul-14,25-Jul-15
-BURBANKCA.GOV,City,Non-Federal Agency,Burbank,CA,ACTIVE,30-Jun-14,26-Sep-15
-BURBANKIL.GOV,City,Non-Federal Agency,Burbank,IL,ACTIVE,22-Aug-14,30-Sep-15
-BURIENWA.GOV,City,Non-Federal Agency,Burien,WA,ACTIVE,2-Jul-14,30-Sep-15
-BURKITTSVILLE-MD.GOV,City,Non-Federal Agency,Burkittsville,MD,ACTIVE,5-Sep-14,4-Aug-15
-BURLINGTON-WI.GOV,City,Non-Federal Agency,Burlington,WI,ACTIVE,5-Aug-14,30-Sep-15
-BURLINGTONKANSAS.GOV,City,Non-Federal Agency,Burlington,KS,ACTIVE,6-May-14,2-May-15
-BURLINGTONNC.GOV,City,Non-Federal Agency,Burlington,NC,ACTIVE,29-Aug-14,28-Sep-15
-BURLINGTONVT.GOV,City,Non-Federal Agency,Burlington,VT,ACTIVE,21-Jan-15,21-Apr-16
-BURNSHARBOR-IN.GOV,City,Non-Federal Agency,Burns Harbor,IN,ACTIVE,2-Sep-14,5-Sep-15
-BURNSVILLEMN.GOV,City,Non-Federal Agency,Burnsville,MN,ACTIVE,12-Jan-15,10-Feb-16
-BURR-RIDGE.GOV,City,Non-Federal Agency,Burr Ridge,IL,ACTIVE,30-Sep-14,30-Sep-15
-BURRILLVILLE-RI.GOV,City,Non-Federal Agency,Harrisville,RI,ACTIVE,8-Sep-14,30-Sep-15
-BURTONMI.GOV,City,Non-Federal Agency,Burton,MI,ACTIVE,16-Oct-14,21-Oct-15
-BUTLERWI.GOV,City,Non-Federal Agency,Butler,WI,ACTIVE,22-Sep-14,21-Dec-15
-BYESVILLEOH.GOV,City,Non-Federal Agency,Byesville,OH,ACTIVE,3-Dec-13,3-Dec-14
-CABOTAR.GOV,City,Non-Federal Agency,Cabot,AR,ACTIVE,10-Jul-14,30-Sep-15
-CABQ.GOV,City,Non-Federal Agency,Albuquerque,NM,ACTIVE,18-Aug-14,16-Nov-15
-CALDWELLTX.GOV,City,Non-Federal Agency,Caldwell,TX,ACTIVE,29-Jan-15,28-Mar-16
-CALEDONIAMN.GOV,City,Non-Federal Agency,Caledonia,MN,ACTIVE,23-Jan-15,11-Feb-16
-CALUMETTWP-IN.GOV,City,Non-Federal Agency,Gary,IN,ACTIVE,30-Dec-14,30-Sep-15
-CAMBRIDGEMA.GOV,City,Non-Federal Agency,Cambridge,MA,ACTIVE,2-Sep-14,30-Sep-15
-CAMBRIDGENY.GOV,City,Non-Federal Agency,Cambridge,NY,ACTIVE,19-Jun-14,10-Jul-15
-CAMDENMAINE.GOV,City,Non-Federal Agency,Camden,ME,ACTIVE,27-Mar-12,17-May-13
-CAMDENTN.GOV,City,Non-Federal Agency,Camden,TN,ACTIVE,23-Jun-14,29-Jun-15
-CAMPBELLOHIO.GOV,City,Non-Federal Agency,Campbell,OH,ACTIVE,22-Nov-10,18-Feb-12
-CANALWINCHESTEROHIO.GOV,City,Non-Federal Agency,Canal Winchester,OH,ACTIVE,21-Apr-14,14-May-15
-CANNONFALLSMN.GOV,City,Non-Federal Agency,Cannon Falls,MN,ACTIVE,28-Jun-14,7-Aug-15
-CANTONOHIO.GOV,City,Non-Federal Agency,Canton,OH,ACTIVE,24-Dec-14,14-Jan-16
-CANTONTWP-OH.GOV,City,Non-Federal Agency,Canton,OH,ACTIVE,29-Nov-14,30-Nov-15
-CANTONTX.GOV,City,Non-Federal Agency,Canton,TX,ACTIVE,13-Jun-14,9-Jul-15
-CARBONDALE-PA.GOV,City,Non-Federal Agency,Carbondale,PA,ACTIVE,4-Nov-13,16-Oct-14
-CARLISLE-IA.GOV,City,Non-Federal Agency,Carlisle,IA,ACTIVE,30-Oct-13,30-Sep-14
-CARLISLEMA.GOV,City,Non-Federal Agency,Carlisle,MA,ACTIVE,13-Mar-14,5-Jun-15
-CARLSBADCA.GOV,City,Non-Federal Agency,Carlsbad,CA,ACTIVE,2-Apr-14,9-Jun-15
-CARNATIONWA.GOV,City,Non-Federal Agency,Carnation,WA,ACTIVE,7-Jul-14,9-Jul-15
-CARNEGIEOK.GOV,City,Non-Federal Agency,Carnegie,OK,ACTIVE,22-Aug-14,22-Aug-15
-CARNEYSPOINTNJ.GOV,City,Non-Federal Agency,Carneys Point,NJ,ACTIVE,22-Jul-13,6-Aug-13
-CARRBORONC.GOV,City,Non-Federal Agency,Carrboro,NC,ACTIVE,6-Oct-14,3-Jan-16
-CARROLLTON-GA.GOV,City,Non-Federal Agency,Carrollton,GA,ACTIVE,6-Sep-13,30-Sep-14
-CARTERLAKE-IA.GOV,City,Non-Federal Agency,Carter Lake,IA,ACTIVE,19-Jul-13,22-Jun-13
-CARTERSVILLEGA.GOV,City,Non-Federal Agency,Cartersville,GA,ACTIVE,5-Feb-15,5-Apr-16
-CARTHAGEMO.GOV,City,Non-Federal Agency,Carthage,MO,ACTIVE,13-Sep-13,29-Nov-14
-CARYNC.GOV,City,Non-Federal Agency,Cary,NC,ACTIVE,6-Feb-15,6-Feb-16
-CASAGRANDEAZ.GOV,City,Non-Federal Agency,Casa Grande,AZ,ACTIVE,7-Aug-14,17-Oct-15
-CASPERWY.GOV,City,Non-Federal Agency,Casper,WY,ACTIVE,20-Aug-14,30-Sep-15
-CASTROVILLETX.GOV,City,Non-Federal Agency,Castroville,TX,ACTIVE,3-Oct-14,2-Nov-15
-CATHEDRALCITY.GOV,City,Non-Federal Agency,Cathedral City,CA,ACTIVE,19-Aug-14,26-Aug-15
-CAVESPRINGSAR.GOV,City,Non-Federal Agency,Cave Springs,AR,ACTIVE,19-Feb-15,19-Feb-16
-CECILTONMD.GOV,City,Non-Federal Agency,Cecilton ,MD,ACTIVE,2-Jan-15,21-Jan-16
-CECILTOWNSHIP-PA.GOV,City,Non-Federal Agency,Cecil,PA,ACTIVE,30-Sep-14,30-Sep-15
-CEDARHURST.GOV,City,Non-Federal Agency,cedarhurst,NY,ACTIVE,30-Sep-14,30-Sep-15
-CEDARPARKTEXAS.GOV,City,Non-Federal Agency,Cedar Park,TX,ACTIVE,24-Nov-14,23-Jan-16
-CEDARRAPIDS-IA.GOV,City,Non-Federal Agency,Cedar Rapids,IA,ACTIVE,9-Oct-14,30-Sep-15
-CEDARTOWNGEORGIA.GOV,City,Non-Federal Agency,Cedartown,GA,ACTIVE,12-Sep-11,10-Jul-12
-CENTENNIALCO.GOV,City,Non-Federal Agency,Centennial,CO,ACTIVE,22-Jul-14,19-Aug-15
-CENTERCO.GOV,City,Non-Federal Agency,Center,CO,ACTIVE,17-Jul-13,2-Feb-14
-CENTERVILLEOHIO.GOV,City,Non-Federal Agency,Centerville,OH,ACTIVE,19-Sep-14,30-Sep-15
-CENTERVILLETX.GOV,City,Non-Federal Agency,College Station,TX,ACTIVE,15-Jul-14,9-Oct-15
-CENTRAL-LA.GOV,City,Non-Federal Agency,Central,LA,ACTIVE,27-May-14,30-Jun-15
-CENTRALPOINTOREGON.GOV,City,Non-Federal Agency,Central Point,OR,ACTIVE,8-Jan-15,21-Apr-15
-CENTREVILLE-MD.GOV,City,Non-Federal Agency,Centreville,MD,ACTIVE,15-Sep-10,30-Sep-11
-CERESCO-NE.GOV,City,Non-Federal Agency,Ceresco,NE,ACTIVE,19-Oct-10,30-Sep-11
-CGAZ.GOV,City,Non-Federal Agency,Casa Grande,AZ,ACTIVE,4-Dec-14,4-Mar-16
-CHADDSFORDPA.GOV,City,Non-Federal Agency,Chadds Ford,PA,ACTIVE,15-Jan-14,21-Jan-15
-CHAMBERSBURGPA.GOV,City,Non-Federal Agency,Chambersburg,PA,ACTIVE,16-Aug-12,17-Oct-13
-CHAMBLEEGA.GOV,City,Non-Federal Agency,Chamblee,GA,ACTIVE,11-Oct-14,12-Oct-15
-CHARLESTON-SC.GOV,City,Non-Federal Agency,Charleston,SC,ACTIVE,21-Apr-14,27-Apr-15
-CHARLESTONWV.GOV,City,Non-Federal Agency,Charleston,WV,ACTIVE,20-Oct-14,20-Oct-15
-CHARLESTOWN-NH.GOV,City,Non-Federal Agency,Charlestown,NH,ACTIVE,23-Oct-14,10-Nov-15
-CHARLOTTENC.GOV,City,Non-Federal Agency,Charlotte,NC,ACTIVE,19-Mar-14,26-May-15
-CHARLOTTESVILLEVA.GOV,City,Non-Federal Agency,Charlottesville,VA,ACTIVE,4-Feb-15,4-Feb-16
-CHATHAM-MA.GOV,City,Non-Federal Agency,Chatham,MA,ACTIVE,18-Aug-14,2-Sep-15
-CHATHAM-VA.GOV,City,Non-Federal Agency,Chatham,VA,ACTIVE,1-Aug-14,30-Sep-15
-CHATHAMTOWNSHIP-NJ.GOV,City,Non-Federal Agency,Chatham,NJ,ACTIVE,19-Feb-14,17-May-15
-CHATSWORTHGA.GOV,City,Non-Federal Agency,Chatsworth,GA,ACTIVE,13-Jun-13,12-Aug-14
-CHATTANOOGA.GOV,City,Non-Federal Agency,Chattanooga,TN,ACTIVE,4-Mar-15,30-Sep-15
-CHELSEAMA.GOV,City,Non-Federal Agency,Chelsea,MA,ACTIVE,18-Sep-14,30-Sep-15
-CHESAPEAKECITY-MD.GOV,City,Non-Federal Agency,Chesapeake City,MD,ACTIVE,7-Apr-14,7-Mar-15
-CHESHIRE-MA.GOV,City,Non-Federal Agency,Cheshire,MA,ACTIVE,3-Jul-14,30-Sep-15
-CHESTER-NY.GOV,City,Non-Federal Agency,Chester,NY,ACTIVE,21-May-14,21-May-15
-CHESTNUTHILLTWP-PA.GOV,City,Non-Federal Agency,Brodheadsville,PA,ACTIVE,30-Sep-14,30-Sep-15
-CHEVERLY-MD.GOV,City,Non-Federal Agency,Cheverly,MD,ACTIVE,16-Sep-14,15-Nov-15
-CHEVYCHASEVILLAGEMD.GOV,City,Non-Federal Agency,Chevy Chase,MD,ACTIVE,27-Feb-15,26-Sep-15
-CHICOCA.GOV,City,Non-Federal Agency,Chico,CA,ACTIVE,30-Oct-14,1-Oct-15
-CHICOPEEMA.GOV,City,Non-Federal Agency,Chicopee,MA,ACTIVE,18-Nov-14,22-Nov-15
-CHILMARKMA.GOV,City,Non-Federal Agency,Chilmark,MA,ACTIVE,20-Oct-14,20-Oct-15
-CHINAGROVENC.GOV,City,Non-Federal Agency,China Grove,NC,ACTIVE,25-Sep-14,30-Sep-15
-CHINCOTEAGUE-VA.GOV,City,Non-Federal Agency,Chincoteague,VA,ACTIVE,2-Jul-14,30-Sep-15
-CHIPPEWAFALLS-WI.GOV,City,Non-Federal Agency,Chippewa Falls,WI,ACTIVE,19-Aug-13,16-Jul-14
-CHOWANCOUNTY-NC.GOV,City,Non-Federal Agency,Edenton,NC,ACTIVE,15-Jul-13,30-Sep-14
-CHURCHHILLTN.GOV,City,Non-Federal Agency,Church Hill,TN,ACTIVE,13-Aug-12,8-Nov-13
-CIBOLOTX.GOV,City,Non-Federal Agency,Cibolo,TX,ACTIVE,18-Nov-14,13-Nov-15
-CINCINNATI-OH.GOV,City,Non-Federal Agency,Cincinnati,OH,ACTIVE,2-Jun-14,30-Aug-15
-CINCINNATIOHIO.GOV,City,Non-Federal Agency,Cincinnati,OH,ACTIVE,2-Jun-14,7-Aug-15
-CITYKANKAKEE-IL.GOV,City,Non-Federal Agency,KANKAKEE,IL,ACTIVE,16-Jul-13,30-Aug-14
-CITYOFADAMS-WI.GOV,City,Non-Federal Agency,Adams,WI,ACTIVE,15-Sep-14,30-Sep-15
-CITYOFAIKENSC.GOV,City,Non-Federal Agency,Aiken,SC,ACTIVE,20-Aug-14,19-Sep-15
-CITYOFALAMEDACA.GOV,City,Non-Federal Agency,Alameda,CA,ACTIVE,28-Apr-14,26-May-15
-CITYOFALBIONMI.GOV,City,Non-Federal Agency,albion,MI,ACTIVE,27-Jan-15,25-Feb-16
-CITYOFALCOA-TN.GOV,City,Non-Federal Agency,Alcoa,TN,ACTIVE,8-Jan-15,8-Apr-16
-CITYOFALGOODTN.GOV,City,Non-Federal Agency,Algood,TN,ACTIVE,21-Nov-14,16-Dec-15
-CITYOFALMAGA.GOV,City,Non-Federal Agency,Alma,GA,ACTIVE,8-Sep-14,6-Sep-15
-CITYOFBAKERLA.GOV,City,Non-Federal Agency,Baker ,LA,ACTIVE,17-Jul-13,19-Mar-14
-CITYOFBELOITWI.GOV,City,Non-Federal Agency,Beloit,WI,ACTIVE,3-Dec-14,19-Feb-16
-CITYOFBENTONHARBORMI.GOV,City,Non-Federal Agency,Benton Harbor,MI,ACTIVE,8-Mar-12,8-Mar-13
-CITYOFBLUERIDGEGA.GOV,City,Non-Federal Agency,Blue Ridge,GA,ACTIVE,3-Dec-14,10-Feb-16
-CITYOFBOWIEMD.GOV,City,Non-Federal Agency,Bowie,MD,ACTIVE,19-Sep-12,30-Sep-13
-CITYOFBOWMANGA.GOV,City,Non-Federal Agency,Bowman,GA,ACTIVE,11-Mar-15,11-Mar-16
-CITYOFBRUNSWICK-GA.GOV,City,Non-Federal Agency,Brunswick,GA,ACTIVE,12-Feb-15,11-Apr-16
-CITYOFCANALFULTON-OH.GOV,City,Non-Federal Agency,Canal Fulton,OH,ACTIVE,17-Sep-13,7-Nov-14
-CITYOFCAYCE-SC.GOV,City,Non-Federal Agency,Cayce,SC,ACTIVE,9-Jul-14,7-Sep-15
-CITYOFCHETEK-WI.GOV,City,Non-Federal Agency,Chetek,WI,ACTIVE,3-Jul-14,30-Sep-15
-CITYOFCHOTEAU-MT.GOV,City,Non-Federal Agency,Choteau,MT,ACTIVE,27-May-14,21-Aug-15
-CITYOFCONWAY-AR.GOV,City,Non-Federal Agency,Conway,AR,ACTIVE,5-Feb-15,5-Feb-16
-CITYOFCOWETA-OK.GOV,City,Non-Federal Agency,Coweta,OK,ACTIVE,6-Jan-14,2-Feb-15
-CITYOFCRISFIELD-MD.GOV,City,Non-Federal Agency,Crisfield,MD,ACTIVE,18-Jun-12,16-Jul-13
-CITYOFCUDAHYCA.GOV,City,Non-Federal Agency,Cudahy,CA,ACTIVE,29-Aug-12,30-Sep-13
-CITYOFDALTON-GA.GOV,City,Non-Federal Agency,Dalton,GA,ACTIVE,15-Dec-14,15-Dec-15
-CITYOFDOUGLASGA.GOV,City,Non-Federal Agency,Douglas,GA,ACTIVE,17-Jul-14,28-Sep-15
-CITYOFDOVERIDAHO.GOV,City,Non-Federal Agency,Dover,ID,ACTIVE,8-Dec-14,8-Dec-15
-CITYOFDUNBARWV.GOV,City,Non-Federal Agency,Dunbar,WV,ACTIVE,2-Mar-15,29-May-16
-CITYOFDUPONTWA.GOV,City,Non-Federal Agency,DuPont,WA,ACTIVE,6-Jun-14,20-Jun-15
-CITYOFENGLEWOOD-NJ.GOV,City,Non-Federal Agency,Englewood,NJ,ACTIVE,29-Sep-10,29-Sep-11
-CITYOFEUDORAKS.GOV,City,Non-Federal Agency,Eudora,KS,ACTIVE,22-Oct-12,27-Dec-13
-CITYOFFAIRFAX-MN.GOV,City,Non-Federal Agency,Fairfax,MN,ACTIVE,2-Jul-14,30-Sep-15
-CITYOFFARMERSVILLE-CA.GOV,City,Non-Federal Agency,Farmersville,CA,ACTIVE,15-Aug-14,9-Sep-15
-CITYOFFARMINGTON-AR.GOV,City,Non-Federal Agency,Farmington,AR,ACTIVE,5-Jun-14,3-Sep-15
-CITYOFFOLKSTON-GA.GOV,City,Non-Federal Agency,Folkston,GA,ACTIVE,14-Oct-14,5-Oct-15
-CITYOFFORTOGLETHORPEGA.GOV,City,Non-Federal Agency,FORT OGLETHORPE,GA,ACTIVE,27-Mar-13,29-Mar-14
-CITYOFGAFFNEY-SC.GOV,City,Non-Federal Agency,Gaffney,SC,ACTIVE,1-Oct-14,30-Sep-15
-CITYOFGALENAPARK-TX.GOV,City,Non-Federal Agency,Galena Park,TX,ACTIVE,8-Aug-14,30-Aug-15
-CITYOFGRAVETTE-AR.GOV,City,Non-Federal Agency,Gravette,AR,ACTIVE,31-Jul-14,1-Aug-15
-CITYOFGUNNISON-CO.GOV,City,Non-Federal Agency,Gunnison,CO,ACTIVE,10-Jan-14,3-Apr-15
-CITYOFHAMPTON-GA.GOV,City,Non-Federal Agency,Hampton,GA,ACTIVE,11-Apr-14,10-Jul-15
-CITYOFHARRISON-MI.GOV,City,Non-Federal Agency,Harrison,MI,ACTIVE,16-Aug-13,30-Aug-14
-CITYOFHAYWARDWI.GOV,City,Non-Federal Agency,Hayward,WI,ACTIVE,17-Jun-14,11-Sep-15
-CITYOFHIRAMGA.GOV,City,Non-Federal Agency,HIRAM,GA,ACTIVE,16-Jan-15,15-Feb-16
-CITYOFHOKAH-MN.GOV,City,Non-Federal Agency,Hokah,MN,ACTIVE,7-Mar-14,5-Jun-15
-CITYOFHOMER-AK.GOV,City,Non-Federal Agency,Homer,AK,ACTIVE,29-Dec-14,30-Nov-15
-CITYOFHUMBLE-TX.GOV,City,Non-Federal Agency,Humble,TX,ACTIVE,24-Feb-15,22-May-16
-CITYOFHUMBLETX.GOV,City,Non-Federal Agency,Humble,TX,ACTIVE,24-Feb-15,23-May-16
-CITYOFKEYWEST-FL.GOV,City,Non-Federal Agency,Key West,FL,ACTIVE,31-Jul-14,31-Jul-15
-CITYOFKINGMAN.GOV,City,Non-Federal Agency,Kingman,AZ,ACTIVE,7-Jul-14,30-Sep-15
-CITYOFKINGSBURG-CA.GOV,City,Non-Federal Agency,Kingsburg,CA,ACTIVE,29-Jul-14,30-Sep-15
-CITYOFLACRESCENT-MN.GOV,City,Non-Federal Agency,La Crescent,MN,ACTIVE,2-Sep-14,31-Aug-15
-CITYOFLAGRANGEMO.GOV,City,Non-Federal Agency,LaGrange,MO,ACTIVE,2-Jul-14,30-Sep-15
-CITYOFLAHABRA-CA.GOV,City,Non-Federal Agency,LA HABRA,CA,ACTIVE,31-May-14,1-Jun-15
-CITYOFLENEXA-KS.GOV,City,Non-Federal Agency,Lenexa,KS,ACTIVE,2-Jul-14,30-Sep-15
-CITYOFLENEXAKS.GOV,City,Non-Federal Agency,Lenexa,KS,ACTIVE,2-Jan-15,9-Jan-16
-CITYOFLINCOLN-IL.GOV,City,Non-Federal Agency,Lincoln,IL,ACTIVE,8-Jan-14,15-Feb-15
-CITYOFLINDALETX.GOV,City,Non-Federal Agency,LINDALE,TX,ACTIVE,13-Oct-14,11-Dec-15
-CITYOFLISBON-IA.GOV,City,Non-Federal Agency,Lisbon,IA,ACTIVE,16-Sep-14,29-Oct-15
-CITYOFLUBBOCKTX.GOV,City,Non-Federal Agency,Lubbock,TX,ACTIVE,2-Mar-15,3-Apr-16
-CITYOFMACON-MO.GOV,City,Non-Federal Agency,Macon,MO,ACTIVE,19-Jul-12,12-Oct-13
-CITYOFMARIONIL.GOV,City,Non-Federal Agency,Marion,IL,ACTIVE,11-Mar-14,8-Jun-15
-CITYOFMARIONWI.GOV,City,Non-Federal Agency,MARION,WI,ACTIVE,15-Jan-13,15-Jan-14
-CITYOFMCCAYSVILLEGA.GOV,City,Non-Federal Agency,McCaysville,GA,ACTIVE,25-Apr-14,24-Jul-15
-CITYOFMIDLANDMI.GOV,City,Non-Federal Agency,Midland,MI,ACTIVE,27-May-14,27-May-15
-CITYOFMILLBROOK-AL.GOV,City,Non-Federal Agency,Millbrook,AL,ACTIVE,24-Dec-13,24-Nov-14
-CITYOFMILLENGA.GOV,City,Non-Federal Agency,Millen,GA,ACTIVE,(blank),14-Jan-16
-CITYOFMONONGAHELA-PA.GOV,City,Non-Federal Agency,Monongahela,PA,ACTIVE,30-Dec-14,14-Jan-16
-CITYOFMORROWGA.GOV,City,Non-Federal Agency,Morrow,GA,ACTIVE,24-Jul-14,24-Jul-15
-CITYOFMTVERNON-IA.GOV,City,Non-Federal Agency,Mount Vernon,IA,ACTIVE,8-Aug-14,6-Nov-15
-CITYOFNANTICOKE-PA.GOV,City,Non-Federal Agency,Nanticoke,PA,ACTIVE,13-Feb-14,15-Mar-15
-CITYOFNEWBURGH-NY.GOV,City,Non-Federal Agency,Newburgh,NY,ACTIVE,19-Sep-14,30-Sep-15
-CITYOFNEWULM-MN.GOV,City,Non-Federal Agency,New Ulm,MN,ACTIVE,1-Aug-14,30-Sep-15
-CITYOFNORMANDY.GOV,City,Non-Federal Agency,St. Louis,MO,ACTIVE,21-Nov-14,7-Sep-15
-CITYOFOMAHA-NE.GOV,City,Non-Federal Agency,Omaha,NE,ACTIVE,23-Jul-13,21-Oct-14
-CITYOFPACIFICWA.GOV,City,Non-Federal Agency,Pacific,WA,ACTIVE,23-Sep-14,20-Jul-15
-CITYOFPALMVALLEY-TX.GOV,City,Non-Federal Agency,Harlingen,TX,ACTIVE,19-Oct-11,30-Oct-12
-CITYOFPARISTN.GOV,City,Non-Federal Agency,Paris,TN,ACTIVE,11-Aug-14,7-Sep-15
-CITYOFPARMA-OH.GOV,City,Non-Federal Agency,Parma,OH,ACTIVE,9-Jul-14,27-Aug-15
-CITYOFPATTERSONLA.GOV,City,Non-Federal Agency,Patterson,LA,ACTIVE,29-Dec-14,24-Jan-16
-CITYOFPEARLANDTX.GOV,City,Non-Federal Agency,Pearland,TX,ACTIVE,10-Mar-11,9-May-12
-CITYOFPHOENIX.GOV,City,Non-Federal Agency,Phoenix,AZ,ACTIVE,27-Aug-14,30-Sep-15
-CITYOFPIGEONFORGETN.GOV,City,Non-Federal Agency,Pigeon Forge,TN,ACTIVE,15-Aug-14,15-Aug-15
-CITYOFPLAINVILLE-KS.GOV,City,Non-Federal Agency,Plainville,KS,ACTIVE,5-Aug-14,30-Sep-15
-CITYOFPLATTSBURGH-NY.GOV,City,Non-Federal Agency,Plattsburgh,NY,ACTIVE,9-Feb-15,20-Feb-16
-CITYOFPLEASANTONCA.GOV,City,Non-Federal Agency,Pleasanton,CA,ACTIVE,29-Oct-14,18-Nov-15
-CITYOFPOCOMOKEMD.GOV,City,Non-Federal Agency,Pocomoke City,MD,ACTIVE,3-Apr-14,4-Apr-15
-CITYOFPORTLANDTN.GOV,City,Non-Federal Agency,Portland,TN,ACTIVE,10-Jun-14,10-Jun-15
-CITYOFREDMOND.GOV,City,Non-Federal Agency,Redmond,WA,ACTIVE,9-Jul-14,30-Sep-15
-CITYOFROCKHILLSC.GOV,City,Non-Federal Agency,Rock Hill,SC,ACTIVE,30-Oct-14,30-Oct-15
-CITYOFROCKPORT-IN.GOV,City,Non-Federal Agency,Rockport,IN,ACTIVE,17-Nov-14,13-Dec-15
-CITYOFSAFFORDAZ.GOV,City,Non-Federal Agency,Safford,AZ,ACTIVE,5-Aug-13,18-Oct-14
-CITYOFSALEMNJ.GOV,City,Non-Federal Agency,Salem,NJ,ACTIVE,8-Aug-14,27-Sep-15
-CITYOFSANTEECA.GOV,City,Non-Federal Agency,Santee,CA,ACTIVE,1-Apr-14,18-Jun-15
-CITYOFSPARTANBURG-SC.GOV,City,Non-Federal Agency,Spartanburg,SC,ACTIVE,2-Jul-14,30-Sep-15
-CITYOFSTOCKBRIDGE-GA.GOV,City,Non-Federal Agency,Stockbridge,GA,ACTIVE,3-Jun-13,29-Jun-14
-CITYOFSUGAR-LANDTX.GOV,City,Non-Federal Agency,Sugar Land,TX,ACTIVE,30-Oct-12,30-Sep-13
-CITYOFSUGARLAND-TX.GOV,City,Non-Federal Agency,Sugar Land,TX,ACTIVE,30-Oct-12,30-Sep-13
-CITYOFSUGARLANDTX.GOV,City,Non-Federal Agency,Sugar Land,TX,ACTIVE,30-Oct-12,30-Sep-13
-CITYOFTITUSVILLEPA.GOV,City,Non-Federal Agency,Titusville,PA,ACTIVE,23-Apr-14,20-Jun-15
-CITYOFTORRANCECA.GOV,City,Non-Federal Agency,Torrance,CA,ACTIVE,18-Feb-15,7-May-16
-CITYOFTUKWILA-WA.GOV,City,Non-Federal Agency,Tukwila,WA,ACTIVE,2-Oct-13,30-Sep-14
-CITYOFTYLER-TX.GOV,City,Non-Federal Agency,Tyler,TX,ACTIVE,13-Aug-12,2-Sep-13
-CITYOFTYLERTX.GOV,City,Non-Federal Agency,Tyler,TX,ACTIVE,13-Aug-12,2-Sep-13
-CITYOFWASHINGTONGA.GOV,City,Non-Federal Agency,Washington,GA,ACTIVE,10-Apr-13,24-Mar-14
-CITYOFWEATHERBYLAKE-MO.GOV,City,Non-Federal Agency,Weatherby Lake,MO,ACTIVE,17-Oct-14,18-Oct-15
-CITYOFWESTONLAKES-TX.GOV,City,Non-Federal Agency,Fulshear,TX,ACTIVE,15-Jul-13,7-Apr-13
-CITYOFWEYAUWEGA-WI.GOV,City,Non-Federal Agency,Weyauwega,WI,ACTIVE,5-Jul-13,6-Jul-14
-CITYOFWHEATON-IL.GOV,City,Non-Federal Agency,Wheaton,IL,ACTIVE,8-Jan-15,7-Feb-16
-CITYOFWORLANDWY.GOV,City,Non-Federal Agency,Worland,WY,ACTIVE,19-May-14,16-Jul-15
-CITYOFYUKONOK.GOV,City,Non-Federal Agency,Yukon,OK,ACTIVE,29-Apr-14,28-Jul-15
-CLAIRTON-PA.GOV,City,Non-Federal Agency,Clairton,PA,ACTIVE,23-Oct-12,23-Oct-13
-CLARKSTONGA.GOV,City,Non-Federal Agency,Clarkston,GA,ACTIVE,27-Jul-12,27-Jul-13
-CLAYTONMO.GOV,City,Non-Federal Agency,Clayton,MO,ACTIVE,24-Oct-14,12-Nov-15
-CLEARLAKE-WI.GOV,City,Non-Federal Agency,Clear Lake,WI,ACTIVE,2-Apr-14,18-Apr-15
-CLEARLAKESHORES-TX.GOV,City,Non-Federal Agency,Clear Lake Shores,TX,ACTIVE,8-Sep-14,30-Sep-15
-CLERMONTFL.GOV,City,Non-Federal Agency,Clermont,FM,ACTIVE,15-Oct-14,15-Oct-15
-CLEVELAND-OH.GOV,City,Non-Federal Agency,Cleveland,OH,ACTIVE,8-Sep-14,30-Sep-15
-CLEVELANDTN.GOV,City,Non-Federal Agency,Cleveland,TN,ACTIVE,2-Aug-13,23-Jul-14
-CLEWISTON-FL.GOV,City,Non-Federal Agency,Clewiston,FL,ACTIVE,2-Oct-12,30-Sep-13
-CLIFFSIDEPARKNJ.GOV,City,Non-Federal Agency,Cliffside Park,NJ,ACTIVE,14-Sep-14,30-Sep-15
-CLIFTONFORGEVA.GOV,City,Non-Federal Agency,Clifton Forge,VA,ACTIVE,9-Sep-13,11-Jun-14
-CLINTONMA.GOV,City,Non-Federal Agency,Clinton,MA,ACTIVE,7-Nov-14,7-Nov-15
-CLINTONNJ.GOV,City,Non-Federal Agency,New Jersey,NJ,ACTIVE,2-Jul-14,30-Sep-15
-CLINTONOK.GOV,City,Non-Federal Agency,Clinton,OK,ACTIVE,25-Jul-13,25-Jul-14
-CMSDCA.GOV,City,Non-Federal Agency,Costa Mesa,CA,ACTIVE,4-Aug-14,30-Sep-15
-COALRUNKY.GOV,City,Non-Federal Agency,Pikeville,KY,ACTIVE,22-Jan-15,23-Jan-16
-COLCHESTERCT.GOV,City,Non-Federal Agency,Colchester,CT,ACTIVE,2-May-14,30-May-15
-COLCHESTERVT.GOV,City,Non-Federal Agency,Colchester,VT,ACTIVE,3-Feb-15,3-May-16
-COLDSPRINGKY.GOV,City,Non-Federal Agency,COLD SPRING,KY,ACTIVE,19-May-14,30-Jul-15
-COLDSPRINGNY.GOV,City,Non-Federal Agency,Cold Spring ,NY,ACTIVE,25-Jul-14,11-Sep-15
-COLFAX-CA.GOV,City,Non-Federal Agency,Colfax,CA,ACTIVE,5-Feb-15,5-Mar-16
-COLLEGEPARKMD.GOV,City,Non-Federal Agency,College Park,MD,ACTIVE,18-Dec-14,16-Feb-16
-COLLEGEVILLE-PA.GOV,City,Non-Federal Agency,Collegeville,PA,ACTIVE,18-Sep-14,30-Sep-15
-COLLIERVILLETN.GOV,City,Non-Federal Agency,Collierville,TN,ACTIVE,27-Feb-15,27-May-16
-COLLINCOUNTYTEXAS.GOV,City,Non-Federal Agency,Mckinney,TX,ACTIVE,3-Sep-14,30-Sep-15
-COLLINCOUNTYTX.GOV,City,Non-Federal Agency,McKinney,TX,ACTIVE,3-Sep-14,30-Sep-15
-COLONIALHEIGHTSVA.GOV,City,Non-Federal Agency,Colonial Heights,VA,ACTIVE,20-Jun-14,13-Sep-15
-COLONIE-NY.GOV,City,Non-Federal Agency,Newtonville,NY,ACTIVE,20-Oct-10,30-Sep-11
-COLORADOSPRINGS.GOV,City,Non-Federal Agency,Colorado Springs,CO,ACTIVE,18-Feb-15,6-Feb-16
-COLRAIN-MA.GOV,City,Non-Federal Agency,Colrain,MA,ACTIVE,18-Nov-14,23-Nov-15
-COLUMBIANAOHIO.GOV,City,Non-Federal Agency,Columbiana,OH,ACTIVE,28-Jul-14,28-Jul-15
-COLUMBIATN.GOV,City,Non-Federal Agency,Columbia,TN,ACTIVE,11-Sep-14,4-Oct-15
-COLUMBIATWP-OH.GOV,City,Non-Federal Agency,Columbia Station,OH,ACTIVE,30-Dec-13,26-Mar-15
-COLUMBUS.GOV,City,Non-Federal Agency,Columbus,OH,ACTIVE,17-Sep-14,13-Sep-15
-COLUMBUSOH.GOV,City,Non-Federal Agency,Columbus,OH,ACTIVE,17-Sep-14,13-Sep-15
-COLUMBUSOHIO.GOV,City,Non-Federal Agency,Columbus,OH,ACTIVE,17-Sep-14,13-Sep-15
-COMMERCIALPOINTOHIO.GOV,City,Non-Federal Agency,Commercial Point,OH,ACTIVE,19-Mar-14,22-May-15
-CONCORDMA.GOV,City,Non-Federal Agency,Concord,MA,ACTIVE,6-Oct-14,3-Nov-15
-CONCORDNC.GOV,City,Non-Federal Agency,Concord,NC,ACTIVE,3-Mar-15,31-Mar-16
-CONCORDNH.GOV,City,Non-Federal Agency,Concord,NH,ACTIVE,4-Sep-14,3-Nov-15
-CONCRETEWA.GOV,City,Non-Federal Agency,Concrete,WA,ACTIVE,6-Oct-14,3-Dec-15
-CONNEAUTOHIO.GOV,City,Non-Federal Agency,Conneaut,OH,ACTIVE,17-Mar-14,11-Jun-15
-CONNERSVILLEIN.GOV,City,Non-Federal Agency,Connersville,IN,ACTIVE,5-Sep-14,30-Sep-15
-CONOVERNC.GOV,City,Non-Federal Agency,Conover,NC,ACTIVE,1-Jul-14,31-Jul-15
-CONYERSGA.GOV,City,Non-Federal Agency,Conyers,GA,ACTIVE,4-Jun-12,5-May-13
-COOKEVILLE-TN.GOV,City,Non-Federal Agency,Cookeville,TN,ACTIVE,12-Nov-14,4-Dec-15
-COONRAPIDSMN.GOV,City,Non-Federal Agency,Coon Rapids,MN,ACTIVE,12-May-14,10-Aug-15
-COPPELLTX.GOV,City,Non-Federal Agency,Coppell,TX,ACTIVE,12-Aug-14,6-Aug-15
-COPPERASCOVETX.GOV,City,Non-Federal Agency,Copperas Cove,TX,ACTIVE,3-Sep-14,13-Sep-15
-COR.GOV,City,Non-Federal Agency,Richardson,TX,ACTIVE,1-Aug-14,30-Sep-15
-CORALGABLES-FL.GOV,City,Non-Federal Agency,Coral Gables,FL,ACTIVE,23-Jul-14,30-Sep-15
-CORALGABLESFL.GOV,City,Non-Federal Agency,Coral Gables,FL,ACTIVE,23-Jul-14,30-Sep-15
-CORBIN-KY.GOV,City,Non-Federal Agency,Corbin,KY,ACTIVE,5-Mar-15,28-Mar-16
-CORNINGAR.GOV,City,Non-Federal Agency,Corning,AR,ACTIVE,8-Apr-14,9-Apr-15
-CORNWALLNY.GOV,City,Non-Federal Agency,Cornwall,NY,ACTIVE,22-Apr-14,23-May-15
-CORPUSCHRISTI-TX.GOV,City,Non-Federal Agency,Corpus Christi,TX,ACTIVE,19-Sep-14,30-Sep-15
-CORRALESNM.GOV,City,Non-Federal Agency,Corales,NM,ACTIVE,13-Feb-15,13-Feb-16
-CORRYPA.GOV,City,Non-Federal Agency,Corry,PA,ACTIVE,31-Mar-14,25-Jun-15
-CORVALLISOREGON.GOV,City,Non-Federal Agency,Corvallis,OR,ACTIVE,7-Nov-14,1-Dec-15
-CORYDON-IN.GOV,City,Non-Federal Agency,Corydon,IN,ACTIVE,5-May-14,12-May-15
-COSPRINGS.GOV,City,Non-Federal Agency,Colorado Springs,CO,ACTIVE,18-Feb-15,19-Mar-16
-COSTAMESACA.GOV,City,Non-Federal Agency,Costa Mesa,CA,ACTIVE,22-May-14,21-Jul-15
-COTTAGECITYMD.GOV,City,Non-Federal Agency,Cottage City,MD,ACTIVE,19-Feb-13,3-May-14
-COTTONWOODAZ.GOV,City,Non-Federal Agency,Cottonwood,AZ,ACTIVE,25-Jul-14,30-Jul-15
-COUNTRYSIDE-IL.GOV,City,Non-Federal Agency,Countryside,IL,ACTIVE,1-Aug-14,30-Sep-15
-COVINACA.GOV,City,Non-Federal Agency,Covina,CA,ACTIVE,17-Mar-14,16-Mar-15
-COVINGTON-OH.GOV,City,Non-Federal Agency,COVINGTON ,OH,ACTIVE,30-Aug-13,15-Oct-14
-COVINGTONKY.GOV,City,Non-Federal Agency,Covington,KY,ACTIVE,3-Sep-14,30-Sep-15
-COVINGTONWA.GOV,City,Non-Federal Agency,Covington,WA,ACTIVE,4-Nov-14,22-Nov-15
-CRANBERRYISLES-ME.GOV,City,Non-Federal Agency,Islesford,ME,ACTIVE,25-Feb-15,16-Apr-16
-CRAWFORDSVILLE-IN.GOV,City,Non-Federal Agency,Crawfordsville,IN,ACTIVE,7-Aug-14,30-Sep-15
-CREDITRIVER-MN.GOV,City,Non-Federal Agency,Prior Lake,MN,ACTIVE,19-Feb-15,14-May-16
-CRESTONIOWA.GOV,City,Non-Federal Agency,Creston,IA,ACTIVE,30-Oct-14,28-Jan-16
-CRETE-NE.GOV,City,Non-Federal Agency,Crete,NE,ACTIVE,24-Jun-14,20-Sep-15
-CROSSROADSTX.GOV,City,Non-Federal Agency,Crossroads,TX,ACTIVE,29-Dec-14,28-Mar-16
-CROSSVILLETN.GOV,City,Non-Federal Agency,Crossville,TN,ACTIVE,1-Oct-14,5-Oct-15
-CROTONONHUDSON-NY.GOV,City,Non-Federal Agency,Croton-On-Hudson,NY,ACTIVE,6-Aug-14,30-Sep-15
-CUBAASSESSORIL.GOV,City,Non-Federal Agency,Barrington,IL,ACTIVE,4-Dec-14,4-Dec-15
-CUBATWPIL.GOV,City,Non-Federal Agency,Barrington,IL,ACTIVE,4-Dec-14,4-Dec-15
-CUDAHY-WI.GOV,City,Non-Federal Agency,Cudahy,WI,ACTIVE,17-Jun-14,15-Sep-15
-CULPEPERVA.GOV,City,Non-Federal Agency,Culpeper,VA,ACTIVE,8-Aug-12,7-Sep-13
-CUMBERLANDMD.GOV,City,Non-Federal Agency,Cumberland,MD,ACTIVE,13-Jun-14,13-Jun-15
-CUMMINGTON-MA.GOV,City,Non-Federal Agency,Cummington,MA,ACTIVE,2-Sep-14,30-Sep-15
-CUTLERBAY-FL.GOV,City,Non-Federal Agency,Cutler Bay,FL,ACTIVE,23-Feb-15,24-Mar-16
-DACULAGA.GOV,City,Non-Federal Agency,Dacula,GA,ACTIVE,8-Sep-14,7-Dec-15
-DAHLONEGA-GA.GOV,City,Non-Federal Agency,Dahlonega,GA,ACTIVE,13-Feb-15,30-Apr-16
-DALHARTTX.GOV,City,Non-Federal Agency,Dalhart,TX,ACTIVE,6-Feb-14,6-Feb-15
-DALLAS-GA.GOV,City,Non-Federal Agency,Dallas,GA,ACTIVE,21-Jul-14,17-Oct-15
-DALLASOR.GOV,City,Non-Federal Agency,Dallas,OR,ACTIVE,13-May-14,12-Jul-15
-DALLASOREGON.GOV,City,Non-Federal Agency,Dallas,OR,ACTIVE,13-May-14,12-Jun-15
-DALTON-MA.GOV,City,Non-Federal Agency,Dalton,MA,ACTIVE,31-Oct-14,30-Sep-15
-DAMASCUSOREGON.GOV,City,Non-Federal Agency,Damascus,OR,ACTIVE,4-Mar-15,3-May-16
-DANBURY-CT.GOV,City,Non-Federal Agency,Danbury,CT,ACTIVE,18-Sep-14,30-Sep-15
-DANDRIDGETN.GOV,City,Non-Federal Agency,Dandridge,TN,ACTIVE,23-Feb-15,23-Feb-16
-DANIABEACHFL.GOV,City,Non-Federal Agency,DANIA BEACH,FL,ACTIVE,17-Dec-14,6-Jan-16
-DANVILLEVA.GOV,City,Non-Federal Agency,Danville,VA,ACTIVE,12-Mar-15,1-May-16
-DARIENIL.GOV,City,Non-Federal Agency,Darien,IL,ACTIVE,23-Jun-14,20-Jul-15
-DAUGHERTYTOWNSHIP-PA.GOV,City,Non-Federal Agency,New Brighton,PA,ACTIVE,15-Sep-14,15-Sep-15
-DAVIE-FL.GOV,City,Non-Federal Agency,Davie,FL,ACTIVE,15-Jul-14,30-Sep-15
-DAWSONVILLE-GA.GOV,City,Non-Federal Agency,Dawsonville,GA,ACTIVE,4-Apr-14,2-Jun-15
-DAYTON-ME.GOV,City,Non-Federal Agency,Dayton,ME,ACTIVE,8-Sep-14,30-Sep-15
-DAYTONOHIO.GOV,City,Non-Federal Agency,Dayton,OH,ACTIVE,25-Jun-14,17-Aug-15
-DECATURIL.GOV,City,Non-Federal Agency,Decatur,IL,ACTIVE,13-Jun-14,13-Jun-15
-DECATURILLINOIS.GOV,City,Non-Federal Agency,Decatur,IL,ACTIVE,13-Jun-14,13-Jun-15
-DEDHAM-MA.GOV,City,Non-Federal Agency,Dedham,MA,ACTIVE,9-Sep-14,30-Sep-15
-DEERFIELDMICHIGAN.GOV,City,Non-Federal Agency,Deerfield,MI,ACTIVE,17-Oct-13,15-Dec-14
-DEERPARK-OH.GOV,City,Non-Federal Agency,Deer Park,OH,ACTIVE,23-Feb-15,27-Feb-16
-DEERPARKTX.GOV,City,Non-Federal Agency,Deer Park,TX,ACTIVE,2-Jul-14,30-Sep-15
-DEKORRA-WI.GOV,City,Non-Federal Agency,Poynette,WI,ACTIVE,6-Jun-14,8-Jun-15
-DELAWARETOWNSHIPPA.GOV,City,Non-Federal Agency,Dingmans Ferry,PA,ACTIVE,19-Nov-14,2-Feb-16
-DELRAYBEACHFL.GOV,City,Non-Federal Agency,Delray Beach,FL,ACTIVE,10-Sep-14,11-Jul-15
-DELTA-CO.GOV,City,Non-Federal Agency,Delta,CO,ACTIVE,28-Apr-14,26-Jul-15
-DELTAMI.GOV,City,Non-Federal Agency,Lansing,MI,ACTIVE,12-Aug-14,30-Sep-15
-DELTONAFL.GOV,City,Non-Federal Agency,Deltona,FL,ACTIVE,11-Feb-15,10-May-16
-DEMOPOLISAL.GOV,City,Non-Federal Agency,Demopolis,AL,ACTIVE,16-Jan-14,13-Feb-15
-DERBYCT.GOV,City,Non-Federal Agency,Derby,CT,ACTIVE,23-Apr-12,18-May-13
-DHAZ.GOV,City,Non-Federal Agency,Humboldt,AZ,ACTIVE,2-Aug-13,5-Jun-14
-DIAMONDBARCA.GOV,City,Non-Federal Agency,Diamond Bar,CA,ACTIVE,7-Jan-15,23-Feb-16
-DICKINSONTEXAS.GOV,City,Non-Federal Agency,Dickinson,TX,ACTIVE,3-Mar-15,21-Apr-16
-DICKSONCITY-PA.GOV,City,Non-Federal Agency,Dickson City,PA,ACTIVE,5-Nov-14,5-Nov-15
-DIGHTON-MA.GOV,City,Non-Federal Agency,Dighton,MA,ACTIVE,12-Aug-14,30-Sep-15
-DONALDOREGON.GOV,City,Non-Federal Agency,Donald,OR,ACTIVE,27-Sep-12,27-Sep-13
-DONALDSONVILLE-LA.GOV,City,Non-Federal Agency,Donaldsonville,LA,ACTIVE,9-Oct-14,9-Oct-15
-DORALPD-FL.GOV,City,Non-Federal Agency,Doral,FL,ACTIVE,8-Jan-15,7-Jan-16
-DOUGLASAZ.GOV,City,Non-Federal Agency,Douglas,AZ,ACTIVE,5-Jun-14,3-Sep-15
-DOUGLASVILLEGA.GOV,City,Non-Federal Agency,Douglasville,GA,ACTIVE,1-Oct-14,30-Nov-15
-DREW-MS.GOV,City,Non-Federal Agency,Drew,MS,ACTIVE,15-Nov-14,12-Jul-15
-DRUIDHILLSKY.GOV,City,Non-Federal Agency,Louisville,KY,ACTIVE,15-Aug-14,13-Nov-15
-DUBLIN-CA.GOV,City,Non-Federal Agency,Dublin,CA,ACTIVE,22-Jul-14,25-Aug-15
-DUBLINCA.GOV,City,Non-Federal Agency,Dublin,CA,ACTIVE,22-Jul-14,25-Aug-15
-DUBLINOHIOUSA.GOV,City,Non-Federal Agency,Dublin,OH,ACTIVE,2-Apr-14,27-Jun-15
-DUBOISPA.GOV,City,Non-Federal Agency,DuBois,PA,ACTIVE,4-Feb-15,21-Apr-16
-DULUTHMN.GOV,City,Non-Federal Agency,Duluth,MN,ACTIVE,12-Jun-14,6-Jul-15
-DUMFRIESVA.GOV,City,Non-Federal Agency,Dumfries,VA,ACTIVE,12-Mar-12,14-Apr-13
-DUMONTNJ.GOV,City,Non-Federal Agency,Dumont,NJ,ACTIVE,8-Sep-14,8-Jul-15
-DUNCANOK.GOV,City,Non-Federal Agency,Duncan,OK,ACTIVE,9-Jul-14,1-Aug-15
-DUNCANVILLETX.GOV,City,Non-Federal Agency,Duncanville,TX,ACTIVE,21-Oct-14,15-Oct-15
-DUNDEEVILLAGEMI.GOV,City,Non-Federal Agency,Dundee,MI,ACTIVE,28-Jul-14,26-Sep-15
-DUNSTABLE-MA.GOV,City,Non-Federal Agency,Dunstable,MA,ACTIVE,20-Aug-14,26-Aug-15
-DUNWOODYGA.GOV,City,Non-Federal Agency,Dunwoody,GA,ACTIVE,10-Oct-14,10-Oct-15
-DUNWOODYGEORGIA.GOV,City,Non-Federal Agency,Dunwoody,GA,ACTIVE,12-Aug-10,10-Oct-11
-DUPONTWA.GOV,City,Non-Federal Agency,DuPont,WA,ACTIVE,27-Feb-15,28-Apr-16
-DUSHOREPA.GOV,City,Non-Federal Agency,Dushore,PA,ACTIVE,7-Jan-15,21-Jan-16
-DUVALLWA.GOV,City,Non-Federal Agency,Duvall,WA,ACTIVE,22-Oct-14,20-Jan-16
-DYERSBURGTN.GOV,City,Non-Federal Agency,Dyersburg,TN,ACTIVE,3-Mar-15,31-Mar-16
-EAGARAZ.GOV,City,Non-Federal Agency,Eagar,AZ,ACTIVE,3-Apr-14,5-Apr-15
-EAGLE-WI.GOV,City,Non-Federal Agency,Eagle,WI,ACTIVE,30-Jan-14,27-Mar-15
-EAGLELAKE-TX.GOV,City,Non-Federal Agency,Eagle Lake,TX,ACTIVE,8-Sep-14,30-Sep-15
-EASTBOROUGH-KS.GOV,City,Non-Federal Agency,Eastborough,KS,ACTIVE,2-Jul-14,2-Jul-15
-EASTCOVENTRY-PA.GOV,City,Non-Federal Agency,Pottstown,PA,ACTIVE,2-Jul-14,30-Sep-15
-EASTHAMPTONCT.GOV,City,Non-Federal Agency,East Hampton,CT,ACTIVE,22-Dec-14,15-Jan-16
-EASTHAMPTONNY.GOV,City,Non-Federal Agency,Amagansett,NY,ACTIVE,10-Apr-13,25-Apr-14
-EASTHAMPTONVILLAGENY.GOV,City,Non-Federal Agency,East Hampton,NY,ACTIVE,28-Oct-14,28-Oct-15
-EASTHARTFORDCT.GOV,City,Non-Federal Agency,East Hartford,CT,ACTIVE,11-Dec-14,10-Mar-16
-EASTKINGSTONNH.GOV,City,Non-Federal Agency,East Kingston,NH,ACTIVE,18-Jun-14,18-Jun-15
-EASTLONGMEADOWMA.GOV,City,Non-Federal Agency,East Longmeadow,MA,ACTIVE,28-Jul-14,18-Sep-15
-EASTMOUNTAINTX.GOV,City,Non-Federal Agency,East Mountain,TX,ACTIVE,6-May-13,6-May-14
-EASTONCT.GOV,City,Non-Federal Agency,Easton,CT,ACTIVE,11-Aug-14,10-Sep-15
-EASTONMD.GOV,City,Non-Federal Agency,Easton,MD,ACTIVE,10-Nov-14,8-Jan-16
-EASTORANGE-NJ.GOV,City,Non-Federal Agency,East ORange,NJ,ACTIVE,9-Jan-14,24-Jan-15
-EASTPALESTINE-OH.GOV,City,Non-Federal Agency,East Palestine,OH,ACTIVE,3-Mar-15,29-May-16
-EASTPORT-ME.GOV,City,Non-Federal Agency,Eastport,ME,ACTIVE,19-Sep-14,30-Sep-15
-EASTRIDGETN.GOV,City,Non-Federal Agency,East Ridge,TN,ACTIVE,17-Jul-13,24-Sep-13
-EASTVALECA.GOV,City,Non-Federal Agency,Eastvale,CA,ACTIVE,30-Sep-14,30-Nov-15
-EATONVILLE-WA.GOV,City,Non-Federal Agency,Eatonville,WA,ACTIVE,9-Jan-15,10-Feb-16
-ECORSEMI.GOV,City,Non-Federal Agency,ECORSE,MI,ACTIVE,27-Oct-14,13-Dec-15
-EDDINGTONMAINE.GOV,City,Non-Federal Agency,Eddington,ME,ACTIVE,25-Jun-14,25-Jun-15
-EDENNY.GOV,City,Non-Federal Agency,Eden,NY,ACTIVE,1-Aug-14,30-Aug-15
-EDGARCOUNTY-IL.GOV,City,Non-Federal Agency,Paris,IL,ACTIVE,31-Aug-12,30-Sep-13
-EDGEWATERFL.GOV,City,Non-Federal Agency,Edgewater,FL,ACTIVE,24-Feb-15,23-Apr-16
-EDGEWOOD-FL.GOV,City,Non-Federal Agency,Edgewood,FL,ACTIVE,1-Oct-14,30-Nov-15
-EDGEWOOD-NM.GOV,City,Non-Federal Agency,Edgewood,NM,ACTIVE,2-Sep-14,2-Sep-15
-EDINAMN.GOV,City,Non-Federal Agency,Edina,MN,ACTIVE,3-Nov-14,31-Jan-16
-EDMONDS-WA.GOV,City,Non-Federal Agency,Edmonds,WA,ACTIVE,19-Mar-14,16-Jun-15
-EDMONDSWA.GOV,City,Non-Federal Agency,Edmonds,WA,ACTIVE,19-Mar-14,16-Jun-15
-EDMONSTONMD.GOV,City,Non-Federal Agency,Edmonston,MD,ACTIVE,22-Oct-14,22-Oct-15
-EHAMPTONNY.GOV,City,Non-Federal Agency,East Hampton,NY,ACTIVE,14-Aug-13,26-May-13
-ELKHARTLAKEWI.GOV,City,Non-Federal Agency,Elkhart Lake,WI,ACTIVE,18-Mar-14,17-May-15
-ELKRIVERMN.GOV,City,Non-Federal Agency,Elk River,MN,ACTIVE,18-Nov-14,16-Feb-16
-ELKTONVA.GOV,City,Non-Federal Agency,Elkton,VA,ACTIVE,12-Sep-12,30-Sep-13
-ELKTOWNSHIPNJ.GOV,City,Non-Federal Agency,Monroeville,NJ,ACTIVE,11-Jan-15,26-Mar-16
-ELLAGO-TX.GOV,City,Non-Federal Agency,El Lago,TX,ACTIVE,14-May-13,14-May-14
-ELLIJAY-GA.GOV,City,Non-Federal Agency,Ellijay,GA,ACTIVE,13-Mar-14,29-Mar-15
-ELLINGTON-CT.GOV,City,Non-Federal Agency,Ellington,CT,ACTIVE,23-Jul-14,30-Sep-15
-ELLSWORTHMAINE.GOV,City,Non-Federal Agency,Ellsworth,ME,ACTIVE,11-Sep-14,20-Sep-15
-ELMIRAGE-AZ.GOV,City,Non-Federal Agency,El Mirage,AZ,ACTIVE,30-Sep-14,30-Sep-15
-ELOYAZ.GOV,City,Non-Federal Agency,Eloy,AZ,ACTIVE,2-Feb-15,2-Feb-16
-ELPASOTEXAS.GOV,City,Non-Federal Agency,El Paso,TX,ACTIVE,2-Jul-14,30-Sep-15
-EMERALDBAY-TX.GOV,City,Non-Federal Agency,Bullard,TX,ACTIVE,28-Jul-14,16-Sep-15
-EMMITSBURGMD.GOV,City,Non-Federal Agency,Emmitsburg,MD,ACTIVE,29-Sep-14,30-Sep-15
-EMPORIA-KANSAS.GOV,City,Non-Federal Agency,Emporia,KS,ACTIVE,30-Dec-14,17-Jul-15
-ENCINITASCA.GOV,City,Non-Federal Agency,Encinitas,CA,ACTIVE,12-May-14,2-Jun-15
-ENCINITASCALIFORNIA.GOV,City,Non-Federal Agency,Encinitas,CA,ACTIVE,18-Dec-14,9-Jan-16
-ENNISTX.GOV,City,Non-Federal Agency,Ennis,TX,ACTIVE,13-Mar-15,12-May-16
-ENTERPRISEAL.GOV,City,Non-Federal Agency,Enterprise,AL,ACTIVE,3-Jul-14,3-Jul-15
-ERIECO.GOV,City,Non-Federal Agency,Erie,CO,ACTIVE,7-Nov-14,6-Dec-15
-ESPANOLANM.GOV,City,Non-Federal Agency,Espanola,NM,ACTIVE,2-Dec-14,30-Sep-15
-ESSEXCT.GOV,City,Non-Federal Agency,Essex,CT,ACTIVE,30-Sep-14,30-Sep-15
-ETON-GA.GOV,City,Non-Federal Agency,Eton,GA,ACTIVE,27-Jul-14,19-Sep-15
-EULESSTX.GOV,City,Non-Federal Agency,Euless,TX,ACTIVE,19-Aug-14,15-Oct-15
-EUREKA-MT.GOV,City,Non-Federal Agency,Eureka,MT,ACTIVE,25-Jul-14,5-Jun-15
-EUREKASPRINGSAR.GOV,City,Non-Federal Agency,Eureka Springs,AR,ACTIVE,4-Feb-15,4-Feb-16
-EVANSCOLORADO.GOV,City,Non-Federal Agency,Evans,CO,ACTIVE,1-Dec-14,9-Aug-15
-EVERETTWA.GOV,City,Non-Federal Agency,Everett,WA,ACTIVE,2-Apr-14,13-Jun-15
-EVESHAM-NJ.GOV,City,Non-Federal Agency,Marlton,NJ,ACTIVE,27-Sep-14,28-Sep-15
-EXETERNH.GOV,City,Non-Federal Agency,Exeter,NH,ACTIVE,15-Jan-14,15-Jan-15
-FABIUS-NY.GOV,City,Non-Federal Agency,Fabius,NY,ACTIVE,2-Dec-14,30-Sep-15
-FAIRFAX-VT.GOV,City,Non-Federal Agency,Fairfax,VT,ACTIVE,8-Sep-14,3-Oct-15
-FAIRFAXVA.GOV,City,Non-Federal Agency,Fairfax,VA,ACTIVE,14-Jul-14,30-Sep-15
-FAIRFIELDOH.GOV,City,Non-Federal Agency,Fairfield,OH,ACTIVE,2-Mar-15,1-Mar-16
-FAIRHOPE-AL.GOV,City,Non-Federal Agency,Fairhope,AL,ACTIVE,28-Aug-12,28-Aug-13
-FAIRMONTWV.GOV,City,Non-Federal Agency,Fairmont,WV,ACTIVE,2-Apr-14,25-Jun-15
-FAIRVIEWNC.GOV,City,Non-Federal Agency,Monroe,NC,ACTIVE,17-Feb-15,10-Apr-16
-FAIRVIEWOREGON.GOV,City,Non-Federal Agency,Fairview,OR,ACTIVE,5-Jun-14,10-Aug-15
-FALLCREEKWI.GOV,City,Non-Federal Agency,Fall Creek,WI,ACTIVE,16-Dec-14,29-Dec-15
-FALLSCHURCHCITYVA.GOV,City,Non-Federal Agency,Falls Church,VA,ACTIVE,22-Dec-14,22-Dec-15
-FALLSCHURCHVA.GOV,City,Non-Federal Agency,Falls Church,VA,ACTIVE,22-Dec-14,22-Dec-15
-FALLSCITYOREGON.GOV,City,Non-Federal Agency,Falls City,OR,ACTIVE,21-Jul-14,16-Oct-15
-FARGOND.GOV,City,Non-Federal Agency,Fargo,ND,ACTIVE,31-Mar-14,11-Apr-15
-FARMERSBRANCHTX.GOV,City,Non-Federal Agency,Farmers Branch,TX,ACTIVE,1-Aug-14,30-Oct-15
-FARMINGTON-MO.GOV,City,Non-Federal Agency,Farmington,MO,ACTIVE,8-Oct-13,7-Dec-14
-FARMINGTONHILLSMI.GOV,City,Non-Federal Agency,Farmington Hills,MI,ACTIVE,3-Feb-11,25-Apr-12
-FAYETTEVILLE-AR.GOV,City,Non-Federal Agency,Fayetteville,AR,ACTIVE,21-Feb-14,22-Apr-15
-FAYETTEVILLENC.GOV,City,Non-Federal Agency,Fayetteville,NC,ACTIVE,3-Sep-14,1-Nov-15
-FAYETTEVILLENY.GOV,City,Non-Federal Agency,Fayetteville,NY,ACTIVE,30-Oct-12,30-Sep-13
-FEDERALWAYWA.GOV,City,Non-Federal Agency,Federal Way ,WA,ACTIVE,2-Mar-15,28-Mar-16
-FERNDALEMI.GOV,City,Non-Federal Agency,Ferndale,MI,ACTIVE,6-Jan-15,7-Jan-16
-FITCHBURGMA.GOV,City,Non-Federal Agency,Fitchburg,MA,ACTIVE,23-Jan-15,22-Jan-16
-FITCHBURGWI.GOV,City,Non-Federal Agency,Fitchburg,WI,ACTIVE,1-Apr-14,30-May-15
-FITZWILLIAM-NH.GOV,City,Non-Federal Agency,Fitzwilliam,NH,ACTIVE,8-Sep-14,7-Sep-15
-FLAGSTAFFAZ.GOV,City,Non-Federal Agency,Flagstaff,AZ,ACTIVE,24-Oct-14,13-Jan-16
-FLORENCE-KY.GOV,City,Non-Federal Agency,Florence,KY,ACTIVE,31-Mar-14,27-Jun-15
-FLORENCE-NJ.GOV,City,Non-Federal Agency,Florence,NJ,ACTIVE,31-Mar-14,29-Jun-15
-FLORENCEAZ.GOV,City,Non-Federal Agency,Florence,AZ,ACTIVE,13-Feb-15,13-Apr-16
-FLORIDACITYFL.GOV,City,Non-Federal Agency,Florida City,FL,ACTIVE,2-Jul-14,30-Sep-15
-FORESTGROVE-OR.GOV,City,Non-Federal Agency,FOREST GROVE,OR,ACTIVE,25-Jul-13,27-Aug-14
-FORESTHEIGHTSMD.GOV,City,Non-Federal Agency,Forest Heights,MD,ACTIVE,27-Feb-14,15-Apr-15
-FORESTPARKOH.GOV,City,Non-Federal Agency,Forest Park,OH,ACTIVE,13-Aug-13,10-Sep-13
-FORESTPARKOHIO.GOV,City,Non-Federal Agency,Forest Park,OH,ACTIVE,9-Sep-11,10-Sep-12
-FORESTPARKOK.GOV,City,Non-Federal Agency,Forest Park,OK,ACTIVE,25-Feb-15,25-Feb-16
-FORTLUPTON-CO.GOV,City,Non-Federal Agency,Fort Lupton,CO,ACTIVE,15-Jul-14,10-Oct-15
-FORTLUPTONCO.GOV,City,Non-Federal Agency,Fort Lupton,CO,ACTIVE,22-Dec-14,20-Mar-16
-FORTMADISON-IA.GOV,City,Non-Federal Agency,Fort Madison,IA,ACTIVE,20-Oct-14,18-Jan-16
-FORTMILLSC.GOV,City,Non-Federal Agency,Fort Mill,SC,ACTIVE,21-Mar-13,4-Feb-14
-FORTMYERSBEACHFL.GOV,City,Non-Federal Agency,Fort Myers Beach,FL,ACTIVE,3-Dec-14,21-Dec-15
-FORTSMITHAR.GOV,City,Non-Federal Agency,Fort Smith,AR,ACTIVE,10-Oct-14,8-Jan-16
-FORTWORTH-TEXAS.GOV,City,Non-Federal Agency,Fort Worth,TX,ACTIVE,7-Aug-14,3-Sep-15
-FORTWORTH-TX.GOV,City,Non-Federal Agency,Fort Worth,TX,ACTIVE,7-Aug-14,3-Sep-15
-FORTWORTHTEXAS.GOV,City,Non-Federal Agency,Fort Worth,TX,ACTIVE,7-Aug-14,3-Sep-15
-FOSTORIAOHIO.GOV,City,Non-Federal Agency,Fostoria,OH,ACTIVE,28-Aug-14,28-Aug-15
-FOXBOROUGHMA.GOV,City,Non-Federal Agency,Foxborough,MA,ACTIVE,12-Dec-14,21-Jan-16
-FRAMINGHAMMA.GOV,City,Non-Federal Agency,Framingham,MA,ACTIVE,15-Sep-14,30-Sep-15
-FRANCESTOWN-NH.GOV,City,Non-Federal Agency,Francestown,NH,ACTIVE,16-Jul-14,28-Aug-15
-FRANKFORT-IN.GOV,City,Non-Federal Agency,Frankfort,IN,ACTIVE,21-May-14,20-Jun-15
-FRANKFORT-KY.GOV,City,Non-Federal Agency,Frankfort,KY,ACTIVE,22-Jul-13,4-Oct-14
-FRANKLIN-IN.GOV,City,Non-Federal Agency,FRANKLIN,IN,ACTIVE,12-Sep-11,30-Sep-12
-FRANKLIN-TN.GOV,City,Non-Federal Agency,Franklin,TN,ACTIVE,9-Jun-14,5-Aug-15
-FRANKLINPA.GOV,City,Non-Federal Agency,Franklin,PA,ACTIVE,30-Jul-14,3-Aug-15
-FRANKLINTN.GOV,City,Non-Federal Agency,Franklin,TN,ACTIVE,9-Jun-14,5-Aug-15
-FREDENBERGTWP-MN.GOV,City,Non-Federal Agency,Duluth,MN,ACTIVE,14-Aug-13,13-Feb-13
-FREDERICKCO.GOV,City,Non-Federal Agency,Frederick,CO,ACTIVE,12-Sep-12,30-Sep-13
-FREDERICKSBURGVA.GOV,City,Non-Federal Agency,Fredericksburg,VA,ACTIVE,2-Jul-14,30-Sep-15
-FREEHOLDBOROUGHNJ.GOV,City,Non-Federal Agency,Freehold,NJ,ACTIVE,23-Jan-15,23-Jan-16
-FREEPORTNY.GOV,City,Non-Federal Agency,Freeport,NY,ACTIVE,2-Jul-14,30-Sep-15
-FREETOWNMA.GOV,City,Non-Federal Agency,Assonet,MA,ACTIVE,12-Jan-15,25-Jan-16
-FREMONTNC.GOV,City,Non-Federal Agency,Fremont,NC,ACTIVE,17-Jul-13,28-Apr-13
-FREMONTNE.GOV,City,Non-Federal Agency,Fremont,NE,ACTIVE,17-Nov-14,16-Oct-15
-FRENCHSETTLEMENT-LA.GOV,City,Non-Federal Agency,French Settlement,LA,ACTIVE,14-Nov-13,30-Sep-13
-FRIDLEYMN.GOV,City,Non-Federal Agency,Fridley,MN,ACTIVE,14-Aug-14,14-Aug-15
-FRIENDSHIPHEIGHTSMD.GOV,City,Non-Federal Agency,Chevy Chase,MD,ACTIVE,2-Jul-14,30-Sep-15
-FROMBERG-MT.GOV,City,Non-Federal Agency,Fromberg,MT,ACTIVE,16-Feb-14,5-Feb-14
-FRONTROYAL-VA.GOV,City,Non-Federal Agency,Front Royal,VA,ACTIVE,1-Dec-14,30-Sep-15
-FRONTROYALVA.GOV,City,Non-Federal Agency,Front Royal,VA,ACTIVE,30-Oct-14,23-Dec-15
-FRUITPORTTOWNSHIP-MI.GOV,City,Non-Federal Agency,Fruitport,MI,ACTIVE,5-May-14,2-Jul-15
-FULSHEARTEXAS.GOV,City,Non-Federal Agency,Fulshear,TX,ACTIVE,5-Jan-15,10-Jan-16
-GAHANNA.GOV,City,Non-Federal Agency,Gahanna,OH,ACTIVE,13-Jun-14,27-Aug-15
-GALESBURG-IL.GOV,City,Non-Federal Agency,Galesburg,IL,ACTIVE,11-Mar-15,9-Jun-16
-GALLATIN-TN.GOV,City,Non-Federal Agency,Gallatin,TN,ACTIVE,2-Sep-14,30-Sep-15
-GALLAWAYTN.GOV,City,Non-Federal Agency,Gallaway,TN,ACTIVE,23-Dec-14,20-Mar-16
-GALLOWAYTWP-NJ.GOV,City,Non-Federal Agency,Galloway,NJ,ACTIVE,30-Apr-14,14-Jun-15
-GALLUPNM.GOV,City,Non-Federal Agency,GALLUP,NM,ACTIVE,18-Dec-13,13-Mar-15
-GALVAIL.GOV,City,Non-Federal Agency,Galva,IL,ACTIVE,6-Mar-14,4-Jun-15
-GARDENCITY-GA.GOV,City,Non-Federal Agency,Garden City,GA,ACTIVE,24-Jun-14,6-Jul-15
-GARDNERKANSAS.GOV,City,Non-Federal Agency,Gardner,KS,ACTIVE,31-May-14,30-Aug-15
-GARDNERVILLE-NV.GOV,City,Non-Federal Agency,Gardnerville,NV,ACTIVE,20-Aug-14,30-Sep-15
-GARLANDTX.GOV,City,Non-Federal Agency,Garland,TX,ACTIVE,17-Sep-12,15-Dec-13
-GARNERNC.GOV,City,Non-Federal Agency,Garner,NC,ACTIVE,6-Aug-14,4-Nov-15
-GARRETTPARK-MD.GOV,City,Non-Federal Agency,Garrett Park,MD,ACTIVE,8-Sep-14,6-Sep-15
-GATLINBURGTN.GOV,City,Non-Federal Agency,Gatlinburg,TN,ACTIVE,1-Jul-14,27-Jul-15
-GEORGETOWN-KENTUCKY.GOV,City,Non-Federal Agency,Georgetown,KY,ACTIVE,31-Jul-13,30-Sep-13
-GEORGETOWN-MI.GOV,City,Non-Federal Agency,Jenison,MI,ACTIVE,16-Dec-14,16-Mar-16
-GEORGETOWNKY.GOV,City,Non-Federal Agency,Georgetown,KY,ACTIVE,24-Jun-14,21-Apr-15
-GEORGETOWNTX.GOV,City,Non-Federal Agency,Georgetown,TX,ACTIVE,5-Dec-14,5-Dec-15
-GERMANTOWN-TN.GOV,City,Non-Federal Agency,Germantown,TN,ACTIVE,3-Jul-14,30-Sep-15
-GETTYSBURG-PA.GOV,City,Non-Federal Agency,Gettysburg,PA,ACTIVE,17-Jun-13,14-Sep-14
-GILLETTEWY.GOV,City,Non-Federal Agency,Gillette,WY,ACTIVE,15-Oct-13,15-Sep-14
-GIRARDKANSAS.GOV,City,Non-Federal Agency,Girard,KS,ACTIVE,21-Jan-14,19-Apr-15
-GLASTONBURY-CT.GOV,City,Non-Federal Agency,Glastonbury,CT,ACTIVE,5-Feb-15,6-Feb-16
-GLENDALE-WI.GOV,City,Non-Federal Agency,Glendale,WI,ACTIVE,9-Sep-13,9-Sep-14
-GLENDALEAZ.GOV,City,Non-Federal Agency,Glendale,AZ,ACTIVE,11-Sep-13,20-Sep-14
-GLENDALECA.GOV,City,Non-Federal Agency,Glendale,CA,ACTIVE,22-Jan-14,22-Apr-15
-GLENVIEWKY.GOV,City,Non-Federal Agency,Glenview,KY,ACTIVE,23-Apr-14,18-Apr-15
-GLENWILLOW-OH.GOV,City,Non-Federal Agency,Glenwillow,OH,ACTIVE,28-Jul-14,30-Sep-15
-GLOBEAZ.GOV,City,Non-Federal Agency,GLOBE,AZ,ACTIVE,2-Jan-15,1-Mar-16
-GLOUCESTER-MA.GOV,City,Non-Federal Agency,Gloucester,MA,ACTIVE,3-Sep-14,27-Sep-15
-GODDARDKS.GOV,City,Non-Federal Agency,Goddard,KS,ACTIVE,13-Feb-15,14-Apr-16
-GODLEYTX.GOV,City,Non-Federal Agency,Godley,TX,ACTIVE,5-Mar-15,30-May-16
-GOFFSTOWNNH.GOV,City,Non-Federal Agency,Goffstown,NH,ACTIVE,24-Dec-14,22-Feb-16
-GOLDBEACHOREGON.GOV,City,Non-Federal Agency,GoldBeach,OR,ACTIVE,15-Oct-14,14-Oct-15
-GOLDENVALLEYMN.GOV,City,Non-Federal Agency,Golden Valley,MN,ACTIVE,2-May-14,8-Jul-15
-GOLDSBORONC.GOV,City,Non-Federal Agency,Goldsboro,NC,ACTIVE,18-Mar-14,1-Jun-15
-GOODHOPEAL.GOV,City,Non-Federal Agency,Cullman,AL,ACTIVE,15-Oct-13,3-Dec-14
-GOODYEARAZ.GOV,City,Non-Federal Agency,Goodyear,AZ,ACTIVE,4-Aug-14,30-Sep-15
-GOSHEN-OH.GOV,City,Non-Federal Agency,Goshen,OH,ACTIVE,21-Jan-14,29-Mar-15
-GOSHEN-OHIO.GOV,City,Non-Federal Agency,Goshen,OH,ACTIVE,1-Feb-12,29-Mar-13
-GOSHENCT.GOV,City,Non-Federal Agency,Goshen,CT,ACTIVE,18-Aug-14,14-Nov-15
-GPSHORESMI.GOV,City,Non-Federal Agency,Grosse Pointe Shores,MI,ACTIVE,2-Oct-14,5-Dec-15
-GRAFTON-MA.GOV,City,Non-Federal Agency,Grafton,MA,ACTIVE,9-Mar-15,31-Mar-16
-GRANBY-MA.GOV,City,Non-Federal Agency,Granby,MA,ACTIVE,15-Sep-14,10-Dec-15
-GRANDTERRACE-CA.GOV,City,Non-Federal Agency,Grand Terrace,CA,ACTIVE,22-Sep-14,22-Sep-15
-GRANDVIEW-IN.GOV,City,Non-Federal Agency,Grandview,IN,ACTIVE,20-Aug-14,15-Nov-15
-GRANGERIOWA.GOV,City,Non-Federal Agency,Granger,IA,ACTIVE,16-Sep-14,18-Sep-15
-GRANITEFALLSWA.GOV,City,Non-Federal Agency,Granite Falls,WA,ACTIVE,15-Aug-14,7-Sep-15
-GRANITEQUARRYNC.GOV,City,Non-Federal Agency,Granite Quarry ,NC,ACTIVE,17-Jul-13,4-Nov-13
-GRANTFORKIL.GOV,City,Non-Federal Agency,Highland,IL,ACTIVE,13-Sep-14,13-Sep-15
-GRANTSPASSOREGON.GOV,City,Non-Federal Agency,Grants Pass,OR,ACTIVE,5-Sep-12,7-Sep-13
-GRANTSVILLEUT.GOV,City,Non-Federal Agency,Grantsville,UT,ACTIVE,15-Sep-14,13-Dec-15
-GRAPEVINETEXAS.GOV,City,Non-Federal Agency,Grapevine,TX,ACTIVE,18-Mar-14,15-Jun-15
-GRAPEVINETX.GOV,City,Non-Federal Agency,Grapevine,TX,ACTIVE,18-Mar-14,15-Jun-15
-GREECENY.GOV,City,Non-Federal Agency,Rochester,NY,ACTIVE,18-Jun-14,30-Aug-15
-GREENBAYWI.GOV,City,Non-Federal Agency,Green Bay,WI,ACTIVE,22-Jul-14,18-Oct-15
-GREENBELTMD.GOV,City,Non-Federal Agency,Greenbelt,MD,ACTIVE,30-Jul-14,30-Sep-15
-GREENCASTLEPA.GOV,City,Non-Federal Agency,Greencastle,PA,ACTIVE,14-Jan-15,16-Jan-16
-GREENEVILLETN.GOV,City,Non-Federal Agency,Greeneville,TN,ACTIVE,14-Jan-15,26-Jul-15
-GREENFIELD-MA.GOV,City,Non-Federal Agency,Greenfield,MA,ACTIVE,11-Aug-14,12-Aug-15
-GREENFIELD-NH.GOV,City,Non-Federal Agency,Greenfield,NH,ACTIVE,22-Jul-14,18-Sep-15
-GREENHOUSTONTX.GOV,City,Non-Federal Agency,Houston,TX,ACTIVE,13-Feb-14,12-May-15
-GREENISLANDNY.GOV,City,Non-Federal Agency,Green Island,NY,ACTIVE,16-Oct-14,10-Sep-15
-GREENMOUNTAINFALLSCO.GOV,City,Non-Federal Agency,Green Mountain Falls,CO,ACTIVE,16-Jan-14,19-Jan-15
-GREENSBORO-GA.GOV,City,Non-Federal Agency,Greensboro,GA,ACTIVE,3-Jan-13,3-Mar-14
-GREENSBOROGA.GOV,City,Non-Federal Agency,Greensboro,GA,ACTIVE,3-Jan-13,3-Dec-13
-GREENVILLENC.GOV,City,Non-Federal Agency,Greenville,NC,ACTIVE,11-Sep-14,30-Sep-15
-GREENVILLESC.GOV,City,Non-Federal Agency,Greenville,SC,ACTIVE,8-Jul-14,30-Sep-15
-GRESHAMOREGON.GOV,City,Non-Federal Agency,Gresham,OR,ACTIVE,7-Jul-14,5-Oct-15
-GREYFOREST-TX.GOV,City,Non-Federal Agency,Grey Forest,TX,ACTIVE,20-Mar-14,21-Mar-15
-GRIMESIOWA.GOV,City,Non-Federal Agency,Grimes,IA,ACTIVE,8-May-12,8-May-13
-GROTON-CT.GOV,City,Non-Federal Agency,Groton,CT,ACTIVE,9-Feb-15,5-May-16
-GROTONSD.GOV,City,Non-Federal Agency,Groton,SD,ACTIVE,2-Jul-14,29-Sep-15
-GROVECITYOHIO.GOV,City,Non-Federal Agency,Grove City,OH,ACTIVE,10-Sep-14,10-Sep-15
-GROVELAND-FL.GOV,City,Non-Federal Agency,Groveland,FL,ACTIVE,24-Nov-14,29-Dec-15
-GULFBREEZEFL.GOV,City,Non-Federal Agency,Gulf Breeze,FL,ACTIVE,5-Sep-14,6-Sep-15
-GULFPORT-MS.GOV,City,Non-Federal Agency,Gulfport,MS,ACTIVE,2-Apr-14,22-Apr-15
-GULFSHORESAL.GOV,City,Non-Federal Agency,Gulf Shores,AL,ACTIVE,18-Oct-13,30-Sep-14
-GUSTAVUS-AK.GOV,City,Non-Federal Agency,Gustavus,AK,ACTIVE,8-Aug-14,30-Sep-15
-HADLEYMA.GOV,City,Non-Federal Agency,Hadley,MA,ACTIVE,15-Mar-13,13-Jun-14
-HAHIRAGA.GOV,City,Non-Federal Agency,Hahira,GA,ACTIVE,2-Dec-14,2-Dec-15
-HALLANDALEBEACHFL.GOV,City,Non-Federal Agency,hallandale beach,FL,ACTIVE,8-Jul-13,30-Sep-14
-HAMILTON-OH.GOV,City,Non-Federal Agency,Hamilton,OH,ACTIVE,18-Aug-14,21-Oct-15
-HAMPDENMAINE.GOV,City,Non-Federal Agency,Hampden,ME,ACTIVE,3-Sep-14,1-Sep-15
-HAMPSTEADMD.GOV,City,Non-Federal Agency,Hampstead,MD,ACTIVE,22-Sep-14,22-Oct-15
-HAMPTON.GOV,City,Non-Federal Agency,Hampton,VA,ACTIVE,25-Jun-14,19-Aug-15
-HAMPTONSC.GOV,City,Non-Federal Agency,Hampton,SC,ACTIVE,19-May-14,16-Aug-15
-HANNIBAL-MO.GOV,City,Non-Federal Agency,Hannibal,MO,ACTIVE,18-Feb-15,11-Apr-16
-HANOVER-MA.GOV,City,Non-Federal Agency,Hanover,MA,ACTIVE,10-Dec-14,6-Dec-15
-HANOVERVA.GOV,City,Non-Federal Agency,Hanover,VA,ACTIVE,24-Jul-14,30-Aug-15
-HANSON-MA.GOV,City,Non-Federal Agency,Hanson,MA,ACTIVE,8-Sep-14,30-Sep-15
-HAPPYVALLEYOR.GOV,City,Non-Federal Agency,Happy Valley,OR,ACTIVE,9-Oct-14,7-Jan-16
-HARMONYTWP-NJ.GOV,City,Non-Federal Agency,Phillipsburg,NJ,ACTIVE,5-Dec-14,30-Sep-14
-HARPERCOUNTYKS.GOV,City,Non-Federal Agency,Anthony,KS,ACTIVE,1-Oct-14,30-Sep-15
-HARRAH-OK.GOV,City,Non-Federal Agency,Harrah,OK,ACTIVE,7-Jul-14,30-Sep-15
-HARRISBURGPA.GOV,City,Non-Federal Agency,Harrisburg,PA,ACTIVE,30-Oct-14,30-Sep-15
-HARRISBURGSD.GOV,City,Non-Federal Agency,Harrisburg,SD,ACTIVE,2-Jul-14,3-May-15
-HARRISONBURGVA.GOV,City,Non-Federal Agency,Harrisonburg,VA,ACTIVE,10-Mar-14,13-Mar-15
-HARRISONOH.GOV,City,Non-Federal Agency,Harrison,OH,ACTIVE,4-Feb-15,30-Sep-14
-HARRISONOHIO.GOV,City,Non-Federal Agency,Harrison,OH,ACTIVE,4-Feb-15,28-Nov-14
-HARTFORD.GOV,City,Non-Federal Agency,Hartford,CT,ACTIVE,7-Jul-14,30-Sep-15
-HARTSVILLESC.GOV,City,Non-Federal Agency,Hartsville,SC,ACTIVE,10-Sep-14,9-Dec-15
-HARWICH-MA.GOV,City,Non-Federal Agency,Harwich,MA,ACTIVE,17-Jun-14,24-Mar-15
-HASTINGSMN.GOV,City,Non-Federal Agency,Hastings,MN,ACTIVE,26-Mar-14,21-Jun-15
-HAVREDEGRACEMD.GOV,City,Non-Federal Agency,Havre de Grace,MD,ACTIVE,28-May-14,26-Aug-15
-HAWTHORNECA.GOV,City,Non-Federal Agency,Hawthorne,CA,ACTIVE,20-May-14,21-May-15
-HAYDEN-CO.GOV,City,Non-Federal Agency,Hayden,CO,ACTIVE,26-Aug-13,16-Oct-13
-HAYSIVIRGINIA.GOV,City,Non-Federal Agency,Haysi,VA,ACTIVE,13-Jun-14,8-Jul-15
-HEADOFTHEHARBORNY.GOV,City,Non-Federal Agency,Saint James,NY,ACTIVE,16-Feb-15,16-Feb-16
-HEATHOHIO.GOV,City,Non-Federal Agency,Heath,OH,ACTIVE,21-Jul-14,18-Sep-15
-HELENAMT.GOV,City,Non-Federal Agency,Helena,MT,ACTIVE,17-Feb-15,21-Mar-16
-HELOTES-TX.GOV,City,Non-Federal Agency,Helotes,TX,ACTIVE,1-Jul-14,17-Sep-15
-HENDERSONNEVADA.GOV,City,Non-Federal Agency,Henderson,NV,ACTIVE,29-Jul-14,23-Aug-15
-HENDERSONNV.GOV,City,Non-Federal Agency,Henderson,NV,ACTIVE,29-Jan-15,22-Mar-16
-HENDERSONVILLENC.GOV,City,Non-Federal Agency,Hendersonville,NC,ACTIVE,18-Feb-15,18-Feb-16
-HEREFORD-TX.GOV,City,Non-Federal Agency,Hereford,TX,ACTIVE,24-Nov-14,18-Nov-15
-HERNDON-VA.GOV,City,Non-Federal Agency,Herndon,VA,ACTIVE,2-Oct-14,30-Sep-15
-HEYWORTH-IL.GOV,City,Non-Federal Agency,Heyworth,IL,ACTIVE,17-Feb-15,16-May-16
-HIALEAHFL.GOV,City,Non-Federal Agency,Hialeah,FL,ACTIVE,21-May-14,31-May-15
-HIAWASSEEGA.GOV,City,Non-Federal Agency,Hiawassee,GA,ACTIVE,16-Apr-14,11-May-15
-HICKORYCREEK-TX.GOV,City,Non-Federal Agency,Hickory Creek,TX,ACTIVE,29-Jul-13,30-Sep-14
-HICKORYNC.GOV,City,Non-Federal Agency,Hickory,NC,ACTIVE,15-Jul-13,28-Feb-14
-HIDEOUTUTAH.GOV,City,Non-Federal Agency,Hideout,UT,ACTIVE,30-Jul-14,7-Sep-15
-HIGHLANDHEIGHTS-KY.GOV,City,Non-Federal Agency,Highland Heights,KY,ACTIVE,6-May-14,14-Jun-15
-HIGHLANDIL.GOV,City,Non-Federal Agency,Highland,IL,ACTIVE,17-Jul-14,1-Jun-15
-HIGHLANDS-NY.GOV,City,Non-Federal Agency,Highland Falls,NY,ACTIVE,18-Jun-14,26-Mar-15
-HILLIARDOHIO.GOV,City,Non-Federal Agency,Hilliard,OH,ACTIVE,23-Jul-14,25-Aug-15
-HILLSBORO-OR.GOV,City,Non-Federal Agency,Hillsboro,OR,ACTIVE,12-Aug-13,7-Sep-14
-HILLSBORO-OREGON.GOV,City,Non-Federal Agency,HILLSBORO,OR,ACTIVE,30-Dec-14,26-Mar-16
-HILLSBOROOREGON.GOV,City,Non-Federal Agency,Hillsboro,OR,ACTIVE,26-Mar-12,26-Mar-13
-HILTONHEADISLANDSC.GOV,City,Non-Federal Agency,Hilton Head Island,SC,ACTIVE,4-Sep-14,30-Sep-15
-HINGHAM-MA.GOV,City,Non-Federal Agency,Hingham,MA,ACTIVE,5-Sep-13,13-Sep-14
-HIRAM-GA.GOV,City,Non-Federal Agency,Hiram,GA,ACTIVE,16-Jan-15,24-Jan-16
-HOBOKENNJ.GOV,City,Non-Federal Agency,Hoboken,NJ,ACTIVE,4-Feb-15,26-Mar-16
-HOLBROOKMA.GOV,City,Non-Federal Agency,Holbrook,MA,ACTIVE,12-Dec-14,19-Feb-16
-HOLDEN-MA.GOV,City,Non-Federal Agency,Holden,MA,ACTIVE,19-Feb-15,27-Apr-16
-HOLDENMA.GOV,City,Non-Federal Agency,HOLDEN,MA,ACTIVE,19-Feb-15,27-Apr-16
-HOLDERNESS-NH.GOV,City,Non-Federal Agency,Holderness,NH,ACTIVE,27-Aug-13,2-Sep-14
-HOLLYWOODPARK-TX.GOV,City,Non-Federal Agency,Hollywood Park,TX,ACTIVE,11-Aug-14,28-Sep-15
-HOMERGLENIL.GOV,City,Non-Federal Agency,Homer Glen,IL,ACTIVE,19-Jul-13,31-Mar-14
-HOMEWOODIL.GOV,City,Non-Federal Agency,Homewood,IL,ACTIVE,24-Feb-15,25-Apr-16
-HOOPESTON-IL.GOV,City,Non-Federal Agency,Hoopeston,IL,ACTIVE,21-May-14,20-Jun-15
-HOOVERAL.GOV,City,Non-Federal Agency,Hoover,AL,ACTIVE,17-Sep-14,30-Sep-15
-HOOVERALABAMA.GOV,City,Non-Federal Agency,Hoover,AL,ACTIVE,17-Sep-14,30-Sep-15
-HOPEDALE-MA.GOV,City,Non-Federal Agency,Hopedale,MA,ACTIVE,2-Sep-14,30-Sep-15
-HOPEWELLVA.GOV,City,Non-Federal Agency,HOPEWELL,VA,ACTIVE,30-Dec-14,28-Feb-16
-HOPKINSVILLE-KY.GOV,City,Non-Federal Agency,Hopkinsville,KY,ACTIVE,18-Jul-13,28-Sep-13
-HOPKINTON-NH.GOV,City,Non-Federal Agency,Hopkinton,NH,ACTIVE,16-Jul-12,16-Aug-13
-HOPKINTONMA.GOV,City,Non-Federal Agency,Hopkinton,MA,ACTIVE,10-Nov-14,5-Dec-15
-HORICONNY.GOV,City,Non-Federal Agency,Brant Lake,NY,ACTIVE,1-Oct-14,31-Oct-15
-HORIZONCITY-TX.GOV,City,Non-Federal Agency,Horizon City,TX,ACTIVE,18-Sep-12,1-Apr-13
-HORSESHOE-BAY-TX.GOV,City,Non-Federal Agency,Horseshoe Bay,TX,ACTIVE,8-Jan-13,31-Mar-14
-HOUSTON-AK.GOV,City,Non-Federal Agency,Houston,AK,ACTIVE,15-Nov-13,13-Feb-15
-HPCA.GOV,City,Non-Federal Agency,Huntington Park,CA,ACTIVE,8-Sep-14,8-Sep-15
-HRPDCVA.GOV,City,Non-Federal Agency,Chesapeake,VA,ACTIVE,4-Mar-14,13-Apr-15
-HUACHUCACITYAZ.GOV,City,Non-Federal Agency,Huachuca City,AZ,ACTIVE,24-Sep-14,4-Oct-15
-HUDSONNH.GOV,City,Non-Federal Agency,Hudson,NH,ACTIVE,7-Nov-14,13-Dec-15
-HUETTER-ID.GOV,City,Non-Federal Agency,POST FALLS,ID,ACTIVE,22-Jun-09,17-Sep-10
-HULMEVILLE-PA.GOV,City,Non-Federal Agency,Hulmeville,PA,ACTIVE,31-Dec-14,20-Feb-16
-HUMBLETX.GOV,City,Non-Federal Agency,Humble,TX,ACTIVE,24-Feb-15,23-May-16
-HUNTINGBURG-IN.GOV,City,Non-Federal Agency,Huntingburg,IN,ACTIVE,10-Dec-14,9-Mar-16
-HUNTINGTONBEACHCA.GOV,City,Non-Federal Agency,Huntington Beach,CA,ACTIVE,15-Oct-14,13-Jan-16
-HUNTINGTONNY.GOV,City,Non-Federal Agency,Huntington,NY,ACTIVE,13-Jun-14,13-Jul-15
-HUNTSPOINT-WA.GOV,City,Non-Federal Agency,Hunts Point,WA,ACTIVE,16-Jul-14,13-Sep-15
-HUNTSVILLEAL.GOV,City,Non-Federal Agency,Huntsville,AL,ACTIVE,14-Jan-15,25-Mar-16
-HURLOCK-MD.GOV,City,Non-Federal Agency,Hurlock,MD,ACTIVE,23-Feb-15,17-Mar-16
-HURST-TEXAS.GOV,City,Non-Federal Agency,Hurst,TX,ACTIVE,30-Sep-11,30-Sep-12
-HURSTTX.GOV,City,Non-Federal Agency,Hurst,TX,ACTIVE,10-Feb-15,8-Mar-16
-HUTTOTX.GOV,City,Non-Federal Agency,Hutto,TX,ACTIVE,11-Mar-14,10-Apr-15
-HVLNC.GOV,City,Non-Federal Agency,Hendersonville,NC,ACTIVE,16-Feb-15,16-Feb-16
-IDABEL-OK.GOV,City,Non-Federal Agency,Idabel,OK,ACTIVE,29-Sep-14,22-Sep-15
-IDAHOFALLSIDAHO.GOV,City,Non-Federal Agency,Idaho Falls,ID,ACTIVE,3-Feb-15,5-Mar-16
-ILWACO-WA.GOV,City,Non-Federal Agency,Ilwaco,WA,ACTIVE,20-Nov-14,18-Feb-16
-IMPERIALBEACHCA.GOV,City,Non-Federal Agency,Imperial Beach,CA,ACTIVE,8-Jan-15,18-Mar-16
-INCLINEVILLAGE-NV.GOV,City,Non-Federal Agency,INCLINE VILLAGE,NV,ACTIVE,15-Aug-11,24-Oct-12
-INDEPENDENCEKS.GOV,City,Non-Federal Agency,INDEPENDENCE,KS,ACTIVE,28-Apr-14,26-Jun-15
-INDEPENDENCEOHIO.GOV,City,Non-Federal Agency,Independence,OH,ACTIVE,10-Jul-14,6-Aug-15
-INDIANAPOLIS-IN.GOV,City,Non-Federal Agency,Indianapolis,IN,ACTIVE,15-May-14,9-Jul-15
-INDIANOLAIOWA.GOV,City,Non-Federal Agency,Indianola,IA,ACTIVE,2-Dec-14,28-Feb-16
-INDIANOLAMS.GOV,City,Non-Federal Agency,Indianola,MS,ACTIVE,19-Sep-14,18-Dec-15
-INDIANPOINT-MO.GOV,City,Non-Federal Agency,Branson,MO,ACTIVE,1-Oct-14,30-Sep-15
-INDY.GOV,City,Non-Federal Agency,Indianapolis,IN,ACTIVE,15-May-14,9-Jul-15
-INGLESIDETX.GOV,City,Non-Federal Agency,Ingleside,TX,ACTIVE,22-Jul-14,20-Sep-15
-INTERLACHEN-FL.GOV,City,Non-Federal Agency,Interlachen,FL,ACTIVE,2-Jul-14,30-Sep-15
-INVERNESS-FL.GOV,City,Non-Federal Agency,Inverness,FL,ACTIVE,12-May-14,31-Jul-15
-INVERNESS-IL.GOV,City,Non-Federal Agency,Inverness,IL,ACTIVE,26-Sep-14,26-Sep-15
-IPSWICH-MA.GOV,City,Non-Federal Agency,Ipswich,MA,ACTIVE,14-Nov-14,19-Dec-15
-IPSWICHMA.GOV,City,Non-Federal Agency,Ipswich,MA,ACTIVE,19-Aug-14,17-Sep-15
-IRONTONMO.GOV,City,Non-Federal Agency,Ironton,MO,ACTIVE,16-May-14,11-Jul-15
-IRVINGTONNY.GOV,City,Non-Federal Agency,Irvington,NY,ACTIVE,2-Sep-14,30-Sep-15
-ISLIP-NY.GOV,City,Non-Federal Agency,Islip,NY,ACTIVE,23-Jun-14,20-Jul-15
-ISLIPTOWN-NY.GOV,City,Non-Federal Agency,Islip,NY,ACTIVE,23-Jun-14,20-Jul-15
-ISSAQUAHWA.GOV,City,Non-Federal Agency,Issaquah,WA,ACTIVE,23-Feb-15,25-Apr-16
-JACINTOCITY-TX.GOV,City,Non-Federal Agency,Jacinto City,TX,ACTIVE,6-Feb-14,6-Apr-15
-JACKSON-SC.GOV,City,Non-Federal Agency,Jackson,SC,ACTIVE,25-Jul-13,5-Feb-14
-JACKSONMS.GOV,City,Non-Federal Agency,Jackson,MS,ACTIVE,25-Sep-14,16-Nov-15
-JACKSONTOWNSHIP-PA.GOV,City,Non-Federal Agency,Myerstown,PA,ACTIVE,29-May-14,10-Jul-15
-JACKSONTOWNSHIPPA.GOV,City,Non-Federal Agency,Jackson Township,PA,ACTIVE,16-Jan-15,16-Jan-16
-JACKSONTWP-PA.GOV,City,Non-Federal Agency,Reeders,PA,ACTIVE,9-Mar-15,7-Apr-16
-JAMESTOWN-NC.GOV,City,Non-Federal Agency,Jamestown,NC,ACTIVE,28-Jan-15,28-Feb-16
-JAMESTOWNRI.GOV,City,Non-Federal Agency,Jamestown,RI,ACTIVE,17-Jul-14,17-Jul-15
-JAMESTOWNTN.GOV,City,Non-Federal Agency,Jamestown,TN,ACTIVE,30-Jan-14,30-Jan-15
-JEFFERSONCITYMO.GOV,City,Non-Federal Agency,Jefferson City,MO,ACTIVE,1-Jul-14,1-Jul-15
-JEFFERSONTOWNKY.GOV,City,Non-Federal Agency,Jeffersontown,KY,ACTIVE,30-Apr-14,28-Jun-15
-JERICHOVT.GOV,City,Non-Federal Agency,Jericho,VT,ACTIVE,8-Jul-14,30-Sep-15
-JEROME-OH.GOV,City,Non-Federal Agency,Plain City,OH,ACTIVE,9-Nov-12,16-Nov-13
-JESUPGA.GOV,City,Non-Federal Agency,Jesup,GA,ACTIVE,14-Oct-14,30-Sep-15
-JOHNSCREEKGA.GOV,City,Non-Federal Agency,Johns Creek,GA,ACTIVE,31-Jan-14,20-Apr-15
-JOHNSONCITYTN.GOV,City,Non-Federal Agency,Johnson City,TN,ACTIVE,30-Jul-14,26-Jun-15
-JONESVILLENC.GOV,City,Non-Federal Agency,Jonesville,NC,ACTIVE,8-Oct-14,8-Oct-15
-JUNCTIONCITY-KS.GOV,City,Non-Federal Agency,Junction City,KS,ACTIVE,5-May-14,14-Jul-15
-JUNCTIONCITYOREGON.GOV,City,Non-Federal Agency,Junction City,OR,ACTIVE,17-Feb-15,16-Apr-16
-JUPITERFL.GOV,City,Non-Federal Agency,Jupiter,FL,ACTIVE,12-Aug-13,30-Sep-13
-KANNAPOLISNC.GOV,City,Non-Federal Agency,Concord,NC,ACTIVE,11-Sep-14,11-Sep-15
-KELSO.GOV,City,Non-Federal Agency,Kelso,WA,ACTIVE,2-Jul-14,30-Sep-15
-KEMAH-TX.GOV,City,Non-Federal Agency,Kemah,TX,ACTIVE,29-Jan-15,13-Apr-16
-KENMOREWA.GOV,City,Non-Federal Agency,Kenmore,WA,ACTIVE,28-May-14,18-May-15
-KENNEBUNKPORTME.GOV,City,Non-Federal Agency,Kennebunkport,ME,ACTIVE,3-Feb-15,9-Apr-16
-KENNESAW-GA.GOV,City,Non-Federal Agency,Kennesaw,GA,ACTIVE,26-Mar-14,13-Jun-15
-KENTWA.GOV,City,Non-Federal Agency,Kent,WA,ACTIVE,13-Aug-14,12-Oct-15
-KERRVILLETX.GOV,City,Non-Federal Agency,Kerrville,TX,ACTIVE,4-Feb-15,5-Feb-16
-KILLEENTEXAS.GOV,City,Non-Federal Agency,Killeen,TX,ACTIVE,18-Jun-13,31-Jul-14
-KILLINGLYCT.GOV,City,Non-Federal Agency,Danielson,CT,ACTIVE,4-Aug-14,3-Sep-15
-KINDERHOOK-NY.GOV,City,Non-Federal Agency,Niverville,NY,ACTIVE,5-Oct-14,30-Sep-15
-KINGFIELD-ME.GOV,City,Non-Federal Agency,Kingfield,ME,ACTIVE,27-Sep-10,30-Sep-11
-KINGSLANDGA.GOV,City,Non-Federal Agency,Kingsland,GA,ACTIVE,31-Jul-14,30-Aug-15
-KINGSPORTTN.GOV,City,Non-Federal Agency,Kingsport,TN,ACTIVE,17-Jul-13,3-Oct-13
-KINGSTON-NY.GOV,City,Non-Federal Agency,Kingston,NY,ACTIVE,15-Jul-14,11-Oct-15
-KINGSTONSPRINGS-TN.GOV,City,Non-Federal Agency,Kingston Springs,TN,ACTIVE,8-Sep-14,7-Dec-15
-KINROSSTOWNSHIP-MI.GOV,City,Non-Federal Agency,Kincheloe,MI,ACTIVE,25-Jul-14,20-Oct-15
-KINSTONNC.GOV,City,Non-Federal Agency,Kinston,NC,ACTIVE,15-Jul-13,17-Nov-13
-KIRKLANDWA.GOV,City,Non-Federal Agency,Kirkland,WA,ACTIVE,10-Dec-14,9-Mar-16
-KISSIMMEE-FL.GOV,City,Non-Federal Agency,Kissimmee,FL,ACTIVE,23-Jul-13,15-Sep-13
-KITTERYME.GOV,City,Non-Federal Agency,Kittery,ME,ACTIVE,27-Aug-13,20-Nov-12
-KNIGHTDALENC.GOV,City,Non-Federal Agency,Knightdale,NC,ACTIVE,4-Sep-14,30-Jul-15
-KNOXVILLEIA.GOV,City,Non-Federal Agency,Knoxville,IA,ACTIVE,31-Jul-14,25-Oct-15
-KNOXVILLEIOWA.GOV,City,Non-Federal Agency,Knoxville,IA,ACTIVE,31-Jul-14,25-Oct-15
-KNOXVILLETN.GOV,City,Non-Federal Agency,Knoxville,TN,ACTIVE,7-Nov-14,27-Nov-15
-LACKAWANNANY.GOV,City,Non-Federal Agency,Lackawanna,NY,ACTIVE,12-Feb-15,14-Feb-16
-LACKAWAXENTOWNSHIPPA.GOV,City,Non-Federal Agency,Hawley,PA,ACTIVE,1-Dec-14,24-Feb-16
-LAFOLLETTETN.GOV,City,Non-Federal Agency,LaFollette,TN,ACTIVE,14-May-12,17-May-13
-LAGRANGEGA.GOV,City,Non-Federal Agency,LaGrange,GA,ACTIVE,29-Sep-14,29-Sep-15
-LAHABRACA.GOV,City,Non-Federal Agency,LA HABRA,CA,ACTIVE,31-May-14,1-Jun-15
-LAKEFORESTCA.GOV,City,Non-Federal Agency,Lake Forest,CA,ACTIVE,8-Aug-14,23-Oct-15
-LAKEGROVENY.GOV,City,Non-Federal Agency,Lake Grove,NY,ACTIVE,4-Oct-13,10-Nov-14
-LAKEJACKSONTX.GOV,City,Non-Federal Agency,Lake Jackson,TX,ACTIVE,31-Jul-14,14-Aug-15
-LAKELANDGA.GOV,City,Non-Federal Agency,Lakeland,GA,ACTIVE,3-Sep-14,3-Aug-15
-LAKELANDTN.GOV,City,Non-Federal Agency,Lakeland,TN,ACTIVE,16-Oct-12,28-Oct-13
-LAKEPARKNC.GOV,City,Non-Federal Agency,Indian Trail,NC,ACTIVE,16-Apr-14,16-May-15
-LAKEPROVIDENCELA.GOV,City,Non-Federal Agency,Lake Providence,LA,ACTIVE,7-Jan-14,7-Jan-15
-LAKESTATION-IN.GOV,City,Non-Federal Agency,Lake Station,IN,ACTIVE,16-Jan-15,8-Jan-16
-LAKESTEVENSWA.GOV,City,Non-Federal Agency,Lake Stevens,WA,ACTIVE,3-Feb-15,4-Apr-16
-LAKEVILLE-MN.GOV,City,Non-Federal Agency,Lakeville,MN,ACTIVE,29-Dec-14,28-Feb-16
-LAKEVILLEMN.GOV,City,Non-Federal Agency,Lakeville,MN,ACTIVE,29-Dec-14,28-Feb-16
-LAKEVILLEMNFIRE.GOV,City,Non-Federal Agency,Lakeville,MN,ACTIVE,20-Feb-15,28-Apr-16
-LAKEWAY-TX.GOV,City,Non-Federal Agency,Lakeway,TX,ACTIVE,4-Sep-14,3-Nov-15
-LAKEWOODNJ.GOV,City,Non-Federal Agency,Lakewood,NJ,ACTIVE,2-Mar-15,28-Mar-16
-LANCASTERCITYSC.GOV,City,Non-Federal Agency,Lancaster,SC,ACTIVE,25-Aug-10,2-Sep-11
-LANCASTERNY.GOV,City,Non-Federal Agency,Lancaster,NY,ACTIVE,30-Jul-14,13-Oct-15
-LANESBORO-MN.GOV,City,Non-Federal Agency,Lanesboro,MN,ACTIVE,12-Dec-14,10-Feb-16
-LANESBOROUGH-MA.GOV,City,Non-Federal Agency,LANESBOROUGH,MA,ACTIVE,11-Aug-14,30-Sep-15
-LANSINGMI.GOV,City,Non-Federal Agency,Lansing,MI,ACTIVE,2-Feb-11,9-Apr-12
-LANTABUS-PA.GOV,City,Non-Federal Agency,Allentown,PA,ACTIVE,9-Mar-14,7-Jun-15
-LAPORTETX.GOV,City,Non-Federal Agency,La Porte,TX,ACTIVE,1-Aug-14,30-Sep-15
-LAREDOTEXAS.GOV,City,Non-Federal Agency,Laredo,TX,ACTIVE,22-Sep-14,22-Sep-15
-LASALLE-IL.GOV,City,Non-Federal Agency,LaSalle,IL,ACTIVE,3-Sep-13,30-Sep-14
-LASVEGASNM.GOV,City,Non-Federal Agency,Las Vegas,NM,ACTIVE,23-Dec-14,20-Dec-15
-LAUDERDALEBYTHESEA-FL.GOV,City,Non-Federal Agency,Lauderdale By The Sea,FL,ACTIVE,9-Jul-14,18-Sep-15
-LAUDERHILL-FL.GOV,City,Non-Federal Agency,Lauderhill,FL,ACTIVE,30-Sep-12,30-Sep-13
-LAUDERHILLFL.GOV,City,Non-Federal Agency,Lauderhill,FL,ACTIVE,30-Sep-12,31-Aug-13
-LAVERGNETN.GOV,City,Non-Federal Agency,La Vergne,TN,ACTIVE,2-Sep-14,29-Nov-15
-LAVERNIA-TX.GOV,City,Non-Federal Agency,La Vernia,TX,ACTIVE,3-Dec-14,4-Dec-15
-LAWRENCEBURGTN.GOV,City,Non-Federal Agency,Lawrenceburg,TN,ACTIVE,8-Jan-15,11-Feb-16
-LAWTONMI.GOV,City,Non-Federal Agency,Lawton,MI,ACTIVE,2-Oct-14,3-Oct-15
-LBTS-FL.GOV,City,Non-Federal Agency,Lauderdale-By-The-Sea,FL,ACTIVE,9-Jul-14,2-Sep-15
-LEAGUECITY-TX.GOV,City,Non-Federal Agency,League City,TX,ACTIVE,28-Jul-14,17-Sep-15
-LEAGUECITYTX.GOV,City,Non-Federal Agency,League City,TX,ACTIVE,4-Mar-15,28-Apr-16
-LEANDERTX.GOV,City,Non-Federal Agency,Leander,TX,ACTIVE,4-Sep-14,3-Dec-15
-LEBANONCT.GOV,City,Non-Federal Agency,Lebanon,CT,ACTIVE,24-Jun-14,3-Sep-15
-LEBANONOHIO.GOV,City,Non-Federal Agency,Lebanon,OH,ACTIVE,18-Aug-14,31-Aug-15
-LECLAIREIOWA.GOV,City,Non-Federal Agency,LECLAIRE,IA,ACTIVE,5-Sep-14,30-Sep-15
-LEEDSALABAMA.GOV,City,Non-Federal Agency,Leeds,AL,ACTIVE,29-Jul-14,20-Aug-15
-LEESBURGFLORIDA.GOV,City,Non-Federal Agency,Leesburg,FL,ACTIVE,16-Jul-14,13-Sep-15
-LEESVILLELA.GOV,City,Non-Federal Agency,LEESVILLE,LA,ACTIVE,5-Jul-13,5-Jul-14
-LEHI-UT.GOV,City,Non-Federal Agency,Lehi,UT,ACTIVE,17-Apr-14,12-Jul-15
-LENEXA-KS.GOV,City,Non-Federal Agency,Lenexa,KS,ACTIVE,2-Jul-14,30-Sep-15
-LENOIR-NC.GOV,City,Non-Federal Agency,Lenoir,NC,ACTIVE,16-Jul-14,26-Aug-15
-LEOMINSTER-MA.GOV,City,Non-Federal Agency,Leominster,MA,ACTIVE,15-Oct-14,30-Sep-15
-LEONIANJ.GOV,City,Non-Federal Agency,Leonia,NJ,ACTIVE,20-Aug-14,8-Sep-15
-LEONVALLEYTEXAS.GOV,City,Non-Federal Agency,Leon Valley,TX,ACTIVE,1-Oct-12,30-Nov-13
-LEROYTOWNSHIP-MI.GOV,City,Non-Federal Agency,Webberville,MI,ACTIVE,9-Jan-15,8-Jan-16
-LETSMOVEBRIDGEPORTCT.GOV,City,Non-Federal Agency,Bridgeport,CT,ACTIVE,28-Jun-11,29-Jun-12
-LEWISBURGTN.GOV,City,Non-Federal Agency,Lewisburg,TN,ACTIVE,15-May-14,1-Mar-15
-LEWISTONMAINE.GOV,City,Non-Federal Agency,Lewiston,ME,ACTIVE,18-Sep-14,18-Aug-15
-LEXINGTONKY.GOV,City,Non-Federal Agency,lexington,KY,ACTIVE,12-Mar-15,31-May-16
-LEXINGTONNC.GOV,City,Non-Federal Agency,Lexington,NC,ACTIVE,6-Jan-15,18-Jan-16
-LEXINGTONTN.GOV,City,Non-Federal Agency,Lexington,TN,ACTIVE,18-Aug-14,9-Sep-15
-LEXINGTONVA.GOV,City,Non-Federal Agency,Lexington,VA,ACTIVE,29-Jul-14,27-Oct-15
-LHCAZ.GOV,City,Non-Federal Agency,Lake Havasu City,AZ,ACTIVE,3-Dec-14,28-Feb-16
-LIBERTYLAKEWA.GOV,City,Non-Federal Agency,Liberty Lake,WA,ACTIVE,3-Jul-14,30-Sep-15
-LIBERTYMISSOURI.GOV,City,Non-Federal Agency,Liberty,MO,ACTIVE,27-Feb-15,27-Feb-16
-LIBERTYMO.GOV,City,Non-Federal Agency,Liberty,MO,ACTIVE,26-Feb-15,27-Feb-16
-LIMERICK-ME.GOV,City,Non-Federal Agency,Limerick,ME,ACTIVE,16-Mar-10,4-Apr-11
-LINCOLNCA.GOV,City,Non-Federal Agency,Lincoln,CA,ACTIVE,26-Feb-15,26-Feb-16
-LINCOLNIL.GOV,City,Non-Federal Agency,Lincoln,IL,ACTIVE,9-Dec-14,8-Mar-16
-LINDALE-TX.GOV,City,Non-Federal Agency,Lindale,TX,ACTIVE,2-Jul-14,30-Sep-15
-LINDALETX.GOV,City,Non-Federal Agency,Lindale,TX,ACTIVE,2-Jul-14,30-Sep-15
-LINDENWOLDNJ.GOV,City,Non-Federal Agency,Lindenwold,NJ,ACTIVE,29-Aug-14,29-Aug-15
-LINNDALEVILLAGE-OH.GOV,City,Non-Federal Agency,Linndale,OH,ACTIVE,23-Nov-12,17-Feb-14
-LINTON-IN.GOV,City,Non-Federal Agency,Linton,IN,ACTIVE,31-May-13,31-May-14
-LITCHFIELD-NH.GOV,City,Non-Federal Agency,Litchfield,NH,ACTIVE,3-Oct-14,26-Nov-15
-LITCHFIELDNH.GOV,City,Non-Federal Agency,Litchfield,NH,ACTIVE,3-Oct-14,30-Dec-15
-LOCKHAVENPA.GOV,City,Non-Federal Agency,Lock Haven,PA,ACTIVE,5-Nov-14,5-Nov-15
-LOCKPORTNY.GOV,City,Non-Federal Agency,Lockport,NY,ACTIVE,7-Nov-14,7-Nov-15
-LOCUSTGROVE-GA.GOV,City,Non-Federal Agency,Locust Grove,GA,ACTIVE,4-Sep-14,30-Sep-15
-LOGANCO.GOV,City,Non-Federal Agency,Sterling,CO,ACTIVE,1-Aug-14,30-Sep-15
-LOGANVILLE-GA.GOV,City,Non-Federal Agency,Loganville,GA,ACTIVE,19-May-14,6-Jul-15
-LOMALINDA-CA.GOV,City,Non-Federal Agency,Loma Linda,CA,ACTIVE,2-Sep-14,30-Sep-15
-LONEOAKTX.GOV,City,Non-Federal Agency,LONE OAK,TX,ACTIVE,16-Oct-14,15-Dec-15
-LONGBEACH.GOV,City,Non-Federal Agency,Long Beach,CA,ACTIVE,4-Sep-14,30-Sep-15
-LONGBEACHNY.GOV,City,Non-Federal Agency,Long Beach,NY,ACTIVE,16-Oct-14,16-Oct-15
-LONGBEACHWA.GOV,City,Non-Federal Agency,Long Beach,WA,ACTIVE,4-Jul-14,31-Aug-15
-LONGHILLNJ.GOV,City,Non-Federal Agency,Long Hill,NJ,ACTIVE,14-Feb-15,24-Apr-16
-LONGLAKEMN.GOV,City,Non-Federal Agency,Long Lake,MN,ACTIVE,15-Aug-13,5-Jan-14
-LONGMONTCOLORADO.GOV,City,Non-Federal Agency,Longmont,CO,ACTIVE,21-Mar-14,21-Mar-15
-LONGPORTNJ.GOV,City,Non-Federal Agency,Longport,NJ,ACTIVE,4-Dec-14,20-Feb-16
-LONGVIEWTEXAS.GOV,City,Non-Federal Agency,Longview,TX,ACTIVE,10-Dec-14,5-Mar-16
-LONGVIEWTX.GOV,City,Non-Federal Agency,Longview,TX,ACTIVE,10-Dec-14,6-Mar-16
-LORENATX.GOV,City,Non-Federal Agency,Lorena,TX,ACTIVE,19-Feb-15,22-Apr-16
-LOSALTOSCA.GOV,City,Non-Federal Agency,Los Altos,CA,ACTIVE,5-Feb-15,2-Feb-16
-LOSANGELES-CA.GOV,City,Non-Federal Agency,Los Angeles,CA,ACTIVE,22-Aug-12,30-Sep-13
-LOSRANCHOSNM.GOV,City,Non-Federal Agency,Los Ranchos de Albuquerque,NM,ACTIVE,19-Feb-15,22-Feb-16
-LOUISBURGKANSAS.GOV,City,Non-Federal Agency,Louisburg,KS,ACTIVE,4-Dec-14,15-Jan-16
-LOUISVILLE-KY.GOV,City,Non-Federal Agency,Louisville,KY,ACTIVE,30-Sep-12,30-Sep-13
-LOUISVILLECO.GOV,City,Non-Federal Agency,Louisville,CO,ACTIVE,21-Apr-14,6-May-15
-LOUISVILLEKY.GOV,City,Non-Federal Agency,Louisville,KY,ACTIVE,14-Oct-14,30-Sep-15
-LOVEJOY-GA.GOV,City,Non-Federal Agency,Lovejoy,GA,ACTIVE,18-Jul-13,7-Jan-14
-LOVETTSVILLEVA.GOV,City,Non-Federal Agency,Lovettsville,VA,ACTIVE,30-Jan-15,28-Feb-16
-LOVINGTON-IL.GOV,City,Non-Federal Agency,Lovington,IL,ACTIVE,7-Jan-15,25-Mar-16
-LOWELLARKANSAS.GOV,City,Non-Federal Agency,Lowell,AR,ACTIVE,18-Jul-14,30-Sep-15
-LOWERALLOWAYSCREEK-NJ.GOV,City,Non-Federal Agency,Hancocks Bridge,NJ,ACTIVE,22-Oct-14,20-Jan-16
-LUBBOCKTX.GOV,City,Non-Federal Agency,Lubbock,TX,ACTIVE,2-Mar-15,3-Apr-16
-LUDINGTON-MI.GOV,City,Non-Federal Agency,Ludington,MI,ACTIVE,22-Oct-14,30-Sep-15
-LUNENBURGMA.GOV,City,Non-Federal Agency,Lunenburg,MA,ACTIVE,10-Feb-15,14-Apr-16
-LYMAN-ME.GOV,City,Non-Federal Agency,Lyman,ME,ACTIVE,16-Dec-14,12-Mar-16
-LYMANSC.GOV,City,Non-Federal Agency,Lyman,SC,ACTIVE,24-Sep-14,30-Sep-15
-LYMECT.GOV,City,Non-Federal Agency,Lyme,CT,ACTIVE,7-May-14,7-May-15
-LYMENH.GOV,City,Non-Federal Agency,Lyme,NH,ACTIVE,22-Sep-14,16-Sep-15
-LYNDEBOROUGHNH.GOV,City,Non-Federal Agency,Lyndeborough,NH,ACTIVE,18-Jun-12,18-Jun-13
-LYNDONKS.GOV,City,Non-Federal Agency,Lyndon,KS,ACTIVE,9-Jun-14,8-Jul-15
-LYNNMA.GOV,City,Non-Federal Agency,Lynn,MA,ACTIVE,11-Feb-14,11-May-15
-LYNNWOODWA.GOV,City,Non-Federal Agency,Lynnwood,WA,ACTIVE,28-Jan-15,7-Mar-16
-LYONSTOWNSHIPIL.GOV,City,Non-Federal Agency,Countryside,IL,ACTIVE,27-Oct-14,16-Nov-15
-MACOMB-MI.GOV,City,Non-Federal Agency,Macomb,MI,ACTIVE,3-Sep-14,30-Sep-15
-MACONGA.GOV,City,Non-Federal Agency,Macon,GA,ACTIVE,6-Mar-12,4-Jun-13
-MADEIRABEACHFL.GOV,City,Non-Federal Agency,Madeira Beach,FL,ACTIVE,22-Sep-14,4-Dec-15
-MADERA-CA.GOV,City,Non-Federal Agency,Madera,CA,ACTIVE,19-Mar-14,21-Apr-15
-MADISON-AL.GOV,City,Non-Federal Agency,Madison,AL,ACTIVE,21-Sep-11,30-Sep-12
-MADISON-IN.GOV,City,Non-Federal Agency,Madison,IN,ACTIVE,7-Jan-14,30-Sep-14
-MADISONAL.GOV,City,Non-Federal Agency,Madison,AL,ACTIVE,4-Feb-15,9-Mar-16
-MAHARISHIVEDICCITY-IOWA.GOV,City,Non-Federal Agency,Maharishi Vedic City,IA,ACTIVE,7-Jun-14,1-Jul-15
-MAHOMET-IL.GOV,City,Non-Federal Agency,Mahomet,IL,ACTIVE,28-Apr-14,26-Jun-15
-MAHWAH-NJ.GOV,City,Non-Federal Agency,Mahwah,NJ,ACTIVE,20-Mar-14,19-Apr-15
-MAIDENNC.GOV,City,Non-Federal Agency,Maiden,NC,ACTIVE,16-Jul-13,18-Mar-14
-MALVERNAR.GOV,City,Non-Federal Agency,Malvern,AR,ACTIVE,5-Sep-14,3-Sep-15
-MANASQUAN-NJ.GOV,City,Non-Federal Agency,MANASQUAN,NJ,ACTIVE,7-Oct-14,7-Oct-15
-MANASSASPARKVA.GOV,City,Non-Federal Agency,Manassas Park,VA,ACTIVE,23-Sep-14,16-Dec-15
-MANASSASVA.GOV,City,Non-Federal Agency,Manassas,VA,ACTIVE,9-Mar-15,8-Apr-16
-MANCHESTER-GA.GOV,City,Non-Federal Agency,Manchester,GA,ACTIVE,26-Feb-15,28-Apr-16
-MANCHESTER-VT.GOV,City,Non-Federal Agency,Manchester Center,VT,ACTIVE,3-Jul-14,18-Aug-15
-MANCHESTERCT.GOV,City,Non-Federal Agency,Manchester,CT,ACTIVE,26-Aug-14,20-Oct-15
-MANCHESTERMD.GOV,City,Non-Federal Agency,MANCHESTER,MD,ACTIVE,21-May-14,13-Jun-15
-MANCHESTERMO.GOV,City,Non-Federal Agency,Manchester,MO,ACTIVE,20-Jan-15,20-Mar-16
-MANCHESTERNH.GOV,City,Non-Federal Agency,Manchester,NH,ACTIVE,7-Jul-14,30-Sep-15
-MANISTEEMI.GOV,City,Non-Federal Agency,Traverse City,MI,ACTIVE,28-Jun-14,29-Jun-15
-MANKATO-MN.GOV,City,Non-Federal Agency,Mankato,MN,ACTIVE,11-Dec-14,24-Jan-16
-MANKATOMN.GOV,City,Non-Federal Agency,Mankato,MN,ACTIVE,15-Jul-14,26-Aug-15
-MANSFIELDCT.GOV,City,Non-Federal Agency,Mansfield,CT,ACTIVE,7-Jan-15,10-Mar-16
-MANSFIELDGA.GOV,City,Non-Federal Agency,Mans,GA,ACTIVE,21-Jul-14,21-Jul-15
-MANSFIELDTEXAS.GOV,City,Non-Federal Agency,Mansfield,TX,ACTIVE,4-Apr-14,5-Apr-15
-MANSFIELDTOWNSHIP-NJ.GOV,City,Non-Federal Agency,Port Murray,NJ,ACTIVE,19-Feb-13,30-Sep-13
-MANTUATOWNSHIPOHIO.GOV,City,Non-Federal Agency,Mantua,OH,ACTIVE,14-Jan-15,14-Mar-16
-MAPLEGROVEMN.GOV,City,Non-Federal Agency,Maple Grove,MN,ACTIVE,31-Mar-14,2-Jun-15
-MAPLEVALLEYWA.GOV,City,Non-Federal Agency,Maple Valley,WA,ACTIVE,11-Mar-15,6-Jun-16
-MAPLEWOODMN.GOV,City,Non-Federal Agency,Maplewood,MN,ACTIVE,13-Feb-15,13-Feb-16
-MARANAAZ.GOV,City,Non-Federal Agency,Marana,AZ,ACTIVE,18-Jun-14,2-Aug-15
-MARBLEFALLSTX.GOV,City,Non-Federal Agency,Marble Falls,TX,ACTIVE,7-Oct-14,5-Nov-15
-MARICOPA-AZ.GOV,City,Non-Federal Agency,Maricopa,AZ,ACTIVE,10-Oct-13,19-Oct-14
-MARIONKY.GOV,City,Non-Federal Agency,Marion,KY,ACTIVE,29-May-14,27-Jul-15
-MARIONMA.GOV,City,Non-Federal Agency,Marion,MA,ACTIVE,11-Mar-15,11-Mar-16
-MARIONSC.GOV,City,Non-Federal Agency,Marion,SC,ACTIVE,28-Mar-14,26-May-15
-MARKESANWI.GOV,City,Non-Federal Agency,Markesan,WI,ACTIVE,12-Mar-14,24-May-15
-MARLBORO-NJ.GOV,City,Non-Federal Agency,Marlboro,NJ,ACTIVE,6-May-14,23-May-15
-MARLBOROUGH-MA.GOV,City,Non-Federal Agency,Marlborough,MA,ACTIVE,23-Sep-14,30-Sep-15
-MARLOWNH.GOV,City,Non-Federal Agency,Marlow,NH,ACTIVE,12-Mar-15,11-Mar-16
-MAROAILLINOIS.GOV,City,Non-Federal Agency,Maroa,IL,ACTIVE,25-Sep-14,19-Dec-15
-MARSHFIELDMO.GOV,City,Non-Federal Agency,Marshfield,MO,ACTIVE,10-Sep-14,11-Sep-15
-MARTINSVILLE-VA.GOV,City,Non-Federal Agency,Martinsville,VA,ACTIVE,11-Aug-14,4-Nov-15
-MARYSVILLEWA.GOV,City,Non-Federal Agency,Marysville,WA,ACTIVE,23-Feb-15,23-Apr-16
-MARYVILLE-TN.GOV,City,Non-Federal Agency,maryville,TN,ACTIVE,10-Nov-14,6-Feb-16
-MASHPEEMA.GOV,City,Non-Federal Agency,Mashpee,MA,ACTIVE,10-Mar-14,4-Jun-15
-MAYAGUEZPR.GOV,City,Non-Federal Agency,Mayaguez,PR,ACTIVE,9-Jan-15,30-Sep-14
-MCCOMB-MS.GOV,City,Non-Federal Agency,McComb,MS,ACTIVE,29-Sep-14,30-Sep-15
-MCDONOUGH-GA.GOV,City,Non-Federal Agency,McDonough,GA,ACTIVE,31-Jan-14,29-Jan-15
-MCKEESPORT-PA.GOV,City,Non-Federal Agency,McKeesport,PA,ACTIVE,19-Nov-13,24-Oct-14
-MCKENZIETN.GOV,City,Non-Federal Agency,McKenzie,TN,ACTIVE,9-Dec-14,30-Jan-16
-MEADOWSPLACETX.GOV,City,Non-Federal Agency,Meadows Place,TX,ACTIVE,8-Sep-14,7-Nov-15
-MECHANICVILLENY.GOV,City,Non-Federal Agency,Mechanicville,NY,ACTIVE,16-Oct-14,16-Jan-16
-MEDINA-WA.GOV,City,Non-Federal Agency,Medina,WA,ACTIVE,2-Sep-14,30-Sep-15
-MEMPHISTN.GOV,City,Non-Federal Agency,Memphis,TN,ACTIVE,1-Aug-14,30-Sep-15
-MENDON-MA.GOV,City,Non-Federal Agency,Mendon,MA,ACTIVE,26-Dec-12,20-Jul-13
-MENDONMA.GOV,City,Non-Federal Agency,Mendon,MA,ACTIVE,6-Aug-14,20-Jul-15
-MENOMONIE-WI.GOV,City,Non-Federal Agency,Menomonie,WI,ACTIVE,9-Jul-14,30-Sep-15
-MENTONEALABAMA.GOV,City,Non-Federal Agency,Mentone,AL,ACTIVE,11-Apr-14,1-May-15
-MERCHANTVILLENJ.GOV,City,Non-Federal Agency,Merchantville,NJ,ACTIVE,28-Feb-14,25-May-15
-MERIDENCT.GOV,City,Non-Federal Agency,Meriden,CT,ACTIVE,21-Jan-15,22-Mar-16
-MERRIMACKNH.GOV,City,Non-Federal Agency,Merrimack,NH,ACTIVE,15-Sep-14,5-Dec-15
-MESAAZ.GOV,City,Non-Federal Agency,Mesa,AZ,ACTIVE,11-Jun-14,9-Jul-15
-MESILLANM.GOV,City,Non-Federal Agency,Mesilla,NM,ACTIVE,12-Feb-15,12-Feb-16
-MESQUITETX.GOV,City,Non-Federal Agency,Mesquite,TX,ACTIVE,9-Sep-14,9-Sep-15
-MIAMIBEACHFL.GOV,City,Non-Federal Agency,Miami Beach,FL,ACTIVE,4-Aug-14,30-Sep-15
-MIAMIGARDENS-FL.GOV,City,Non-Federal Agency,Miami Gardens,FL,ACTIVE,4-Aug-14,30-Sep-15
-MIAMILAKES-FL.GOV,City,Non-Federal Agency,Miami Lakes,FL,ACTIVE,13-Jun-14,18-Jul-15
-MIAMISPRINGS-FL.GOV,City,Non-Federal Agency,Miami Springs,FL,ACTIVE,19-Aug-14,30-Oct-15
-MIAMITOWNSHIPOH.GOV,City,Non-Federal Agency,Milford,OH,ACTIVE,2-Sep-14,30-Sep-15
-MIAMITWPOH.GOV,City,Non-Federal Agency,Milford,OH,ACTIVE,2-Sep-14,30-Sep-15
-MIDDLETONNH.GOV,City,Non-Federal Agency,Middleton,NH,ACTIVE,21-Jul-14,29-Jul-15
-MIDDLETOWN-CT.GOV,City,Non-Federal Agency,Middletown,CT,ACTIVE,28-Jan-15,11-Mar-16
-MIDDLETOWNCT.GOV,City,Non-Federal Agency,Middletown,CT,ACTIVE,26-Nov-14,18-Nov-15
-MIDDLETOWNVA.GOV,City,Non-Federal Agency,Middletown,VA,ACTIVE,16-Jul-13,12-Dec-13
-MIDLANDTEXAS.GOV,City,Non-Federal Agency,Midland,TX,ACTIVE,12-Jan-15,7-Feb-16
-MIDLOTHIANTX.GOV,City,Non-Federal Agency,Midlothian,TX,ACTIVE,13-Feb-15,12-Feb-16
-MIDWAY-NC.GOV,City,Non-Federal Agency,Winston-Salem,NC,ACTIVE,20-Mar-14,18-Jun-15
-MIFFLIN-OH.GOV,City,Non-Federal Agency,Gahanna,OH,ACTIVE,5-Jun-14,3-Mar-15
-MILAN-NY.GOV,City,Non-Federal Agency,Milan,NY,ACTIVE,15-Sep-14,22-Sep-15
-MILANMO.GOV,City,Non-Federal Agency,Milan,MO,ACTIVE,24-Mar-14,20-Jun-15
-MILANOHIO.GOV,City,Non-Federal Agency,Milan,OH,ACTIVE,25-Feb-15,25-Feb-16
-MILFORD-CT.GOV,City,Non-Federal Agency,Milford,CT,ACTIVE,16-Sep-14,30-Sep-15
-MILFORD-DE.GOV,City,Non-Federal Agency,Milford,DE,ACTIVE,3-Jul-14,30-Sep-15
-MILFORDNE.GOV,City,Non-Federal Agency,Milford,NE,ACTIVE,22-Dec-14,20-Feb-16
-MILLIKENCO.GOV,City,Non-Federal Agency,Milliken,CO,ACTIVE,4-Mar-14,31-Mar-15
-MILLIKENCOLORADO.GOV,City,Non-Federal Agency,Milliken,CO,ACTIVE,17-Sep-14,5-Oct-15
-MILLINGTONTN.GOV,City,Non-Federal Agency,Millington,TN,ACTIVE,2-Mar-15,30-Jan-16
-MILLSTONENJ.GOV,City,Non-Federal Agency,Millstone,NJ,ACTIVE,14-Feb-15,10-Mar-16
-MILLVILLENJ.GOV,City,Non-Federal Agency,Millville,NJ,ACTIVE,21-Jan-15,24-Jan-16
-MILTON-WI.GOV,City,Non-Federal Agency,Milton,WI,ACTIVE,5-Jan-15,5-Apr-16
-MILWAUKIEOREGON.GOV,City,Non-Federal Agency,Milwaukie,OR,ACTIVE,6-Aug-13,3-Nov-14
-MINEOLA-NY.GOV,City,Non-Federal Agency,Mineola,NY,ACTIVE,10-Sep-14,30-Sep-15
-MINERALWELLSTX.GOV,City,Non-Federal Agency,Mineral Wells,TX,ACTIVE,10-Mar-14,9-Mar-15
-MINNEAPOLIS-MN.GOV,City,Non-Federal Agency,Minneapolis,MN,ACTIVE,6-Aug-14,30-Sep-15
-MINNEAPOLISMN.GOV,City,Non-Federal Agency,Minneapolis,MN,ACTIVE,6-Aug-14,21-Aug-15
-MINNETONKA-MN.GOV,City,Non-Federal Agency,Minnetonka,MN,ACTIVE,18-Feb-14,13-May-15
-MIRAMARFL.GOV,City,Non-Federal Agency,Miramar,FL,ACTIVE,5-Nov-14,5-Nov-15
-MISSIONHILLSKS.GOV,City,Non-Federal Agency,Mission Hills,KS,ACTIVE,10-Nov-14,29-Sep-15
-MISSOULA-MT.GOV,City,Non-Federal Agency,Missoula,MT,ACTIVE,3-May-11,3-May-12
-MISSOURICITYTEXAS.GOV,City,Non-Federal Agency,Missouri City,TX,ACTIVE,8-Jan-15,12-Mar-16
-MISSOURICITYTX.GOV,City,Non-Federal Agency,Missouri City,TX,ACTIVE,8-Jan-15,12-Mar-16
-MITCHELL-IN.GOV,City,Non-Federal Agency,Mitchell,IN,ACTIVE,24-Sep-12,20-Oct-13
-MOBILE-AL.GOV,City,Non-Federal Agency,Mobile,AL,ACTIVE,16-Jul-13,30-Sep-13
-MOCKSVILLENC.GOV,City,Non-Federal Agency,Mocksville,NC,ACTIVE,27-Aug-14,26-Sep-15
-MONROEGA.GOV,City,Non-Federal Agency,Monroe,GA,ACTIVE,30-Oct-14,29-Dec-15
-MONROEMI.GOV,City,Non-Federal Agency,Monroe,MI,ACTIVE,14-Jul-14,30-Sep-15
-MONROETWP-OH.GOV,City,Non-Federal Agency,Bethel,OH,ACTIVE,20-Nov-14,20-Nov-15
-MONROEWA.GOV,City,Non-Federal Agency,Monroe,WA,ACTIVE,12-Jan-15,16-Feb-16
-MONTAGUE-MA.GOV,City,Non-Federal Agency,Turners Falls,MA,ACTIVE,10-Nov-14,10-Dec-15
-MONTCLAIRCA.GOV,City,Non-Federal Agency,Montclair,CA,ACTIVE,20-Mar-13,20-Mar-14
-MONTEREYMA.GOV,City,Non-Federal Agency,Monterey,MA,ACTIVE,12-Sep-14,12-Oct-15
-MONTGOMERYAL.GOV,City,Non-Federal Agency,Montgomery,AL,ACTIVE,13-Mar-15,7-Mar-16
-MONTGOMERYOHIO.GOV,City,Non-Federal Agency,Montgomery,OH,ACTIVE,14-Feb-12,14-Apr-13
-MONTGOMERYTEXAS.GOV,City,Non-Federal Agency,Montgomery,TX,ACTIVE,8-Apr-14,7-May-15
-MONTICELLOIN.GOV,City,Non-Federal Agency,Monticello,IN,ACTIVE,25-Feb-14,27-Feb-15
-MOODYALABAMA.GOV,City,Non-Federal Agency,Moody,AL,ACTIVE,17-Jul-13,19-Apr-13
-MOORESVILLE-NC.GOV,City,Non-Federal Agency,Mooresville,NC,ACTIVE,24-Jul-14,24-Jul-15
-MOORPARKCA.GOV,City,Non-Federal Agency,Moorpark,CA,ACTIVE,30-Oct-13,29-Nov-14
-MOREHEAD-KY.GOV,City,Non-Federal Agency,Morehead,KY,ACTIVE,19-Aug-14,9-Nov-15
-MORGANTONNC.GOV,City,Non-Federal Agency,Morganton,NC,ACTIVE,3-Mar-15,1-May-16
-MORGANTOWNWV.GOV,City,Non-Federal Agency,Morgantown,WV,ACTIVE,18-Feb-15,10-May-16
-MOULTONBOROUGHNH.GOV,City,Non-Federal Agency,Moultonborough,NH,ACTIVE,29-Jul-14,17-Oct-15
-MOUNTAINAIRNM.GOV,City,Non-Federal Agency,Mountainair,NM,ACTIVE,12-Apr-12,8-Apr-13
-MOUNTAINHOUSECA.GOV,City,Non-Federal Agency,Mountain House,CA,ACTIVE,30-May-14,30-May-15
-MOUNTAINPARK-GA.GOV,City,Non-Federal Agency,Mountain Park,GA,ACTIVE,29-Sep-14,27-Sep-15
-MOUNTAINVIEW.GOV,City,Non-Federal Agency,Mountain View,CA,ACTIVE,9-Sep-14,30-Sep-15
-MOUNTCARMELTN.GOV,City,Non-Federal Agency,Mount Carmel,TN,ACTIVE,18-Dec-14,22-Feb-16
-MOUNTPOCONO-PA.GOV,City,Non-Federal Agency,Mount Pocono,PA,ACTIVE,15-Jul-14,15-Jul-15
-MOUNTVERNONWA.GOV,City,Non-Federal Agency,Mount Vernon,WA,ACTIVE,30-Jun-14,27-Aug-15
-MQUEBRADILLASPR.GOV,City,Non-Federal Agency,Quebradillas,PR,ACTIVE,12-Jul-13,12-Jul-14
-MTCRESTEDBUTTE-CO.GOV,City,Non-Federal Agency,Mt. Crested Butte,CO,ACTIVE,9-Oct-14,8-Nov-15
-MTPLEASANTWI.GOV,City,Non-Federal Agency,Mount Pleasant,WI,ACTIVE,2-Jul-14,30-Sep-15
-MTSHASTACA.GOV,City,Non-Federal Agency,Mt. Shasta,CA,ACTIVE,13-Oct-14,9-Jan-16
-MUKILTEOWA.GOV,City,Non-Federal Agency,Mukilteo,WA,ACTIVE,30-Jun-14,30-Jun-15
-MURFREESBOROTN.GOV,City,Non-Federal Agency,Murfreesboro,TN,ACTIVE,16-Sep-14,17-Sep-15
-MURPHYSBORO-IL.GOV,City,Non-Federal Agency,Murphysboro,IL,ACTIVE,31-Oct-14,30-Dec-15
-MURPHYTX.GOV,City,Non-Federal Agency,Murphy,TX,ACTIVE,11-Jun-14,1-Sep-15
-MURRAYKY.GOV,City,Non-Federal Agency,Murray,KY,ACTIVE,13-Jun-14,2-Sep-15
-MUSCATINEIOWA.GOV,City,Non-Federal Agency,Muscatine,IA,ACTIVE,5-Mar-12,3-Jun-13
-MUSKEGON-MI.GOV,City,Non-Federal Agency,Muskegon,MI,ACTIVE,25-Feb-15,17-May-16
-MYARLINGTONTX.GOV,City,Non-Federal Agency,Arlington,TX,ACTIVE,3-Dec-14,27-Dec-15
-MYCOLUMBUS.GOV,City,Non-Federal Agency,Columbus,OH,ACTIVE,17-Sep-14,13-Sep-15
-MYDELRAYBEACHFL.GOV,City,Non-Federal Agency,Delray Beach,FL,ACTIVE,10-Sep-14,11-Jul-15
-NAGSHEADNC.GOV,City,Non-Federal Agency,Nags Head,NC,ACTIVE,2-Jan-15,1-Feb-16
-NANTICOKECITY-PA.GOV,City,Non-Federal Agency,NANTICOKE,PA,ACTIVE,8-Aug-13,17-Feb-14
-NANTUCKET-MA.GOV,City,Non-Federal Agency,Nantucket,MA,ACTIVE,8-Sep-14,30-Sep-15
-NAPLESCITYUT.GOV,City,Non-Federal Agency,Naples,UT,ACTIVE,28-Jul-14,26-Jul-15
-NARRAGANSETTRI.GOV,City,Non-Federal Agency,Narragansett,RI,ACTIVE,8-Jan-15,12-Jan-16
-NASHOTAH-WI.GOV,City,Non-Federal Agency,Nashotah,WI,ACTIVE,16-Jul-14,14-Oct-15
-NASHUANH.GOV,City,Non-Federal Agency,Nashua,NH,ACTIVE,10-Nov-14,2-Feb-16
-NASHVILLE.GOV,City,Non-Federal Agency,Nashville,TN,ACTIVE,31-Jul-14,30-Sep-15
-NATCHITOCHESLA.GOV,City,Non-Federal Agency,Natchitoches,LA,ACTIVE,23-Jul-14,31-Jul-15
-NATIONALCITYCA.GOV,City,Non-Federal Agency,National City,CA,ACTIVE,1-May-14,7-May-15
-NAUGATUCK-CT.GOV,City,Non-Federal Agency,Naugatuck,CT,ACTIVE,19-Aug-14,5-Nov-15
-NBCA.GOV,City,Non-Federal Agency,Newport Beach,CA,ACTIVE,31-Mar-14,23-May-15
-NEBRASKACITYNE.GOV,City,Non-Federal Agency,Nebraska City,NE,ACTIVE,20-Oct-14,20-Oct-15
-NEEDHAMMA.GOV,City,Non-Federal Agency,NEEDHAM,MA,ACTIVE,27-May-14,25-Jul-15
-NEVADACITYCA.GOV,City,Non-Federal Agency,Nevada City,CA,ACTIVE,26-Sep-12,27-Aug-13
-NEVILLEISLAND-PA.GOV,City,Non-Federal Agency,Pittsburgh,PA,ACTIVE,2-Aug-12,30-Sep-12
-NEWAUBURNMN.GOV,City,Non-Federal Agency,New Auburn,MN,ACTIVE,6-Mar-15,6-Mar-16
-NEWBEDFORD-MA.GOV,City,Non-Federal Agency,New Bedford,MA,ACTIVE,17-Nov-14,18-Nov-15
-NEWBERGOREGON.GOV,City,Non-Federal Agency,Newberg,OR,ACTIVE,19-Jun-14,23-Jun-15
-NEWBOSTONNH.GOV,City,Non-Federal Agency,New Boston,NH,ACTIVE,17-Jul-12,19-Jul-13
-NEWBRIGHTONMN.GOV,City,Non-Federal Agency,New Brighton,MN,ACTIVE,1-Aug-14,30-Sep-15
-NEWBRITAINCT.GOV,City,Non-Federal Agency,New Britain,CT,ACTIVE,28-Feb-14,20-May-15
-NEWBURGH-IN.GOV,City,Non-Federal Agency,Newburgh,IN,ACTIVE,9-Sep-14,30-Sep-15
-NEWBURGHHTSOH.GOV,City,Non-Federal Agency,Newburgh Heights,OH,ACTIVE,3-Jun-14,20-Jun-15
-NEWCANAANCT.GOV,City,Non-Federal Agency,New Canaan,CT,ACTIVE,30-Apr-14,3-May-15
-NEWCARROLLTONMD.GOV,City,Non-Federal Agency,New Carrollton,MD,ACTIVE,27-Jan-15,15-Apr-16
-NEWCASTLEPA.GOV,City,Non-Federal Agency,New Castle,PA,ACTIVE,4-Sep-12,5-Sep-13
-NEWCONCORD-OH.GOV,City,Non-Federal Agency,New Concord,OH,ACTIVE,24-Jul-14,30-Sep-15
-NEWHARMONY-IN.GOV,City,Non-Federal Agency,New Harmony,IN,ACTIVE,30-Sep-14,29-Dec-15
-NEWHAVENCT.GOV,City,Non-Federal Agency,New Haven,CT,ACTIVE,11-Mar-15,11-Mar-16
-NEWINGTONCT.GOV,City,Non-Federal Agency,Newington,CT,ACTIVE,5-Jan-15,14-Dec-15
-NEWMARKETNH.GOV,City,Non-Federal Agency,Newmarket,NH,ACTIVE,5-Aug-14,30-Sep-15
-NEWMARLBOROUGHMA.GOV,City,Non-Federal Agency,Mill River,MA,ACTIVE,30-Jan-14,22-Apr-15
-NEWNANGA.GOV,City,Non-Federal Agency,Newnan,GA,ACTIVE,14-Nov-13,16-Mar-14
-NEWORLEANS-LA.GOV,City,Non-Federal Agency,New Orleans,LA,ACTIVE,19-Jun-14,5-Aug-15
-NEWORLEANSLA.GOV,City,Non-Federal Agency,New Orleans,LA,ACTIVE,19-Jun-14,5-Aug-15
-NEWPORT-RI.GOV,City,Non-Federal Agency,Newport,RI,ACTIVE,8-May-14,27-May-15
-NEWPORTBEACH-CA.GOV,City,Non-Federal Agency,Newport Beach,CA,ACTIVE,2-Jul-13,30-Sep-14
-NEWPORTBEACHCA.GOV,City,Non-Federal Agency,Newport Beach,CA,ACTIVE,31-Mar-14,25-Mar-15
-NEWPORTKY.GOV,City,Non-Federal Agency,Newport,KY,ACTIVE,1-Jul-14,13-Jul-15
-NEWPORTNEWSVA.GOV,City,Non-Federal Agency,Newport News,VA,ACTIVE,18-Jun-14,18-Jun-15
-NEWPORTOREGON.GOV,City,Non-Federal Agency,Newport,OR,ACTIVE,8-Mar-15,7-Apr-16
-NEWRICHMONDWI.GOV,City,Non-Federal Agency,New Richmond ,WI,ACTIVE,17-Nov-14,15-Dec-15
-NEWRUSSIATOWNSHIP-OH.GOV,City,Non-Federal Agency,Oberlin,OH,ACTIVE,7-Aug-14,30-Sep-15
-NEWTON-NH.GOV,City,Non-Federal Agency,Newton,NH,ACTIVE,27-Mar-14,29-Mar-15
-NEWTONNC.GOV,City,Non-Federal Agency,Newton,NC,ACTIVE,19-Aug-14,30-Sep-15
-NEWTOWN-CT.GOV,City,Non-Federal Agency,Newtown,CT,ACTIVE,1-Aug-14,30-Sep-15
-NEWTOWNOHIO.GOV,City,Non-Federal Agency,Newtown,OH,ACTIVE,10-Jul-14,30-Jun-15
-NEWTOWNPA.GOV,City,Non-Federal Agency,Newtown,PA,ACTIVE,4-Aug-14,2-Jul-15
-NIAGARAFALLSNY.GOV,City,Non-Federal Agency,Niagara Falls,NY,ACTIVE,15-Sep-14,14-Sep-15
-NIAGARAFALLSNYCARTS.GOV,City,Non-Federal Agency,Niagara Falls,NY,ACTIVE,30-May-14,30-May-15
-NILES-IL.GOV,City,Non-Federal Agency,Niles,IL,ACTIVE,7-Jan-15,6-Feb-16
-NILESTWPMI.GOV,City,Non-Federal Agency,Niles,MI,ACTIVE,27-Jun-13,19-Jun-14
-NINNEKAHOK.GOV,City,Non-Federal Agency,NINNEKAH,OK,ACTIVE,11-Feb-15,11-Feb-16
-NISSEQUOGUENY.GOV,City,Non-Federal Agency,St. James,NY,ACTIVE,17-Apr-14,24-May-15
-NIXAMO.GOV,City,Non-Federal Agency,Nixa,MO,ACTIVE,2-Mar-15,29-May-16
-NNVA.GOV,City,Non-Federal Agency,Newport News,VA,ACTIVE,18-Jun-14,18-Jun-15
-NOGALESAZ.GOV,City,Non-Federal Agency,Nogales,AZ,ACTIVE,21-Apr-14,27-May-15
-NOLA.GOV,City,Non-Federal Agency,New Orleans,LA,ACTIVE,19-Jun-14,5-Aug-15
-NOLENSVILLETN.GOV,City,Non-Federal Agency,Nolensville,TN,ACTIVE,24-Nov-14,20-Feb-16
-NORFOLK.GOV,City,Non-Federal Agency,Norfolk,VA,ACTIVE,16-Oct-14,20-Oct-15
-NORFOLKVA.GOV,City,Non-Federal Agency,Norfolk,VA,ACTIVE,11-Jan-13,11-Jan-14
-NORMANDYPARKWA.GOV,City,Non-Federal Agency,Normandy Park,WA,ACTIVE,10-Feb-15,9-Apr-16
-NORMANOK.GOV,City,Non-Federal Agency,Norman,OK,ACTIVE,25-Feb-14,27-Mar-15
-NORMANPARKGA.GOV,City,Non-Federal Agency,Norman Park,GA,ACTIVE,4-Sep-14,4-Sep-15
-NORRIDGE-IL.GOV,City,Non-Federal Agency,Norridge,IL,ACTIVE,22-Jul-13,7-Nov-13
-NORTHADAMS-MA.GOV,City,Non-Federal Agency,North Adams,MA,ACTIVE,4-Feb-15,28-Feb-16
-NORTHAMPTONMA.GOV,City,Non-Federal Agency,Northampton,MA,ACTIVE,22-Oct-14,4-Nov-15
-NORTHBENDWA.GOV,City,Non-Federal Agency,North Bend,WA,ACTIVE,10-Mar-14,6-May-15
-NORTHBOROUGH-MA.GOV,City,Non-Federal Agency,Northborough,MA,ACTIVE,18-Dec-12,23-Sep-13
-NORTHBRUNSWICKNJ.GOV,City,Non-Federal Agency,North Brunswick,NJ,ACTIVE,15-Feb-14,6-May-15
-NORTHCANTONOHIO.GOV,City,Non-Federal Agency,North Canton,OH,ACTIVE,8-Dec-14,6-Feb-16
-NORTHFIELD-VT.GOV,City,Non-Federal Agency,Northfield,VT,ACTIVE,5-Mar-15,30-Mar-16
-NORTHFIELDVILLAGE-OH.GOV,City,Non-Federal Agency,NORTHFIELD,OH,ACTIVE,21-Oct-14,18-Oct-15
-NORTHHAVEN-CT.GOV,City,Non-Federal Agency,North Haven,CT,ACTIVE,4-Mar-15,30-Mar-16
-NORTHHEMPSTEADNY.GOV,City,Non-Federal Agency,MANHASSET,NY,ACTIVE,24-Mar-14,20-Jun-15
-NORTHLEBANONTWPPA.GOV,City,Non-Federal Agency,Lebanon,PA,ACTIVE,12-Mar-15,5-Jun-16
-NORTHPORTNY.GOV,City,Non-Federal Agency,Northport,NY,ACTIVE,27-Feb-15,28-Apr-16
-NORTHPROVIDENCERI.GOV,City,Non-Federal Agency,North Providence,RI,ACTIVE,18-Sep-14,20-Nov-15
-NORTHREADINGMA.GOV,City,Non-Federal Agency,North Reading,MA,ACTIVE,28-Sep-14,30-Sep-15
-NORTHSIOUXCITY-SD.GOV,City,Non-Federal Agency,N. Sioux City,SD,ACTIVE,3-Sep-14,30-Sep-15
-NORTHSTONINGTONCT.GOV,City,Non-Federal Agency,North Stonington,CT,ACTIVE,8-Oct-14,6-Oct-15
-NORTHVERNON-IN.GOV,City,Non-Federal Agency,North Vernon,IN,ACTIVE,29-Aug-14,21-Nov-15
-NORTONVA.GOV,City,Non-Federal Agency,Norton,VA,ACTIVE,13-Dec-14,20-Dec-15
-NORWALKCA.GOV,City,Non-Federal Agency,Norwalk,CA,ACTIVE,4-Dec-14,6-Dec-15
-NORWAYMI.GOV,City,Non-Federal Agency,Norway,MI,ACTIVE,2-Sep-14,30-Sep-15
-NORWOOD-MA.GOV,City,Non-Federal Agency,Norwood,MA,ACTIVE,1-Oct-14,3-Nov-15
-NORWOODMA.GOV,City,Non-Federal Agency,Norwood,MA,ACTIVE,1-Oct-14,3-Nov-15
-NOTTINGHAM-NH.GOV,City,Non-Federal Agency,Nottingham,NH,ACTIVE,15-May-14,11-Jul-15
-NSIDFL.GOV,City,Non-Federal Agency,Coral Springs,FL,ACTIVE,2-Mar-15,26-May-16
-NYACK-NY.GOV,City,Non-Federal Agency,Nyack,NY,ACTIVE,22-Jan-15,22-Jan-16
-OAKBLUFFSMA.GOV,City,Non-Federal Agency,Oak Bluffs,MA,ACTIVE,5-Jan-15,30-Jan-16
-OAKHAM-MA.GOV,City,Non-Federal Agency,Oakham,MA,ACTIVE,26-Feb-15,14-Mar-16
-OAKLAND-ME.GOV,City,Non-Federal Agency,Oakland,ME,ACTIVE,19-Jun-14,17-Jun-15
-OAKLANDCA.GOV,City,Non-Federal Agency,Oakland,CA,ACTIVE,27-Jan-15,27-Jan-16
-OAKLANDPARKFL.GOV,City,Non-Federal Agency,Oakland Park,FL,ACTIVE,15-Jan-15,13-Apr-16
-OAKLAWN-IL.GOV,City,Non-Federal Agency,OAK LAWN,IL,ACTIVE,27-May-14,25-Aug-15
-OAKRIDGETN.GOV,City,Non-Federal Agency,"Oak Ridge, TN 37830 United States",TN,ACTIVE,5-Mar-15,5-May-16
-OAKWOODOHIO.GOV,City,Non-Federal Agency,Oakwood,OH,ACTIVE,22-Apr-14,14-May-15
-OBERLINKANSAS.GOV,City,Non-Federal Agency,Oberlin,KS,ACTIVE,29-Dec-14,23-Mar-16
-OCCOQUANVA.GOV,City,Non-Federal Agency,Occoquan,VA,ACTIVE,2-Jun-14,2-Jun-15
-OCEANAWV.GOV,City,Non-Federal Agency,Oceana,WV,ACTIVE,24-Mar-14,6-Jun-15
-OCEANCITYMD.GOV,City,Non-Federal Agency,Ocean City ,MD,ACTIVE,4-Aug-14,10-Oct-15
-OCEANGATE-NJ.GOV,City,Non-Federal Agency,Ocean Gate,NJ,ACTIVE,6-Nov-13,25-Oct-14
-OCEANSPRINGS-MS.GOV,City,Non-Federal Agency,Ocean Springs,MS,ACTIVE,23-Jul-13,14-Apr-13
-OCONOMOWOC-WI.GOV,City,Non-Federal Agency,Oconomowoc,WI,ACTIVE,17-Jun-14,10-Sep-15
-OGDEN-KS.GOV,City,Non-Federal Agency,Ogden ,KS,ACTIVE,5-Dec-14,30-Dec-15
-OLDSAYBROOKCT.GOV,City,Non-Federal Agency,Old Saybrook,CT,ACTIVE,20-Nov-14,20-Nov-15
-OLIVERSPRINGS-TN.GOV,City,Non-Federal Agency,Oliver Springs,TN,ACTIVE,31-Oct-14,30-Dec-15
-OMAHA-NE.GOV,City,Non-Federal Agency,Omaha,NE,ACTIVE,23-Jul-13,21-Oct-14
-OPALOCKAFL.GOV,City,Non-Federal Agency,OPALOCKA,FL,ACTIVE,12-Jan-15,8-Jan-16
-ORMONDBEACH-FL.GOV,City,Non-Federal Agency,Ormond Beach,FL,ACTIVE,24-Jun-14,8-Sep-15
-OROVALLEYAZ.GOV,City,Non-Federal Agency,Oro Valley,AZ,ACTIVE,21-Apr-14,12-Jul-15
-OSAGEBEACH-MO.GOV,City,Non-Federal Agency,OSAGE BEACH,MO,ACTIVE,4-Nov-14,2-Dec-15
-OSCODATOWNSHIPMI.GOV,City,Non-Federal Agency,Oscoda,MI,ACTIVE,13-Oct-14,10-Jan-16
-OTHELLOWA.GOV,City,Non-Federal Agency,Othello,WA,ACTIVE,16-Jan-15,22-Jan-16
-OTISFIELDME.GOV,City,Non-Federal Agency,OTISFIELD,ME,ACTIVE,12-Aug-14,31-Aug-15
-OTTAWAKS.GOV,City,Non-Federal Agency,Ottawa,KS,ACTIVE,6-Nov-14,25-Nov-15
-OYSTERBAY-NY.GOV,City,Non-Federal Agency,Oyster Bay,NY,ACTIVE,30-Dec-14,10-Jan-16
-PADUCAHKY.GOV,City,Non-Federal Agency,Paducah,KY,ACTIVE,2-Jun-14,31-Aug-15
-PALATKA-FL.GOV,City,Non-Federal Agency,Palatka,FL,ACTIVE,27-Jan-14,20-Mar-15
-PALMETTOBAY-FL.GOV,City,Non-Federal Agency,Palmetto Bay,FL,ACTIVE,14-Jul-14,9-Sep-15
-PALMSPRINGS-CA.GOV,City,Non-Federal Agency,Palm Springs,CA,ACTIVE,2-Jun-14,28-Jul-15
-PALMSPRINGSCA.GOV,City,Non-Federal Agency,Palm Springs,CA,ACTIVE,22-Jul-14,17-Oct-15
-PALOSHILLS-IL.GOV,City,Non-Federal Agency,Palos Hills,IL,ACTIVE,3-Jul-14,6-Jul-15
-PANORAMAVILLAGETX.GOV,City,Non-Federal Agency,Panorama Village,TX,ACTIVE,1-Oct-14,22-May-15
-PARADISEVALLEYAZ.GOV,City,Non-Federal Agency,Paradise Valley,AZ,ACTIVE,15-Jan-14,21-Jan-15
-PARISTEXAS.GOV,City,Non-Federal Agency,Paris,TX,ACTIVE,7-Oct-14,6-Jan-16
-PARISTN.GOV,City,Non-Federal Agency,Paris,TN,ACTIVE,5-May-14,29-Jun-15
-PARKERSBURGWV.GOV,City,Non-Federal Agency,Parkersburg,WV,ACTIVE,17-Nov-14,17-Nov-15
-PARKVILLEMO.GOV,City,Non-Federal Agency,Parkville,MO,ACTIVE,20-Mar-14,26-Apr-15
-PARMAHEIGHTSOH.GOV,City,Non-Federal Agency,Parma Heights,OH,ACTIVE,2-Jul-14,30-Sep-15
-PASADENACA.GOV,City,Non-Federal Agency,Pasadena,CA,ACTIVE,27-Oct-14,20-Oct-15
-PASADENATX.GOV,City,Non-Federal Agency,Pasadena,TX,ACTIVE,16-Jul-14,15-Aug-15
-PASCO-WA.GOV,City,Non-Federal Agency,Pasco,WA,ACTIVE,13-Feb-15,18-Sep-15
-PATAGONIA-AZ.GOV,City,Non-Federal Agency,Patagonia,AZ,ACTIVE,28-May-14,29-May-15
-PATERSONNJ.GOV,City,Non-Federal Agency,Paterson,NJ,ACTIVE,22-Aug-14,17-Oct-15
-PAWLING-NY.GOV,City,Non-Federal Agency,Pawling,NY,ACTIVE,24-Apr-12,29-Apr-13
-PAWNEEROCK-KS.GOV,City,Non-Federal Agency,Pawnee Rock,KS,ACTIVE,29-Jan-15,19-Mar-16
-PAXTONFL.GOV,City,Non-Federal Agency,Laurel Hill,FL,ACTIVE,23-Jul-14,18-Oct-15
-PAYSONAZ.GOV,City,Non-Federal Agency,Payson,AZ,ACTIVE,4-Mar-14,2-Jun-15
-PEABODY-MA.GOV,City,Non-Federal Agency,Peabody,MA,ACTIVE,2-Jul-14,30-Sep-15
-PEABODYMA.GOV,City,Non-Federal Agency,PEABODY,MA,ACTIVE,31-Jul-14,18-Oct-15
-PEARLANDTX.GOV,City,Non-Federal Agency,Pearland,TX,ACTIVE,31-Dec-14,25-Mar-16
-PECOSTX.GOV,City,Non-Federal Agency,Pecos,TX,ACTIVE,10-Mar-15,10-Mar-16
-PEMBROKE-MA.GOV,City,Non-Federal Agency,Pembroke,MA,ACTIVE,14-May-14,25-Jun-15
-PEORIAHEIGHTS-IL.GOV,City,Non-Federal Agency,Peoria Heights,IL,ACTIVE,20-Jul-10,20-Aug-11
-PERRYTOWNSHIP-IN.GOV,City,Non-Federal Agency,Indianapolis,IN,ACTIVE,14-Apr-14,24-Apr-15
-PERTHAMBOYNJ.GOV,City,Non-Federal Agency,Perth Amboy,NJ,ACTIVE,17-May-11,17-May-12
-PETERBOROUGHNH.GOV,City,Non-Federal Agency,Peterborough,NH,ACTIVE,29-Jan-15,29-Jan-16
-PETERSBURGAK.GOV,City,Non-Federal Agency,Petersburg,AK,ACTIVE,25-Nov-13,30-Jan-15
-PETERSBURGVA.GOV,City,Non-Federal Agency,Petersburg,VA,ACTIVE,4-Feb-15,11-Mar-16
-PFLUGERVILLETX.GOV,City,Non-Federal Agency,Pflugerville,TX,ACTIVE,10-Feb-15,5-May-16
-PHARR-TX.GOV,City,Non-Federal Agency,Pharr,TX,ACTIVE,20-Nov-14,19-Jan-16
-PHILA.GOV,City,Non-Federal Agency,Philadelphia,PA,ACTIVE,2-Jul-14,30-Sep-15
-PHILLIPSTON-MA.GOV,City,Non-Federal Agency,Phillipston,MA,ACTIVE,23-Sep-14,30-Sep-15
-PHOENIXOREGON.GOV,City,Non-Federal Agency,Phoenix,OR,ACTIVE,12-Mar-15,8-Jun-16
-PIEDMONT-OK.GOV,City,Non-Federal Agency,PIEDMONT,OK,ACTIVE,9-Jan-14,4-Jan-15
-PIKEVILLEKY.GOV,City,Non-Federal Agency,Pikeville,KY,ACTIVE,4-Apr-14,4-Apr-15
-PINEBLUFFSWY.GOV,City,Non-Federal Agency,Pine Bluffs,WY,ACTIVE,16-Jul-13,30-Aug-14
-PINEPLAINS-NY.GOV,City,Non-Federal Agency,Pine Plains,NY,ACTIVE,30-Oct-14,30-Sep-15
-PITTSBORONC.GOV,City,Non-Federal Agency,Pittsboro,NC,ACTIVE,16-Sep-14,15-Dec-15
-PITTSBURGCA.GOV,City,Non-Federal Agency,PITTSBURG,CA,ACTIVE,16-Oct-14,14-Jan-16
-PITTSBURGHPA.GOV,City,Non-Federal Agency,Pittsburgh,PA,ACTIVE,20-Oct-14,20-Oct-15
-PITTSFIELD-MI.GOV,City,Non-Federal Agency,Ann Arbor,MI,ACTIVE,28-May-14,14-Aug-15
-PITTSFIELDNH.GOV,City,Non-Federal Agency,Pittsfield,NH,ACTIVE,11-Jun-14,11-Jun-15
-PLAINFIELDNJ.GOV,City,Non-Federal Agency,Plainfield,NJ,ACTIVE,16-Jun-14,16-Jun-15
-PLANDOMEHEIGHTS-NY.GOV,City,Non-Federal Agency,Manhasset,NY,ACTIVE,12-Aug-14,10-Nov-15
-PLEASANTONCA.GOV,City,Non-Federal Agency,Pleasanton,CA,ACTIVE,29-Oct-14,18-Nov-15
-PLEASANTONTX.GOV,City,Non-Federal Agency,Pleasanton,TX,ACTIVE,17-Feb-15,16-Apr-16
-PLEASANTVALLEY-NY.GOV,City,Non-Federal Agency,Pleasant Valley,NY,ACTIVE,24-Apr-12,29-Apr-13
-PLEASANTVILLE-NY.GOV,City,Non-Federal Agency,Pleasantville,NY,ACTIVE,6-Feb-14,21-Jan-15
-PLOVERWI.GOV,City,Non-Federal Agency,Plover,WI,ACTIVE,13-Aug-14,12-Oct-15
-PLUMSTEAD.GOV,City,Non-Federal Agency,Plumsteadville,PA,ACTIVE,25-Aug-14,27-Sep-15
-PLYMOUTH-MA.GOV,City,Non-Federal Agency,Plymouth,MA,ACTIVE,15-Jul-13,30-Sep-13
-PLYMOUTHMN.GOV,City,Non-Federal Agency,Plymouth,MN,ACTIVE,26-Aug-14,24-Nov-15
-POLKCITYIA.GOV,City,Non-Federal Agency,Polk City,IA,ACTIVE,22-Jul-14,22-Jul-15
-POMPANOBEACHFL.GOV,City,Non-Federal Agency,Pompano Beach,FL,ACTIVE,5-May-14,2-Aug-15
-POMPEY-NY.GOV,City,Non-Federal Agency,MANLIUS,NY,ACTIVE,5-Nov-14,5-Nov-15
-PONCACITYOK.GOV,City,Non-Federal Agency,Ponca City,OK,ACTIVE,9-Jan-14,6-Feb-15
-POOLER-GA.GOV,City,Non-Federal Agency,Pooler,GA,ACTIVE,5-May-14,3-Feb-15
-POOLESVILLEMD.GOV,City,Non-Federal Agency,Poolesville,MD,ACTIVE,21-Jan-15,22-Jan-16
-POPLARBLUFF-MO.GOV,City,Non-Federal Agency,Poplar Bluff,MO,ACTIVE,25-Mar-14,12-May-15
-POQUOSON-VA.GOV,City,Non-Federal Agency,Poquioson,VA,ACTIVE,13-Jan-14,11-Apr-15
-PORTAGEWI.GOV,City,Non-Federal Agency,Portage,WI,ACTIVE,8-Jan-15,22-Feb-16
-PORTALESNM.GOV,City,Non-Federal Agency,Portales,NM,ACTIVE,7-Apr-14,14-Jun-15
-PORTARTHURTX.GOV,City,Non-Federal Agency,Port Arthur,TX,ACTIVE,8-May-14,8-May-15
-PORTCLINTON-OH.GOV,City,Non-Federal Agency,Port Clinton,OH,ACTIVE,17-Feb-15,10-Mar-16
-PORTERVILLE-CA.GOV,City,Non-Federal Agency,Porterville,CA,ACTIVE,23-Sep-14,30-Aug-15
-PORTERVILLECA.GOV,City,Non-Federal Agency,Porterville,CA,ACTIVE,23-Sep-14,30-Aug-15
-PORTLANDMAINE.GOV,City,Non-Federal Agency,Portland,ME,ACTIVE,2-Jul-14,30-Sep-15
-PORTLANDOREGON.GOV,City,Non-Federal Agency,Portland,OR,ACTIVE,18-Dec-14,18-Mar-16
-PORTLANDTX.GOV,City,Non-Federal Agency,Portland,TX,ACTIVE,12-Feb-14,13-Apr-15
-PORTSMOUTHVIRGINIA.GOV,City,Non-Federal Agency,Portsmouth,VA,ACTIVE,3-Sep-14,21-Sep-15
-POTTERTWP-PA.GOV,City,Non-Federal Agency,Monaca,PA,ACTIVE,8-Jul-14,6-Aug-15
-POWHATANVA.GOV,City,Non-Federal Agency,Powhatan,VA,ACTIVE,9-Mar-15,7-Jun-16
-PRAIRIEDUCHIEN-WI.GOV,City,Non-Federal Agency,Prairie du Chien,WI,ACTIVE,19-Sep-14,30-Sep-15
-PRAIRIEVIEWTEXAS.GOV,City,Non-Federal Agency,Prairie View,TX,ACTIVE,29-May-14,27-Aug-15
-PRATTVILLE-AL.GOV,City,Non-Federal Agency,Prattville,AL,ACTIVE,4-Feb-15,3-Feb-16
-PRATTVILLEAL.GOV,City,Non-Federal Agency,Prattville,AL,ACTIVE,4-Feb-15,11-Feb-16
-PRESCOTT-AZ.GOV,City,Non-Federal Agency,Prescott,AZ,ACTIVE,8-Jul-14,21-Aug-15
-PRESCOTTVALLEY-AZ.GOV,City,Non-Federal Agency,Prescott Valley,AZ,ACTIVE,4-Nov-14,4-Nov-15
-PRESQUEISLEMAINE.GOV,City,Non-Federal Agency,Presque Isle,ME,ACTIVE,3-Mar-14,3-Mar-15
-PRIESTRIVER-ID.GOV,City,Non-Federal Agency,Priest River,ID,ACTIVE,7-May-14,25-Jul-15
-PRINCETONNJ.GOV,City,Non-Federal Agency,Princeton,NJ,ACTIVE,10-Jan-15,18-Jan-16
-PRINCETONTX.GOV,City,Non-Federal Agency,Princeton,TX,ACTIVE,26-Dec-14,13-Feb-16
-PROCTORMN.GOV,City,Non-Federal Agency,Proctor,MN,ACTIVE,14-Oct-14,14-Oct-15
-PROSPERTX.GOV,City,Non-Federal Agency,Prosper,TX,ACTIVE,24-Sep-14,30-Sep-15
-PROVIDENCERI.GOV,City,Non-Federal Agency,Providence,RI,ACTIVE,4-Dec-14,22-Dec-15
-PURCELLVILLEVA.GOV,City,Non-Federal Agency,Purcellville,VA,ACTIVE,3-Dec-14,20-Dec-15
-QUAKERTOWN-PA.GOV,City,Non-Federal Agency,Quakertown,PA,ACTIVE,3-Jan-11,3-Jan-12
-QUINCYIL.GOV,City,Non-Federal Agency,Quincy,IL,ACTIVE,30-Sep-14,30-Sep-15
-QUINCYMA.GOV,City,Non-Federal Agency,Quincy,MA,ACTIVE,15-Dec-14,25-Feb-16
-RALEIGHNC.GOV,City,Non-Federal Agency,Raleigh,NC,ACTIVE,11-Mar-15,30-Aug-15
-RANCHOMIRAGECA.GOV,City,Non-Federal Agency,Rancho Mirage,CA,ACTIVE,10-Mar-15,10-Apr-16
-RANDOLPH-MA.GOV,City,Non-Federal Agency,Randolph,MA,ACTIVE,22-Oct-14,28-Nov-15
-RANDOLPHTOWNSHIPOHIO.GOV,City,Non-Federal Agency,Randolph,OH,ACTIVE,5-Feb-14,4-May-15
-RANGELY-CO.GOV,City,Non-Federal Agency,Rangely,CO,ACTIVE,10-Sep-14,14-Sep-15
-RATONNM.GOV,City,Non-Federal Agency,Raton,NM,ACTIVE,4-Dec-14,23-Jan-16
-RAYCITYGA.GOV,City,Non-Federal Agency,Ray City,GA,ACTIVE,18-Jul-13,30-Sep-13
-RAYMONDNH.GOV,City,Non-Federal Agency,Raymond,NH,ACTIVE,30-Jul-13,7-Jul-14
-READINGMA.GOV,City,Non-Federal Agency,READING,MA,ACTIVE,1-Apr-14,17-Apr-15
-READINGPA.GOV,City,Non-Federal Agency,Reading,PA,ACTIVE,26-Dec-14,24-Mar-16
-READYHOUSTONTX.GOV,City,Non-Federal Agency,Houston,TX,ACTIVE,8-Oct-14,3-Jan-16
-READYSOUTHTEXAS.GOV,City,Non-Federal Agency,San Antonio,TX,ACTIVE,2-Mar-15,16-Mar-16
-READYSPRINGFIELDIL.GOV,City,Non-Federal Agency,Springfield,IL,ACTIVE,9-Mar-15,28-Apr-16
-REDBANKTN.GOV,City,Non-Federal Agency,Red Bank,TN,ACTIVE,19-Jul-13,7-Aug-14
-REDBAY-AL.GOV,City,Non-Federal Agency,Red Bay,AL,ACTIVE,17-Dec-12,17-Dec-13
-REDMOND.GOV,City,Non-Federal Agency,Redmond,WA,ACTIVE,9-Jul-14,30-Sep-15
-REMINGTON-VA.GOV,City,Non-Federal Agency,Remington,VA,ACTIVE,7-Apr-14,5-Apr-15
-RENSSELAERNY.GOV,City,Non-Federal Agency,Rensselaer,NY,ACTIVE,25-Feb-15,24-May-16
-RHEACOUNTYTN.GOV,City,Non-Federal Agency,Dayton,TN,ACTIVE,3-Jul-14,30-Sep-15
-RHINEBECK-NY.GOV,City,Non-Federal Agency,Rhinebeck,NY,ACTIVE,30-Jun-14,27-Aug-15
-RICETX.GOV,City,Non-Federal Agency,Rice,TX,ACTIVE,9-Oct-13,9-Oct-12
-RICHFIELDWI.GOV,City,Non-Federal Agency,Hubertus,WI,ACTIVE,9-Jan-15,22-Jan-16
-RICHLANDS-VA.GOV,City,Non-Federal Agency,Richlands,VA,ACTIVE,13-Feb-15,2-May-16
-RICHLANDSNC.GOV,City,Non-Federal Agency,Richlands,NC,ACTIVE,20-May-14,27-Jun-15
-RICHMOND-VA.GOV,City,Non-Federal Agency,Richmond,VA,ACTIVE,13-Nov-12,16-Nov-13
-RICHMONDHILL-GA.GOV,City,Non-Federal Agency,Richmond Hill ,GA,ACTIVE,10-Dec-14,12-Dec-15
-RICHMONDINDIANA.GOV,City,Non-Federal Agency,Richmond,IN,ACTIVE,5-Aug-13,23-Aug-14
-RICHMONDTX.GOV,City,Non-Federal Agency,RICHMOND,TX,ACTIVE,28-Apr-14,28-Apr-15
-RICHMONDVA.GOV,City,Non-Federal Agency,Richmond,VA,ACTIVE,13-Nov-12,16-Nov-13
-RICHMONDVT.GOV,City,Non-Federal Agency,Richmond,VT,ACTIVE,8-Mar-15,6-Mar-16
-RICHWOODTX.GOV,City,Non-Federal Agency,Richwood,TX,ACTIVE,10-Apr-14,9-Jun-15
-RICHWOODWV.GOV,City,Non-Federal Agency,Richwood,WV,ACTIVE,5-Jun-14,5-Jun-15
-RIDGECREST-CA.GOV,City,Non-Federal Agency,Ridgecrest,CA,ACTIVE,15-Jul-13,30-Sep-14
-RIDGEFIELDNJ.GOV,City,Non-Federal Agency,Ridgefield,NJ,ACTIVE,22-Jan-15,21-Feb-16
-RIDGELANDSC.GOV,City,Non-Federal Agency,Ridgeland,SC,ACTIVE,26-Aug-14,13-Oct-15
-RITZVILLE-WA.GOV,City,Non-Federal Agency,Ritzville,WA,ACTIVE,3-Aug-12,30-Sep-12
-RIVERDALEGA.GOV,City,Non-Federal Agency,Riverdale,GA,ACTIVE,21-Nov-14,29-Dec-15
-RIVERDALENJ.GOV,City,Non-Federal Agency,Riverdale,NJ,ACTIVE,17-Apr-14,9-Mar-15
-RIVERDALEPARKMD.GOV,City,Non-Federal Agency,Riverdale,MD,ACTIVE,10-Oct-14,9-Dec-15
-RIVERSIDE-GA.GOV,City,Non-Federal Agency,Moultrie,GA,ACTIVE,3-Mar-14,3-May-15
-RIVERSIDECA.GOV,City,Non-Federal Agency,Riverside,CA,ACTIVE,9-Sep-14,30-Sep-15
-ROAMINGSHORESOH.GOV,City,Non-Federal Agency,Roaming Shores,OH,ACTIVE,31-Jul-14,16-Aug-15
-ROANOKEVA.GOV,City,Non-Federal Agency,Roanoke,VA,ACTIVE,2-Jun-14,30-Aug-15
-ROCKFORD-IL.GOV,City,Non-Federal Agency,Rockford,IL,ACTIVE,2-Sep-14,30-Sep-15
-ROCKFORDIL.GOV,City,Non-Federal Agency,Rockford,IL,ACTIVE,23-Jan-15,23-Apr-16
-ROCKHALLMD.GOV,City,Non-Federal Agency,Rock Hall,MD,ACTIVE,17-Nov-14,17-Nov-15
-ROCKLAND-MA.GOV,City,Non-Federal Agency,Rockland,MA,ACTIVE,2-Jul-14,30-Sep-15
-ROCKMART-GA.GOV,City,Non-Federal Agency,Rockmart,GA,ACTIVE,2-Sep-14,30-Sep-15
-ROCKPORTMA.GOV,City,Non-Federal Agency,Rockport,MA,ACTIVE,17-Feb-15,16-Apr-16
-ROCKPORTMAINE.GOV,City,Non-Federal Agency,Rockport,ME,ACTIVE,23-Jul-12,21-Sep-13
-ROCKVILLE-IN.GOV,City,Non-Federal Agency,Rockville,IN,ACTIVE,11-Jun-14,27-Jul-15
-ROCKVILLEMD.GOV,City,Non-Federal Agency,Rockville,MD,ACTIVE,2-Jul-14,30-Sep-15
-ROCKWELLNC.GOV,City,Non-Federal Agency,Rockwell,NC,ACTIVE,1-Feb-15,3-Feb-16
-ROCKYHILL-NJ.GOV,City,Non-Federal Agency,Rocky Hill,NJ,ACTIVE,10-Oct-12,10-Oct-13
-ROCKYHILLCT.GOV,City,Non-Federal Agency,Rocky Hill,CT,ACTIVE,9-Dec-14,8-Mar-16
-ROCKYMOUNTNC.GOV,City,Non-Federal Agency,Rocky Mount,NC,ACTIVE,8-Apr-14,24-May-15
-ROCKYMOUNTVA.GOV,City,Non-Federal Agency,ROCKY MOUNT,VA,ACTIVE,3-Jan-11,2-Mar-12
-ROGERSAR.GOV,City,Non-Federal Agency,Rogers,AR,ACTIVE,1-Dec-14,22-Jan-16
-ROLESVILLENC.GOV,City,Non-Federal Agency,Rolesville,NC,ACTIVE,7-Nov-12,8-Oct-13
-ROLLINGHILLSESTATES-CA.GOV,City,Non-Federal Agency,Rolling Hills Estates,CA,ACTIVE,21-Jan-15,20-Mar-16
-ROLLINGHILLSESTATESCA.GOV,City,Non-Federal Agency,Rolling Hills Estates,CA,ACTIVE,21-Jan-15,9-Mar-16
-ROME-NY.GOV,City,Non-Federal Agency,Rome,NY,ACTIVE,11-Jul-14,30-Sep-15
-ROMULUS-MI.GOV,City,Non-Federal Agency,Romulus,MI,ACTIVE,10-Jul-12,13-Jul-13
-ROSEVILLE-MI.GOV,City,Non-Federal Agency,Roseville,MI,ACTIVE,2-Jun-14,6-Jul-15
-ROSLYNNY.GOV,City,Non-Federal Agency,Roslyn,NY,ACTIVE,14-Feb-14,14-Mar-15
-ROSWELL-NM.GOV,City,Non-Federal Agency,Roswell,NM,ACTIVE,30-Sep-14,30-Sep-15
-ROUNDROCKTEXAS.GOV,City,Non-Federal Agency,Round Rock,TX,ACTIVE,1-Dec-14,21-Nov-15
-ROWE-MA.GOV,City,Non-Federal Agency,Rowe,MA,ACTIVE,2-Mar-15,11-Feb-16
-ROWLETTTX.GOV,City,Non-Federal Agency,Rowlett,TX,ACTIVE,16-Jun-14,14-Aug-15
-ROXBURY-CT.GOV,City,Non-Federal Agency,Roxbury,CT,ACTIVE,10-Aug-11,9-Sep-12
-ROYALSTON-MA.GOV,City,Non-Federal Agency,Royalston,MA,ACTIVE,8-Aug-13,8-Mar-14
-RPVCA.GOV,City,Non-Federal Agency,Rancho Palos Verdes,CA,ACTIVE,21-Oct-14,21-Oct-15
-RUIDOSO-NM.GOV,City,Non-Federal Agency,Ruidoso,NM,ACTIVE,11-Mar-14,25-Mar-15
-RUMSONNJ.GOV,City,Non-Federal Agency,Rumson,NJ,ACTIVE,19-Feb-13,3-Jan-14
-RUSSELLSPOINT-OH.GOV,City,Non-Federal Agency,Russells Point,OH,ACTIVE,18-Aug-14,16-Jul-15
-RYENY.GOV,City,Non-Federal Agency,Rye,NY,ACTIVE,1-Aug-14,31-Aug-15
-SACKETSHARBOR-NY.GOV,City,Non-Federal Agency,Sackets Harbor,NY,ACTIVE,6-Nov-14,30-Sep-15
-SADDLEBROOKNJ.GOV,City,Non-Federal Agency,Saddlebrook,NJ,ACTIVE,15-Sep-14,30-Sep-15
-SADDLEROCKNY.GOV,City,Non-Federal Agency,SADDLE ROCK,NY,ACTIVE,5-Apr-13,5-Apr-14
-SAFFORDAZ.GOV,City,Non-Federal Agency,Safford,AZ,ACTIVE,5-Aug-13,18-Oct-14
-SAGHARBORNY.GOV,City,Non-Federal Agency,Sag Harbor,NY,ACTIVE,19-Dec-14,7-Mar-16
-SAHUARITAAZ.GOV,City,Non-Federal Agency,Sahuarita,AZ,ACTIVE,11-Jun-14,7-Jun-15
-SAINTPETERMN.GOV,City,Non-Federal Agency,Saint Peter,MN,ACTIVE,18-Sep-14,30-Sep-15
-SALADOTX.GOV,City,Non-Federal Agency,Salado,TX,ACTIVE,31-Jul-13,31-Mar-14
-SALEMCT.GOV,City,Non-Federal Agency,Salem,CT,ACTIVE,3-Sep-14,30-Sep-15
-SALEMVA.GOV,City,Non-Federal Agency,Salem,VA,ACTIVE,14-Oct-14,14-Nov-15
-SALISBURYMA.GOV,City,Non-Federal Agency,Salisbury,MA,ACTIVE,12-Aug-14,10-Nov-15
-SALISBURYNC.GOV,City,Non-Federal Agency,Salisbury,NC,ACTIVE,8-Aug-14,30-Sep-15
-SALTLAKECITY-UT.GOV,City,Non-Federal Agency,Salt Lake City,UT,ACTIVE,18-Nov-13,15-Nov-14
-SAMMAMISHWA.GOV,City,Non-Federal Agency,Sammamish,WA,ACTIVE,29-Dec-14,23-Mar-16
-SANANTONIO.GOV,City,Non-Federal Agency,San Antonio,TX,ACTIVE,1-Jul-14,30-Sep-15
-SANDYSPRINGS-GA.GOV,City,Non-Federal Agency,Sandy Springs,GA,ACTIVE,10-Mar-15,3-Mar-16
-SANDYSPRINGSGA.GOV,City,Non-Federal Agency,Sandy Springs,GA,ACTIVE,9-Sep-14,11-Aug-15
-SANFORDFL.GOV,City,Non-Federal Agency,Sanford,FL,ACTIVE,5-Jan-15,8-Mar-16
-SANFRANCISCO-CA.GOV,City,Non-Federal Agency,San Francisco,CA,ACTIVE,2-Aug-12,30-Sep-13
-SANJOSECA.GOV,City,Non-Federal Agency,San Jose,CA,ACTIVE,27-Aug-14,30-Sep-15
-SANMARCOSTEXAS.GOV,City,Non-Federal Agency,San Marcos,TX,ACTIVE,24-Nov-14,9-Jan-16
-SANMARCOSTX.GOV,City,Non-Federal Agency,San Marcos,TX,ACTIVE,24-Nov-14,9-Jan-16
-SANMARINOCA.GOV,City,Non-Federal Agency,San Marino,CA,ACTIVE,3-Mar-15,2-Mar-16
-SANPABLOCA.GOV,City,Non-Federal Agency,San Pablo,CA,ACTIVE,18-Nov-14,18-Nov-15
-SANTACLARACA.GOV,City,Non-Federal Agency,Santa Clara,CA,ACTIVE,8-Aug-14,5-Oct-15
-SANTACLARITACA.GOV,City,Non-Federal Agency,Santa Clarita,CA,ACTIVE,8-Dec-14,8-Dec-15
-SANTAFENM.GOV,City,Non-Federal Agency,Santa Fe,NM,ACTIVE,31-Jul-13,30-Sep-14
-SANTAMONICACA.GOV,City,Non-Federal Agency,Santa Monica,CA,ACTIVE,15-Sep-14,15-Oct-15
-SARANACLAKENY.GOV,City,Non-Federal Agency,Saranac Lake,NY,ACTIVE,10-Oct-14,10-Oct-15
-SARDISCITYAL.GOV,City,Non-Federal Agency,SARDIS CITY,AL,ACTIVE,22-Sep-14,22-Sep-15
-SAUGUS-MA.GOV,City,Non-Federal Agency,Saugus,MA,ACTIVE,23-Oct-14,11-Jan-16
-SAULTSTEMARIE-MI.GOV,City,Non-Federal Agency,Sault Ste Marie,MI,ACTIVE,2-Mar-15,2-Mar-16
-SAVANNA-IL.GOV,City,Non-Federal Agency,Savanna,IL,ACTIVE,27-Feb-15,27-May-16
-SAVANNAHGA.GOV,City,Non-Federal Agency,Savannah,GA,ACTIVE,25-Aug-14,2-Sep-15
-SBMTD.GOV,City,Non-Federal Agency,Santa Barbara,CA,ACTIVE,18-Nov-14,30-Sep-15
-SCHENECTADYNY.GOV,City,Non-Federal Agency,Schenectady,NY,ACTIVE,12-Feb-15,12-Mar-16
-SCHERTZ-TX.GOV,City,Non-Federal Agency,Schertz,TX,ACTIVE,5-Aug-13,30-Jun-14
-SCIENCEHILL-KY.GOV,City,Non-Federal Agency,Science Hill,KY,ACTIVE,13-Aug-13,30-Sep-14
-SCITUATEMA.GOV,City,Non-Federal Agency,Scituate,MA,ACTIVE,3-Jun-14,22-Aug-15
-SCOTCHPLAINSNJ.GOV,City,Non-Federal Agency,SCOTCH PLAINS,NJ,ACTIVE,4-Dec-14,2-Feb-16
-SCRANTONPA.GOV,City,Non-Federal Agency,Scranton,PA,ACTIVE,1-Oct-14,30-Sep-15
-SEABROOKTX.GOV,City,Non-Federal Agency,Seabrook,TX,ACTIVE,11-Feb-15,14-Mar-16
-SEACLIFF-NY.GOV,City,Non-Federal Agency,Sea Cliff,NY,ACTIVE,7-Aug-14,30-Sep-15
-SEALBEACHCA.GOV,City,Non-Federal Agency,Seal Beach,CA,ACTIVE,18-Feb-15,28-Apr-16
-SEARANCHLAKESFLORIDA.GOV,City,Non-Federal Agency,Sea Ranch Lakes,FL,ACTIVE,8-Mar-13,16-Sep-13
-SEATPLEASANTMD.GOV,City,Non-Federal Agency,Seat Pleasant,MD,ACTIVE,22-Aug-14,30-Sep-15
-SEBEWAINGMI.GOV,City,Non-Federal Agency,Sebewaing,MI,ACTIVE,24-Jul-14,24-Jul-15
-SEDONAAZ.GOV,City,Non-Federal Agency,Sedona,AZ,ACTIVE,15-Aug-14,30-Sep-15
-SEEKONK-MA.GOV,City,Non-Federal Agency,Seekonk,MA,ACTIVE,2-Jul-14,30-Sep-15
-SEGUINTEXAS.GOV,City,Non-Federal Agency,Seguin,TX,ACTIVE,21-Feb-13,19-May-14
-SELAHWA.GOV,City,Non-Federal Agency,Selah,WA,ACTIVE,20-Aug-14,20-Aug-15
-SELLERSBURG-IN.GOV,City,Non-Federal Agency,Sellersburg,IN,ACTIVE,27-May-14,27-May-15
-SELMA-AL.GOV,City,Non-Federal Agency,Selma,AL,ACTIVE,25-Oct-11,12-Jan-12
-SENECASC.GOV,City,Non-Federal Agency,Seneca,SC,ACTIVE,8-Sep-14,8-Sep-15
-SEQUIMWA.GOV,City,Non-Federal Agency,SEQUIM,WA,ACTIVE,13-Apr-14,26-May-15
-SHAKOPEEMN.GOV,City,Non-Federal Agency,Shakopee,MN,ACTIVE,9-Jul-14,1-Oct-15
-SHEBOYGANFALLS-WI.GOV,City,Non-Federal Agency,Sheboygan Falls,WI,ACTIVE,9-Feb-10,7-May-11
-SHEBOYGANWI.GOV,City,Non-Federal Agency,Sheboygan,WI,ACTIVE,14-Mar-14,12-Jun-15
-SHEFFIELDMA.GOV,City,Non-Federal Agency,Sheffield,MA,ACTIVE,23-Jul-14,21-Oct-15
-SHELTERCOVE-CA.GOV,City,Non-Federal Agency,Whitethorn,CA,ACTIVE,25-Sep-14,18-Oct-15
-SHERWOODOREGON.GOV,City,Non-Federal Agency,Sherwood,OR,ACTIVE,17-Nov-14,17-Nov-15
-SHIRLEY-MA.GOV,City,Non-Federal Agency,Shirley,MA,ACTIVE,30-Sep-14,30-Sep-15
-SHIVELYKY.GOV,City,Non-Federal Agency,Shively,KY,ACTIVE,6-Mar-14,6-Mar-15
-SHORELINE-WA.GOV,City,Non-Federal Agency,Shoreline,WA,ACTIVE,21-May-14,26-Jun-15
-SHORELINEWA.GOV,City,Non-Federal Agency,Shoreline,WA,ACTIVE,21-May-14,26-Jun-15
-SHOREVIEWMN.GOV,City,Non-Federal Agency,Shoreview,MN,ACTIVE,16-Jan-15,19-Mar-16
-SHREVEPORTLA.GOV,City,Non-Federal Agency,Shreveport,LA,ACTIVE,17-Feb-15,16-Mar-16
-SHREWSBURYMA.GOV,City,Non-Federal Agency,Shrewsbury,MA,ACTIVE,31-Dec-14,22-Mar-16
-SIERRAVISTAAZ.GOV,City,Non-Federal Agency,Sierra Vista,AZ,ACTIVE,7-Mar-14,16-May-15
-SIGNALMOUNTAINTN.GOV,City,Non-Federal Agency,Signal Mountain,TN,ACTIVE,23-Feb-15,22-May-16
-SILVERCITYNM.GOV,City,Non-Federal Agency,Silver City,NM,ACTIVE,18-Feb-14,18-Feb-15
-SILVERSPRINGTWP-PA.GOV,City,Non-Federal Agency,Mechanicsburg,PA,ACTIVE,5-Sep-14,30-Sep-15
-SIOUXFALLSSD.GOV,City,Non-Federal Agency,Sioux Falls,SD,ACTIVE,2-Sep-14,21-Sep-15
-SISTERBAYWI.GOV,City,Non-Federal Agency,Sister Bay,WI,ACTIVE,28-May-14,19-Aug-15
-SLEEPYHOLLOWNY.GOV,City,Non-Federal Agency,Sleepy Hollow,NY,ACTIVE,31-Oct-14,14-Nov-15
-SMITHFIELDRI.GOV,City,Non-Federal Agency,Smithfield,RI,ACTIVE,20-Oct-14,18-Oct-15
-SMITHFIELDVA.GOV,City,Non-Federal Agency,Smithfield,VA,ACTIVE,2-Jun-14,31-Aug-15
-SMYRNAGA.GOV,City,Non-Federal Agency,Smyrna,GA,ACTIVE,10-Nov-14,30-Nov-15
-SNOHOMISHWA.GOV,City,Non-Federal Agency,Snohomish,WA,ACTIVE,17-Jun-14,16-Aug-15
-SNOWFLAKE-AZ.GOV,City,Non-Federal Agency,Snowflake,AZ,ACTIVE,26-Jul-13,31-Mar-14
-SODDY-DAISY-TN.GOV,City,Non-Federal Agency,Soddy-Daisy,TN,ACTIVE,11-Jul-14,8-Aug-15
-SODDY-DAISYTN.GOV,City,Non-Federal Agency,Soddy-Daisy,TN,ACTIVE,11-Jul-14,8-Aug-15
-SODDYDAISY-TN.GOV,City,Non-Federal Agency,Soddy-Daisy,TN,ACTIVE,11-Jul-14,8-Aug-15
-SODDYDAISYTN.GOV,City,Non-Federal Agency,Soddy-daisy,TN,ACTIVE,11-Jul-14,8-Aug-15
-SOLWAYTOWNSHIP-MN.GOV,City,Non-Federal Agency,Cloquet,MN,ACTIVE,20-Jan-15,18-Nov-15
-SOMERSCT.GOV,City,Non-Federal Agency,Somers,CT,ACTIVE,1-Dec-14,22-Dec-15
-SOMERSETTX.GOV,City,Non-Federal Agency,Somerset,TX,ACTIVE,11-Dec-12,6-Dec-13
-SOMERVILLEMA.GOV,City,Non-Federal Agency,Somerville,MA,ACTIVE,21-May-14,11-Jul-15
-SOUTHAMBOYNJ.GOV,City,Non-Federal Agency,South Amboy,NJ,ACTIVE,16-Jun-14,11-Jun-15
-SOUTHAMPTONTOWNNY.GOV,City,Non-Federal Agency,Southampton,NY,ACTIVE,23-Feb-15,23-Feb-16
-SOUTHBEND-WA.GOV,City,Non-Federal Agency,South Bend,WA,ACTIVE,9-Sep-14,9-Sep-15
-SOUTHBENDIN.GOV,City,Non-Federal Agency,South Bend,IN,ACTIVE,14-Jul-14,12-Oct-15
-SOUTHBURY-CT.GOV,City,Non-Federal Agency,Southbury,CT,ACTIVE,2-Sep-14,30-Sep-15
-SOUTHEAST-NY.GOV,City,Non-Federal Agency,BREWSTER,NY,ACTIVE,10-Mar-14,3-Jun-15
-SOUTHHADLEYMA.GOV,City,Non-Federal Agency,South Hadley,MA,ACTIVE,13-Feb-15,15-Mar-16
-SOUTHJORDANUTAH.GOV,City,Non-Federal Agency,South Jordan,UT,ACTIVE,3-Jun-14,1-Aug-15
-SOUTHMIAMIFL.GOV,City,Non-Federal Agency,South Miami,FL,ACTIVE,22-Oct-14,17-Nov-15
-SOUTHPADRETEXAS.GOV,City,Non-Federal Agency,South Padre Island,TX,ACTIVE,14-Nov-14,11-Feb-16
-SOUTHPASADENACA.GOV,City,Non-Federal Agency,South Pasadena,CA,ACTIVE,28-Apr-14,26-Jul-15
-SOUTHPITTSBURG-TN.GOV,City,Non-Federal Agency,South Pittsburg,TN,ACTIVE,24-Sep-12,22-Dec-13
-SOUTHWILLIAMSPORT-PA.GOV,City,Non-Federal Agency,South Williamsport,PA,ACTIVE,6-Jul-10,30-Sep-11
-SPEEDWAYIN.GOV,City,Non-Federal Agency,Speedway,IN,ACTIVE,21-May-14,21-May-15
-SPENCERMA.GOV,City,Non-Federal Agency,Spencer,MA,ACTIVE,2-Sep-14,15-Sep-15
-SPERRYOK.GOV,City,Non-Federal Agency,Sperry,OK,ACTIVE,15-Jul-13,20-Jun-14
-SPIRITLAKEID.GOV,City,Non-Federal Agency,Spirit Lake,ID,ACTIVE,30-Jan-15,1-Mar-16
-SPRINGCITYPA.GOV,City,Non-Federal Agency,Spring City,PA,ACTIVE,30-Sep-14,30-Sep-15
-SPRINGDALEAR.GOV,City,Non-Federal Agency,Springdale,AR,ACTIVE,18-Dec-13,19-Nov-14
-SPRINGERVILLEAZ.GOV,City,Non-Federal Agency,Springerville,AZ,ACTIVE,17-Dec-13,23-Dec-14
-SPRINGFIELD-MA.GOV,City,Non-Federal Agency,Springfield,MA,ACTIVE,3-Apr-14,3-Apr-15
-SPRINGFIELD-OR.GOV,City,Non-Federal Agency,Springfield,OR,ACTIVE,5-Jul-13,11-Aug-14
-SPRINGFIELDMA.GOV,City,Non-Federal Agency,Springfield,MA,ACTIVE,14-Apr-14,21-Apr-15
-SPRINGHILLKS.GOV,City,Non-Federal Agency,Spring Hill,KS,ACTIVE,27-Jun-14,25-Sep-15
-SPRINGHILLLOUISIANA.GOV,City,Non-Federal Agency,Springhill,LA,ACTIVE,23-Jul-12,16-May-13
-SPRUCEPINE-NC.GOV,City,Non-Federal Agency,Spruce Pine,NC,ACTIVE,3-Apr-14,3-May-15
-STAFFORDNJ.GOV,City,Non-Federal Agency,Manawhakin,NJ,ACTIVE,4-Aug-14,30-Sep-15
-STAFFORDTX.GOV,City,Non-Federal Agency,stafford,TX,ACTIVE,29-Dec-14,30-Dec-15
-STAMFORDCT.GOV,City,Non-Federal Agency,Stamford,CT,ACTIVE,29-Apr-14,12-Jul-15
-STANHOPENJ.GOV,City,Non-Federal Agency,Stanhope,NJ,ACTIVE,17-Apr-14,31-Mar-15
-STARNC.GOV,City,Non-Federal Agency,Star,NC,ACTIVE,28-Jul-14,8-Aug-15
-STATECOLLEGEPA.GOV,City,Non-Federal Agency,State College,PA,ACTIVE,2-Jul-14,30-Sep-15
-STATESBOROGA.GOV,City,Non-Federal Agency,Statesboro,GA,ACTIVE,16-Jul-13,27-Jan-14
-STAYTONOREGON.GOV,City,Non-Federal Agency,Stayton,OR,ACTIVE,23-Feb-15,22-Apr-16
-STCHARLESCITYMO.GOV,City,Non-Federal Agency,Saint Charles,MO,ACTIVE,4-Jun-14,17-Jun-15
-STCROIXFALLSWI.GOV,City,Non-Federal Agency,City of St. Croix Falls,WI,ACTIVE,28-May-14,28-Mar-15
-STEPHENVILLETX.GOV,City,Non-Federal Agency,Stephenville,TX,ACTIVE,10-Jun-14,10-Jun-15
-STERLING-IL.GOV,City,Non-Federal Agency,Sterling,IL,ACTIVE,8-Apr-14,15-Apr-15
-STERLING-MA.GOV,City,Non-Federal Agency,Sterling,MA,ACTIVE,31-Jan-14,29-Apr-15
-STLOUIS-MO.GOV,City,Non-Federal Agency,St. Louis,MO,ACTIVE,10-Apr-14,17-Apr-15
-STLUCIECO.GOV,City,Non-Federal Agency,Ft. Pierce,FL,ACTIVE,8-Oct-14,19-Oct-15
-STMARYSGA.GOV,City,Non-Federal Agency,ST. MARYS,GA,ACTIVE,22-Aug-14,20-Sep-15
-STMATTHEWSKY.GOV,City,Non-Federal Agency,Louisville,KY,ACTIVE,6-Aug-14,6-Aug-15
-STOCKTONCA.GOV,City,Non-Federal Agency,Stockton,CA,ACTIVE,19-Jul-13,30-Sep-14
-STONEHAM-MA.GOV,City,Non-Federal Agency,Stoneham,MA,ACTIVE,11-Mar-14,29-Mar-15
-STONINGTON-CT.GOV,City,Non-Federal Agency,Stonington,CT,ACTIVE,27-Aug-14,18-Sep-15
-STPAUL.GOV,City,Non-Federal Agency,Saint Paul,MN,ACTIVE,2-Jul-14,30-Sep-15
-STPETE-FL.GOV,City,Non-Federal Agency,St. Petersburg,FL,ACTIVE,4-Sep-14,30-Sep-15
-STRATHAMNH.GOV,City,Non-Federal Agency,Stratham,NH,ACTIVE,15-Sep-14,14-Dec-15
-STURGIS-SD.GOV,City,Non-Federal Agency,Sturgis,SD,ACTIVE,22-Oct-14,17-Nov-15
-STURGISMI.GOV,City,Non-Federal Agency,Sturgis,MI,ACTIVE,3-Nov-14,19-Jan-16
-SUDBURY-MA.GOV,City,Non-Federal Agency,Sudbury,MA,ACTIVE,1-Dec-14,30-Oct-15
-SUFFOLK-VA.GOV,City,Non-Federal Agency,Suffolk,VA,ACTIVE,3-Jul-14,30-Sep-15
-SUGAR-LANDCITYTX.GOV,City,Non-Federal Agency,Sugar Land,TX,ACTIVE,30-Oct-12,30-Sep-13
-SUGAR-LANDTX.GOV,City,Non-Federal Agency,Sugar Land,TX,ACTIVE,30-Oct-12,30-Sep-13
-SUGARCITYIDAHO.GOV,City,Non-Federal Agency,Sugar City,ID,ACTIVE,26-Sep-14,27-Sep-15
-SUGARLAND-CITYTX.GOV,City,Non-Federal Agency,Sugar Land,TX,ACTIVE,30-Oct-12,30-Sep-13
-SUGARLAND-TX.GOV,City,Non-Federal Agency,Sugar Land,TX,ACTIVE,30-Oct-12,30-Sep-13
-SUGARLANDCITY-TX.GOV,City,Non-Federal Agency,Sugar Land,TX,ACTIVE,30-Oct-12,30-Sep-13
-SUGARLANDCITYTX.GOV,City,Non-Federal Agency,Sugar Land,TX,ACTIVE,30-Oct-12,30-Sep-13
-SUGARLANDTX.GOV,City,Non-Federal Agency,Sugar Land,TX,ACTIVE,30-Oct-12,30-Sep-13
-SULLIVANOHIO.GOV,City,Non-Federal Agency,Sullivan,OH,ACTIVE,20-Mar-13,6-Mar-14
-SUMMERVILLESC.GOV,City,Non-Federal Agency,Summerville,SC,ACTIVE,3-Sep-14,1-Oct-15
-SUMTERSC.GOV,City,Non-Federal Agency,Sumter,SC,ACTIVE,13-Aug-14,30-Sep-15
-SUNLANDPARK-NM.GOV,City,Non-Federal Agency,Sunland Park,NM,ACTIVE,27-Oct-14,5-Nov-15
-SUNNYSIDE-WA.GOV,City,Non-Federal Agency,Sunnyside,WA,ACTIVE,31-Mar-14,29-Mar-15
-SUNRISEBEACH-MO.GOV,City,Non-Federal Agency,Sunrise Beach,MO,ACTIVE,4-Dec-13,26-Jan-15
-SUNSETBEACHNC.GOV,City,Non-Federal Agency,Sunset Beach,NC,ACTIVE,12-Jul-14,30-Sep-15
-SUPERIORAZ.GOV,City,Non-Federal Agency,Superior,AZ,ACTIVE,23-Jul-13,14-Aug-13
-SUPERIORCOLORADO.GOV,City,Non-Federal Agency,Superior,CO,ACTIVE,17-Sep-14,16-Dec-15
-SURGOINSVILLETN.GOV,City,Non-Federal Agency,Surgoinsville,TN,ACTIVE,19-May-14,13-Jun-15
-SURPRISEAZ.GOV,City,Non-Federal Agency,Surprise,AZ,ACTIVE,4-Nov-14,2-Feb-16
-SYLACAUGAAL.GOV,City,Non-Federal Agency,Sylacauga,AL,ACTIVE,6-Feb-15,25-Apr-16
-SYRACUSEKS.GOV,City,Non-Federal Agency,Syracuse,KS,ACTIVE,31-Mar-14,18-Jun-15
-TABERNACLENJ.GOV,City,Non-Federal Agency,Tabernacle,NJ,ACTIVE,30-Sep-14,30-Sep-15
-TACOMAWA.GOV,City,Non-Federal Agency,Tacoma,WA,ACTIVE,10-Jun-14,3-Apr-15
-TAFTTX.GOV,City,Non-Federal Agency,TAFT,TX,ACTIVE,28-May-13,28-May-14
-TALLAPOOSAGA.GOV,City,Non-Federal Agency,Tallapoosa,GA,ACTIVE,8-May-14,25-May-15
-TALLASSEE-AL.GOV,City,Non-Federal Agency,Millbrook,AL,ACTIVE,7-Jan-14,5-Apr-15
-TALLULAH-LA.GOV,City,Non-Federal Agency,Tallulah,LA,ACTIVE,25-Jul-13,3-Dec-13
-TAMPAFL.GOV,City,Non-Federal Agency,Tampa,FL,ACTIVE,15-Jul-13,29-Sep-13
-TAUNTON-MA.GOV,City,Non-Federal Agency,Taunton,MA,ACTIVE,5-Feb-15,15-Feb-16
-TAYLORMILLKY.GOV,City,Non-Federal Agency,Taylor Mill,KY,ACTIVE,5-Aug-14,30-Sep-15
-TAYLORSVILLEUT.GOV,City,Non-Federal Agency,Taylorsville ,UT,ACTIVE,23-Jul-14,19-Oct-15
-TAYLORTX.GOV,City,Non-Federal Agency,Taylor,TX,ACTIVE,9-Sep-14,24-Sep-15
-TEANECKNJ.GOV,City,Non-Federal Agency,Teaneck,NJ,ACTIVE,19-Jun-14,2-May-15
-TEGACAYSC.GOV,City,Non-Federal Agency,Tega Cay,SC,ACTIVE,13-Mar-14,13-Mar-15
-TELLURIDE-CO.GOV,City,Non-Federal Agency,Telluride,CO,ACTIVE,2-Jul-14,10-Sep-15
-TEMECULACA.GOV,City,Non-Federal Agency,Temecula,CA,ACTIVE,10-Sep-14,9-Dec-15
-TEMPE.GOV,City,Non-Federal Agency,Tempe,AZ,ACTIVE,2-Jul-14,30-Sep-15
-TEMPLETX.GOV,City,Non-Federal Agency,Temple,TX,ACTIVE,19-Feb-14,4-May-15
-TENNILLE-GA.GOV,City,Non-Federal Agency,Tennille,GA,ACTIVE,29-Jul-13,30-Sep-14
-THECOLONYTX.GOV,City,Non-Federal Agency,The Colony,TX,ACTIVE,30-Sep-14,30-Sep-15
-THEWOODLANDS-TX.GOV,City,Non-Federal Agency,The Woodlands,TX,ACTIVE,3-Sep-14,27-Oct-15
-THEWOODLANDSTOWNSHIP-TX.GOV,City,Non-Federal Agency,The Woodlands,TX,ACTIVE,3-Sep-14,9-Nov-15
-THOMASVILLE-NC.GOV,City,Non-Federal Agency,Thomasville,NC,ACTIVE,9-Mar-15,8-Apr-16
-THORNBURG-PA.GOV,City,Non-Federal Agency,Pittsburgh,PA,ACTIVE,9-Jul-14,30-Jul-15
-THORNEBAY-AK.GOV,City,Non-Federal Agency,Thorne Bay,AK,ACTIVE,17-Apr-14,27-Apr-15
-TIFFINOHIO.GOV,City,Non-Federal Agency,Tiffin,OH,ACTIVE,12-Jan-15,20-Mar-16
-TIGARD-OR.GOV,City,Non-Federal Agency,Tigard,OR,ACTIVE,23-Jun-14,20-Sep-15
-TILLAMOOKOR.GOV,City,Non-Federal Agency,Tillamook,OR,ACTIVE,15-Sep-14,30-Sep-15
-TIMNATH-CO.GOV,City,Non-Federal Agency,Timnath,CO,ACTIVE,9-Oct-14,9-Oct-15
-TINLEYPARK-IL.GOV,City,Non-Federal Agency,Tinley Park,IL,ACTIVE,20-Oct-10,30-Sep-11
-TINLEYPARKIL.GOV,City,Non-Federal Agency,Tinley Park,IL,ACTIVE,20-Oct-10,30-Sep-11
-TIOGATX.GOV,City,Non-Federal Agency,Tioga,TX,ACTIVE,23-Oct-14,20-Nov-15
-TIPPCITYOHIO.GOV,City,Non-Federal Agency,Tipp City,OH,ACTIVE,3-Jun-14,30-Aug-15
-TISBURYMA.GOV,City,Non-Federal Agency,Tisbury,MA,ACTIVE,16-May-12,13-May-13
-TOLLAND-MA.GOV,City,Non-Federal Agency,Tolland,MA,ACTIVE,11-Aug-14,30-Sep-15
-TOMBALLTX.GOV,City,Non-Federal Agency,Tomball,TX,ACTIVE,16-Jul-13,29-Dec-13
-TOMPKINSVILLEKY.GOV,City,Non-Federal Agency,Tompkinsville,KY,ACTIVE,8-Oct-14,8-Oct-15
-TOPSFIELD-MA.GOV,City,Non-Federal Agency,Topsfield,MA,ACTIVE,11-Aug-14,1-Sep-15
-TORRANCECA.GOV,City,Non-Federal Agency,Torrance,CA,ACTIVE,18-Feb-15,18-May-16
-TORREYUTAH.GOV,City,Non-Federal Agency,Torrey,UT,ACTIVE,5-Mar-15,3-Mar-16
-TORRINGTON-CT.GOV,City,Non-Federal Agency,Torrington,CT,ACTIVE,10-Jul-14,30-Sep-15
-TORRINGTONWY.GOV,City,Non-Federal Agency,Torrington,WY,ACTIVE,24-Feb-15,14-May-16
-TOWNOFBETHLEHEM-NY.GOV,City,Non-Federal Agency,Delmar,NY,ACTIVE,27-May-14,25-Jun-15
-TOWNOFBLYTHEWOODSC.GOV,City,Non-Federal Agency,Blythewood,SC,ACTIVE,21-Aug-14,16-Dec-14
-TOWNOFCALLAHAN-FL.GOV,City,Non-Federal Agency,Callahan,FL,ACTIVE,14-Jan-15,15-Dec-15
-TOWNOFCARRBORONC.GOV,City,Non-Federal Agency,Carrboro,NC,ACTIVE,6-Oct-14,3-Jan-16
-TOWNOFCARYNC.GOV,City,Non-Federal Agency,Cary,NC,ACTIVE,28-Feb-15,25-May-16
-TOWNOFCATSKILLNY.GOV,City,Non-Federal Agency,Catskill,NY,ACTIVE,15-Aug-14,30-Sep-15
-TOWNOFCHADBOURNNC.GOV,City,Non-Federal Agency,Chadbourn,NC,ACTIVE,28-Jun-10,16-Jun-11
-TOWNOFCLAYTONNC.GOV,City,Non-Federal Agency,Clayton,NC,ACTIVE,2-Jul-14,30-Sep-15
-TOWNOFEASTHAVEN-CT.GOV,City,Non-Federal Agency,East Haven,CT,ACTIVE,19-Aug-13,13-Sep-13
-TOWNOFHALFMOON-NY.GOV,City,Non-Federal Agency,Halfmoon,NY,ACTIVE,7-Jul-14,30-Sep-15
-TOWNOFHAVERHILL-FL.GOV,City,Non-Federal Agency,Haverhill,FL,ACTIVE,29-Aug-14,30-Sep-15
-TOWNOFHOMECROFTIN.GOV,City,Non-Federal Agency,Indianapolis,IN,ACTIVE,9-Dec-13,9-Dec-14
-TOWNOFHOUNSFIELD-NY.GOV,City,Non-Federal Agency,Watertown,NY,ACTIVE,19-Mar-14,22-Mar-15
-TOWNOFISLIP-NY.GOV,City,Non-Federal Agency,Islip,NY,ACTIVE,23-Jun-14,21-Jul-15
-TOWNOFKENTNY.GOV,City,Non-Federal Agency,Kent Lakes,NY,ACTIVE,28-Sep-14,30-Sep-15
-TOWNOFLAPOINTEWI.GOV,City,Non-Federal Agency,La Pointe,WI,ACTIVE,17-Feb-15,11-Feb-16
-TOWNOFLAVETA-CO.GOV,City,Non-Federal Agency,La Veta,CO,ACTIVE,19-Aug-13,20-Jun-14
-TOWNOFMAYNARD-MA.GOV,City,Non-Federal Agency,Maynard,MA,ACTIVE,30-May-14,17-May-15
-TOWNOFMONTEAGLE-TN.GOV,City,Non-Federal Agency,Monteagle,TN,ACTIVE,2-Mar-15,30-Apr-16
-TOWNOFNASHVILLENC.GOV,City,Non-Federal Agency,Nashville,NC,ACTIVE,15-Oct-14,13-Jan-16
-TOWNOFNORTH-SC.GOV,City,Non-Federal Agency,North,SC,ACTIVE,29-Oct-12,21-Sep-13
-TOWNOFNORTHEASTNY.GOV,City,Non-Federal Agency,Millerton,NY,ACTIVE,24-Mar-14,3-Apr-15
-TOWNOFORANGEVA.GOV,City,Non-Federal Agency,Orange,VA,ACTIVE,3-Aug-12,30-Sep-13
-TOWNOFOYSTERBAY-NY.GOV,City,Non-Federal Agency,Oyster Bay,NY,ACTIVE,30-Dec-14,10-Jan-16
-TOWNOFPENNINGTONVA.GOV,City,Non-Federal Agency,Pennington Gap,VA,ACTIVE,7-Mar-14,26-Mar-15
-TOWNOFPOUGHKEEPSIE-NY.GOV,City,Non-Federal Agency,POUGHKEEPSIE,NY,ACTIVE,17-Sep-14,30-Sep-15
-TOWNOFROBERSONVILLE-NC.GOV,City,Non-Federal Agency,Robersonville,NC,ACTIVE,27-Aug-14,30-Sep-15
-TOWNOFRYENY.GOV,City,Non-Federal Agency,PORT CHESTER,NY,ACTIVE,21-Apr-11,21-Apr-12
-TOWNOFSHIELDS-WI.GOV,City,Non-Federal Agency,Montello,WI,ACTIVE,22-Jan-15,19-Apr-16
-TOWNOFSHIRLEY-MA.GOV,City,Non-Federal Agency,Shirley,MA,ACTIVE,30-Sep-14,30-Sep-15
-TOWNOFSTLEO-FL.GOV,City,Non-Federal Agency,Saint Leo,FL,ACTIVE,28-Apr-14,23-Jul-15
-TOWNOFSURFSIDEFL.GOV,City,Non-Federal Agency,Surfside,FL,ACTIVE,30-Jan-15,15-Mar-16
-TOWNOFTROPICUT.GOV,City,Non-Federal Agency,Tropic,UT,ACTIVE,26-Dec-14,23-Feb-16
-TOWNOFVASSNC.GOV,City,Non-Federal Agency,Vass,NC,ACTIVE,20-Jan-15,1-Feb-16
-TOWNOFWALWORTHNY.GOV,City,Non-Federal Agency,Walworth,NY,ACTIVE,31-Mar-14,24-Apr-15
-TOWNOFWARREN-RI.GOV,City,Non-Federal Agency,Warren,RI,ACTIVE,11-Jul-14,30-Sep-15
-TOWNOFWASHINGTONVA.GOV,City,Non-Federal Agency,Washington,VA,ACTIVE,23-Jul-14,22-Jul-15
-TOWNOFWOODSTOCKVA.GOV,City,Non-Federal Agency,Woodstock,VA,ACTIVE,10-Feb-15,11-Apr-16
-TOWNSHIPOFTABERNACLE-NJ.GOV,City,Non-Federal Agency,Tabernacle,NJ,ACTIVE,31-Jul-13,30-Sep-14
-TRAVERSECITYMI.GOV,City,Non-Federal Agency,Traverse City,MI,ACTIVE,2-Sep-14,17-Sep-15
-TREASUREISLAND-FL.GOV,City,Non-Federal Agency,Treasure Island,FL,ACTIVE,1-Jun-12,1-Jun-13
-TRINITY-NC.GOV,City,Non-Federal Agency,Trinity,NC,ACTIVE,8-Aug-14,30-Sep-15
-TRINITYAL.GOV,City,Non-Federal Agency,Trinity,AL,ACTIVE,25-Aug-14,17-Oct-15
-TROPHYCLUBTX.GOV,City,Non-Federal Agency,Trophy Club,TX,ACTIVE,10-Jul-13,10-Jul-14
-TROUTDALEOREGON.GOV,City,Non-Federal Agency,Troutdale,OR,ACTIVE,10-Oct-14,13-Oct-15
-TROYAL.GOV,City,Non-Federal Agency,Troy,AL,ACTIVE,2-Feb-15,2-Feb-16
-TROYMI.GOV,City,Non-Federal Agency,Troy,MI,ACTIVE,21-Aug-14,30-Sep-15
-TROYNY.GOV,City,Non-Federal Agency,Troy,NY,ACTIVE,10-Sep-14,10-Sep-15
-TROYOHIO.GOV,City,Non-Federal Agency,Troy,OH,ACTIVE,14-Aug-14,30-Sep-15
-TRUMANSBURG-NY.GOV,City,Non-Federal Agency,Trumansburg,NY,ACTIVE,22-Apr-14,18-Jul-15
-TRUMBULL-CT.GOV,City,Non-Federal Agency,Trumbull,CT,ACTIVE,24-Dec-14,2-Feb-16
-TRURO-MA.GOV,City,Non-Federal Agency,Truro,MA,ACTIVE,18-Sep-14,30-Sep-15
-TUALATINOREGON.GOV,City,Non-Federal Agency,TUALATIN,OR,ACTIVE,2-Mar-15,31-May-16
-TUKWILA-WA.GOV,City,Non-Federal Agency,Tukwila,WA,ACTIVE,2-Oct-13,30-Sep-14
-TUKWILAWA.GOV,City,Non-Federal Agency,Tukwila,WA,ACTIVE,11-Mar-15,13-Mar-16
-TULIA-TX.GOV,City,Non-Federal Agency,Tulia,TX,ACTIVE,11-Sep-14,30-Sep-15
-TULLAHOMATN.GOV,City,Non-Federal Agency,Tullahoma,TN,ACTIVE,1-Apr-14,14-Apr-15
-TUMWATERWA.GOV,City,Non-Federal Agency,Tumwater,WA,ACTIVE,1-May-14,1-May-15
-TUPELOMS.GOV,City,Non-Federal Agency,Tupelo,MS,ACTIVE,27-Jan-15,3-Mar-16
-TUSAYAN-AZ.GOV,City,Non-Federal Agency,Tusayan,AZ,ACTIVE,24-Feb-15,1-Mar-16
-TUSAYANAZ.GOV,City,Non-Federal Agency,Grand Canyon,AZ,ACTIVE,30-Mar-14,6-Jun-15
-TUSKEGEEALABAMA.GOV,City,Non-Federal Agency,Tuskegee,AL,ACTIVE,16-May-14,16-May-15
-TUXEDOPARK-NY.GOV,City,Non-Federal Agency,Sloatsburg,NY,ACTIVE,8-Jul-14,8-Jul-15
-TWPOCEANNJ.GOV,City,Non-Federal Agency,Waretown,NJ,ACTIVE,2-Sep-14,1-Nov-15
-TYNGSBOROUGHMA.GOV,City,Non-Federal Agency,Tyngsborough,MA,ACTIVE,20-Jan-15,31-Mar-16
-TYRINGHAM-MA.GOV,City,Non-Federal Agency,Tyringham,MA,ACTIVE,5-Nov-14,30-Jan-16
-UCTX.GOV,City,Non-Federal Agency,Universal City,TX,ACTIVE,12-Jun-14,12-Jun-15
-UNDERHILLVT.GOV,City,Non-Federal Agency,"Underhill, Ctr",VT,ACTIVE,9-Jul-14,29-Sep-15
-UNIONCITY-IN.GOV,City,Non-Federal Agency,Union City,IN,ACTIVE,1-Dec-14,30-Oct-15
-UNIONCITYNJ.GOV,City,Non-Federal Agency,Union City,NJ,ACTIVE,29-Mar-10,19-Mar-11
-UNIONCITYTN.GOV,City,Non-Federal Agency,UNION CITY,TN,ACTIVE,9-Dec-14,30-Jan-16
-UNIONSPRINGSAL.GOV,City,Non-Federal Agency,Union Springs,AL,ACTIVE,14-Nov-14,14-Nov-15
-UNIONTWP-HCNJ.GOV,City,Non-Federal Agency,HAMPTON,NJ,ACTIVE,2-Sep-14,18-Nov-15
-UNIVERSALCITYTEXAS.GOV,City,Non-Federal Agency,Universal City,TX,ACTIVE,12-Jun-14,12-Jun-15
-UPLANDCA.GOV,City,Non-Federal Agency,UPLAND,CA,ACTIVE,24-Jul-14,14-Sep-15
-UPPERMARLBOROMD.GOV,City,Non-Federal Agency,Upper Marlboro,MD,ACTIVE,22-Sep-14,25-Oct-15
-UPPERUWCHLAN-PA.GOV,City,Non-Federal Agency,Chester Springs,PA,ACTIVE,5-Mar-15,4-Apr-16
-UPTONMA.GOV,City,Non-Federal Agency,Upton,MA,ACTIVE,23-Jun-14,19-Sep-15
-URBANAILLINOIS.GOV,City,Non-Federal Agency,Urbana,IL,ACTIVE,15-Jan-13,16-Mar-14
-URBANNAVA.GOV,City,Non-Federal Agency,Urbanna,VA,ACTIVE,22-Jul-14,22-Jul-15
-UTICA-IL.GOV,City,Non-Federal Agency,Utica,IL,ACTIVE,2-Jul-14,30-Sep-15
-UVALDETX.GOV,City,Non-Federal Agency,Uvalde,TX,ACTIVE,19-Aug-14,19-Aug-15
-UXBRIDGE-MA.GOV,City,Non-Federal Agency,Uxbridge,MA,ACTIVE,31-Aug-13,30-Sep-14
-VANMETERIA.GOV,City,Non-Federal Agency,Van Meter,IA,ACTIVE,14-Nov-14,7-Nov-15
-VERMONTVILLE-MI.GOV,City,Non-Federal Agency,Vermontville,MI,ACTIVE,2-Jan-15,8-Feb-16
-VERNON-CT.GOV,City,Non-Federal Agency,Vernon,CT,ACTIVE,2-Jul-14,30-Sep-15
-VERNONIA-OR.GOV,City,Non-Federal Agency,Vernonia,OR,ACTIVE,16-Sep-14,30-Sep-15
-VERNONTX.GOV,City,Non-Federal Agency,Vernon,TX,ACTIVE,30-Jan-14,13-Feb-15
-VERONAWI.GOV,City,Non-Federal Agency,Verona,WI,ACTIVE,9-Feb-15,9-Feb-16
-VICKSBURGMS.GOV,City,Non-Federal Agency,Vicksburg,MS,ACTIVE,20-Nov-14,22-Nov-15
-VICTORVILLECA.GOV,City,Non-Federal Agency,Victorville,CA,ACTIVE,21-Aug-14,17-Aug-15
-VIDALIAGA.GOV,City,Non-Federal Agency,VIDALIA,GA,ACTIVE,17-Sep-12,29-Sep-13
-VIENNAVA.GOV,City,Non-Federal Agency,VIENNA,VA,ACTIVE,15-Aug-14,14-Sep-15
-VILLAGEOFBABYLONNY.GOV,City,Non-Federal Agency,Babylon,NY,ACTIVE,4-Sep-14,30-Sep-15
-VILLAGEOFCAMILLUS-NY.GOV,City,Non-Federal Agency,CAMILLUS,NY,ACTIVE,2-Feb-15,5-Feb-16
-VILLAGEOFCRESTWOODIL.GOV,City,Non-Federal Agency,Crestwood,IL,ACTIVE,12-Aug-14,17-Oct-15
-VILLAGEOFGOSHEN-NY.GOV,City,Non-Federal Agency,Goshen,NY,ACTIVE,13-Mar-14,10-Jun-15
-VILLAGEOFHEMPSTEADNY.GOV,City,Non-Federal Agency,Hemsptead,NY,ACTIVE,6-Nov-14,18-Jan-16
-VILLAGEOFKENSINGTONNY.GOV,City,Non-Federal Agency,Great Neck,NY,ACTIVE,5-May-14,5-May-15
-VILLAGEOFMCCOMBOH.GOV,City,Non-Federal Agency,McComb,OH,ACTIVE,16-Jun-14,10-Jun-15
-VILLAGEOFNEWHAVEN-MI.GOV,City,Non-Federal Agency,New Haven,MI,ACTIVE,19-Jun-14,24-May-15
-VILLAGEOFNEWHOLLAND-OH.GOV,City,Non-Federal Agency,New Holland,OH,ACTIVE,25-Feb-15,25-Feb-16
-VILLAGEOFNEWTOWNOHIO.GOV,City,Non-Federal Agency,Newtown,OH,ACTIVE,10-Jul-14,30-Jun-15
-VILLAGEOFPHOENIX-NY.GOV,City,Non-Federal Agency,Phoenix,NY,ACTIVE,3-Sep-14,30-Sep-15
-VILLAGEOFPINEHURSTNC.GOV,City,Non-Federal Agency,Pinehurst,NC,ACTIVE,6-Aug-14,3-Aug-15
-VILLAGEOFQUOGUENY.GOV,City,Non-Federal Agency,Quogue,NY,ACTIVE,12-May-14,10-Jul-15
-VILLAGEOFVOLENTE-TX.GOV,City,Non-Federal Agency,Volente,TX,ACTIVE,5-Jan-15,30-Sep-15
-VILLAGEOFWAUCONDA-IL.GOV,City,Non-Federal Agency,Wauconda,IL,ACTIVE,9-Jun-14,8-Aug-15
-VIRGINIAGARDENS-FL.GOV,City,Non-Federal Agency,Virginia Gardens,FL,ACTIVE,30-Sep-14,30-Sep-15
-VOLENTETEXAS.GOV,City,Non-Federal Agency,Volente,TX,ACTIVE,20-May-14,19-Jul-15
-VOLUNTOWN.GOV,City,Non-Federal Agency,Voluntown,CT,ACTIVE,2-Jul-14,30-Sep-15
-WACOTX.GOV,City,Non-Federal Agency,Waco,TX,ACTIVE,9-Jul-14,9-Jul-15
-WAITEHILLOH.GOV,City,Non-Federal Agency,Waite Hill,OH,ACTIVE,19-Nov-14,17-Feb-16
-WAKEFORESTNC.GOV,City,Non-Federal Agency,WAKE FOREST,NC,ACTIVE,6-Jun-14,10-Jun-15
-WALDENTN.GOV,City,Non-Federal Agency,Signal Mountain,TN,ACTIVE,17-Sep-14,17-Sep-15
-WALKER-LA.GOV,City,Non-Federal Agency,Walker,LA,ACTIVE,8-Jul-14,28-Sep-15
-WALKERSVILLEMD.GOV,City,Non-Federal Agency,Walkersville,MD,ACTIVE,28-Jul-14,28-Jul-15
-WALLINGFORDCT.GOV,City,Non-Federal Agency,Wallingford,CT,ACTIVE,18-Sep-14,24-Sep-15
-WALTONHILLSOHIO.GOV,City,Non-Federal Agency,Walton Hills,OH,ACTIVE,11-Jun-13,12-May-14
-WANATAH-IN.GOV,City,Non-Federal Agency,Wanatah,IN,ACTIVE,11-Aug-14,11-Aug-15
-WAPPINGERSFALLSNY.GOV,City,Non-Federal Agency,Wappingers Falls,NY,ACTIVE,22-Dec-14,22-Dec-15
-WARNERROBINSGA.GOV,City,Non-Federal Agency,Warner Robins,GA,ACTIVE,30-Apr-14,20-Jun-15
-WARREN-MA.GOV,City,Non-Federal Agency,Warren,MA,ACTIVE,24-Jun-13,5-May-14
-WARRENTONVA.GOV,City,Non-Federal Agency,Warrenton,VA,ACTIVE,31-Oct-11,30-Sep-12
-WARWICKRI.GOV,City,Non-Federal Agency,Warwick,RI,ACTIVE,13-Sep-13,20-Sep-14
-WASHINGTONBORO-NJ.GOV,City,Non-Federal Agency,Washington,NJ,ACTIVE,21-Nov-14,10-Jan-16
-WASHINGTONISLAND-WI.GOV,City,Non-Federal Agency,Washington Island,WI,ACTIVE,26-Feb-15,27-Apr-16
-WASHINGTONVA.GOV,City,Non-Federal Agency,Washington,VA,ACTIVE,23-Jul-14,22-Jul-15
-WASHINGTONVIRGINIA.GOV,City,Non-Federal Agency,Washington,VA,ACTIVE,23-Jul-14,22-Jul-15
-WATCHUNGNJ.GOV,City,Non-Federal Agency,Watchung,NJ,ACTIVE,4-May-14,26-Jul-15
-WATERBORO-ME.GOV,City,Non-Federal Agency,East Waterboro,ME,ACTIVE,2-Jul-14,30-Sep-15
-WATERFORDMI.GOV,City,Non-Federal Agency,Waterford,MI,ACTIVE,8-Dec-14,8-Dec-15
-WATERTOWN-MA.GOV,City,Non-Federal Agency,Watertown,MA,ACTIVE,21-Oct-14,27-Oct-15
-WATERTOWN-NY.GOV,City,Non-Federal Agency,Watertown,NY,ACTIVE,25-Aug-14,30-Sep-15
-WATERVILLE-ME.GOV,City,Non-Federal Agency,Waterville,ME,ACTIVE,1-Aug-14,30-Sep-15
-WAUCONDA-IL.GOV,City,Non-Federal Agency,Wauconda,IL,ACTIVE,9-Jun-14,8-Aug-15
-WAUKEGANIL.GOV,City,Non-Federal Agency,Waukegan,IL,ACTIVE,3-Jun-14,16-Aug-15
-WAVELAND-MS.GOV,City,Non-Federal Agency,Waveland,MS,ACTIVE,5-Mar-15,12-Apr-16
-WAYNESVILLENC.GOV,City,Non-Federal Agency,Waynesville,NC,ACTIVE,10-Feb-15,28-Mar-16
-WEATHERFORDTX.GOV,City,Non-Federal Agency,Weatherford,TX,ACTIVE,26-Aug-14,31-Aug-15
-WEATHERLYPA.GOV,City,Non-Federal Agency,Weatherly,PA,ACTIVE,30-Sep-14,30-Sep-15
-WEBSTER-MA.GOV,City,Non-Federal Agency,Webster,MA,ACTIVE,10-Jul-14,30-Sep-15
-WEBSTER-NH.GOV,City,Non-Federal Agency,Webster,NH,ACTIVE,24-Sep-14,26-Oct-15
-WEBSTERFL.GOV,City,Non-Federal Agency,Webster,FL,ACTIVE,3-Feb-11,18-Feb-12
-WELAKA-FL.GOV,City,Non-Federal Agency,Welaka,FL,ACTIVE,5-Nov-14,22-Nov-15
-WELLESLEYMA.GOV,City,Non-Federal Agency,Wellesley,MA,ACTIVE,26-Sep-14,7-Nov-15
-WELLFLEET-MA.GOV,City,Non-Federal Agency,Wellfleet,MA,ACTIVE,13-Jan-15,13-Jan-16
-WELLINGTONFL.GOV,City,Non-Federal Agency,Wellington,FL,ACTIVE,25-Jun-14,24-Sep-15
-WELLSBURGWV.GOV,City,Non-Federal Agency,WELLSBURG,WV,ACTIVE,4-Apr-14,5-Apr-15
-WENATCHEEWA.GOV,City,Non-Federal Agency,Wenatchee,WA,ACTIVE,2-Jul-14,28-Sep-15
-WESLACOTX.GOV,City,Non-Federal Agency,Weslaco,TX,ACTIVE,10-Oct-12,22-Sep-13
-WESSONMS.GOV,City,Non-Federal Agency,Wesson,MS,ACTIVE,25-Sep-12,16-Jul-13
-WESTALLISWI.GOV,City,Non-Federal Agency,West Allis,WI,ACTIVE,22-Feb-15,15-Mar-16
-WESTAMPTONNJ.GOV,City,Non-Federal Agency,Westampton,NJ,ACTIVE,14-Feb-15,7-Mar-16
-WESTBOYLSTON-MA.GOV,City,Non-Federal Agency,West Boylston,MA,ACTIVE,2-Sep-14,30-Sep-15
-WESTBUECHELKY.GOV,City,Non-Federal Agency,WEST BUECHEL,KY,ACTIVE,12-Feb-15,16-Nov-15
-WESTCOLUMBIASC.GOV,City,Non-Federal Agency,West Columbia,SC,ACTIVE,8-Jul-14,30-Sep-15
-WESTFARGOND.GOV,City,Non-Federal Agency,Bismarck,ND,ACTIVE,14-Jul-14,6-Oct-15
-WESTFIELDNJ.GOV,City,Non-Federal Agency,Westfield,NJ,ACTIVE,29-Dec-14,29-Nov-15
-WESTFORD-MA.GOV,City,Non-Federal Agency,Westford,MA,ACTIVE,5-Sep-14,15-Sep-15
-WESTFORDMA.GOV,City,Non-Federal Agency,Westford,MA,ACTIVE,5-Sep-14,14-Sep-15
-WESTFRANKFORT-IL.GOV,City,Non-Federal Agency,West Frankfort,IL,ACTIVE,28-Jul-14,26-Jul-15
-WESTHARTFORDCT.GOV,City,Non-Federal Agency,West Hartford,CT,ACTIVE,20-Jan-15,19-Mar-16
-WESTHAVEN-CT.GOV,City,Non-Federal Agency,West Haven,CT,ACTIVE,22-Oct-13,27-Oct-14
-WESTLINNOREGON.GOV,City,Non-Federal Agency,West Linn,OR,ACTIVE,27-May-14,15-Aug-15
-WESTMILTONOHIO.GOV,City,Non-Federal Agency,West Milton,OH,ACTIVE,18-Nov-14,29-Dec-15
-WESTMINSTER-MA.GOV,City,Non-Federal Agency,Westminster,MA,ACTIVE,9-Sep-14,4-Dec-15
-WESTMINSTERMD.GOV,City,Non-Federal Agency,Westminster,MD,ACTIVE,23-Apr-14,22-Jun-15
-WESTONCT.GOV,City,Non-Federal Agency,Weston,CT,ACTIVE,10-Jun-14,9-Aug-15
-WESTONWI.GOV,City,Non-Federal Agency,Weston,WI,ACTIVE,2-Jan-14,26-Mar-15
-WESTPALMBEACH-FL.GOV,City,Non-Federal Agency,West Palm Beach,FL,ACTIVE,2-Jul-14,30-Sep-15
-WESTPORT-MA.GOV,City,Non-Federal Agency,Westport,MA,ACTIVE,20-Oct-14,15-Nov-15
-WESTPORTCT.GOV,City,Non-Federal Agency,Westport,CT,ACTIVE,27-May-14,23-Aug-15
-WESTSTOCKBRIDGE-MA.GOV,City,Non-Federal Agency,West Stockbridge,MA,ACTIVE,15-Dec-14,22-Feb-16
-WESTTISBURY-MA.GOV,City,Non-Federal Agency,West Tisbury,MA,ACTIVE,28-Oct-14,28-Nov-15
-WESTUTX.GOV,City,Non-Federal Agency,West University Place ,TX,ACTIVE,12-Mar-13,9-Jun-14
-WESTWOOD-MA.GOV,City,Non-Federal Agency,Westwood,MA,ACTIVE,18-Aug-14,17-Sep-15
-WESTWOODMA.GOV,City,Non-Federal Agency,Westwood,MA,ACTIVE,3-Feb-15,4-Jan-16
-WESTWOODNJ.GOV,City,Non-Federal Agency,Westwood,NJ,ACTIVE,30-Oct-14,30-Sep-15
-WETHERSFIELDCT.GOV,City,Non-Federal Agency,Wethersfield,CT,ACTIVE,14-Jul-14,11-Sep-15
-WHEELINGIL.GOV,City,Non-Federal Agency,Wheeling,IL,ACTIVE,8-Jul-14,20-Jul-15
-WHEELINGWV.GOV,City,Non-Federal Agency,Wheeling,WV,ACTIVE,5-Dec-11,7-Jul-12
-WHITECOUNTY-IL.GOV,City,Non-Federal Agency,Carmi,IL,ACTIVE,11-Aug-13,30-Sep-14
-WHITEHOUSEOH.GOV,City,Non-Federal Agency,Whitehouse,OH,ACTIVE,18-Feb-15,6-May-16
-WHITEPLAINSNY.GOV,City,Non-Federal Agency,White Plains,NY,ACTIVE,31-Oct-14,25-Jan-16
-WHITEWATER-WI.GOV,City,Non-Federal Agency,Whitewater,WI,ACTIVE,2-Oct-12,30-Sep-13
-WHITINGWI.GOV,City,Non-Federal Agency,Stevens Point,WI,ACTIVE,27-May-14,27-May-15
-WHITTIERALASKA.GOV,City,Non-Federal Agency,Whittier,AK,ACTIVE,29-Dec-14,20-Mar-16
-WICHITA.GOV,City,Non-Federal Agency,Wichita,KS,ACTIVE,11-Aug-14,8-Sep-15
-WICHITAFALLSTX.GOV,City,Non-Federal Agency,Wichita Falls,TX,ACTIVE,18-Sep-14,14-Oct-15
-WILBRAHAM-MA.GOV,City,Non-Federal Agency,Wilbraham,MA,ACTIVE,3-Nov-14,1-Nov-15
-WILDWOOD-FL.GOV,City,Non-Federal Agency,Wildwood,FL,ACTIVE,1-Oct-14,31-Oct-15
-WILKINSBURGPA.GOV,City,Non-Federal Agency,Wilkinsburg,PA,ACTIVE,19-Jul-13,19-Nov-13
-WILLAMINAOREGON.GOV,City,Non-Federal Agency,Willamina,OR,ACTIVE,19-Mar-14,13-Jun-15
-WILLIAMSAZ.GOV,City,Non-Federal Agency,Williams,AZ,ACTIVE,16-Jul-12,5-Nov-12
-WILLIAMSPORTMD.GOV,City,Non-Federal Agency,WILLIAMSPORT,MD,ACTIVE,25-Mar-14,21-Feb-15
-WILLINGBORONJ.GOV,City,Non-Federal Agency,Willingboro,NJ,ACTIVE,22-Dec-14,8-Mar-16
-WILLISTONFL.GOV,City,Non-Federal Agency,Williston,FL,ACTIVE,30-May-14,30-May-15
-WILLMARMN.GOV,City,Non-Federal Agency,Willmar,MN,ACTIVE,29-Apr-14,11-May-15
-WILLOUGHBYHILLS-OH.GOV,City,Non-Federal Agency,Willoughby Hills,OH,ACTIVE,27-Mar-14,20-Apr-15
-WILLOWSPRINGS-IL.GOV,City,Non-Federal Agency,Willow Springs,IL,ACTIVE,18-Nov-14,30-Sep-15
-WILMINGTONDE.GOV,City,Non-Federal Agency,Wilmington,DE,ACTIVE,28-Oct-14,1-Nov-15
-WILMINGTONMA.GOV,City,Non-Federal Agency,wilmington,MA,ACTIVE,10-Apr-14,6-May-15
-WINCHESTER-IN.GOV,City,Non-Federal Agency,Winchester,IN,ACTIVE,5-Mar-15,3-Jun-16
-WINCHESTER-NH.GOV,City,Non-Federal Agency,Winchester,NH,ACTIVE,3-Apr-14,7-May-15
-WINCHESTERVA.GOV,City,Non-Federal Agency,Winchester,VA,ACTIVE,8-Dec-14,22-Dec-15
-WINDCREST-TX.GOV,City,Non-Federal Agency,Windcrest,TX,ACTIVE,3-Nov-14,25-Sep-15
-WINDGAP-PA.GOV,City,Non-Federal Agency,Wind Gap,PA,ACTIVE,29-Aug-14,26-Sep-15
-WINDSOR-VA.GOV,City,Non-Federal Agency,Windsor,VA,ACTIVE,7-Aug-14,30-Sep-15
-WINDSORWI.GOV,City,Non-Federal Agency,DeForest,WI,ACTIVE,5-Jan-15,25-Feb-16
-WINNECONNEWI.GOV,City,Non-Federal Agency,Winneconne,WI,ACTIVE,23-Sep-14,30-Sep-15
-WINSLOW-ME.GOV,City,Non-Federal Agency,Winslow,ME,ACTIVE,1-Aug-14,9-Oct-15
-WOBURNMA.GOV,City,Non-Federal Agency,Woburn,MA,ACTIVE,18-Jan-13,27-Oct-13
-WOODBURN-OR.GOV,City,Non-Federal Agency,Woodburn,OR,ACTIVE,24-Oct-14,10-Jan-16
-WOODFIN-NC.GOV,City,Non-Federal Agency,Woodfin,NC,ACTIVE,31-Jan-11,30-Jan-12
-WOODHEIGHTS-MO.GOV,City,Non-Federal Agency,Wood Heights,MO,ACTIVE,7-Oct-14,7-Oct-15
-WOODSTOCKCT.GOV,City,Non-Federal Agency,Woodstock,CT,ACTIVE,10-Sep-14,4-Dec-15
-WOODSTOCKGA.GOV,City,Non-Federal Agency,Woodstock,GA,ACTIVE,7-Oct-14,4-Nov-15
-WOODSTOCKIL.GOV,City,Non-Federal Agency,Woodstock,IL,ACTIVE,13-Oct-14,12-Oct-15
-WOODVILLE-TX.GOV,City,Non-Federal Agency,Woodville,TX,ACTIVE,1-May-14,25-Jun-15
-WORCESTERMA.GOV,City,Non-Federal Agency,Worcester,MA,ACTIVE,22-Oct-14,28-Oct-15
-WRGA.GOV,City,Non-Federal Agency,Warner Robins,GA,ACTIVE,30-Apr-14,27-Jul-15
-WSPMN.GOV,City,Non-Federal Agency,West Saint Paul,MN,ACTIVE,4-Aug-14,4-Aug-15
-WVC-UT.GOV,City,Non-Federal Agency,West Valley,UT,ACTIVE,2-Jul-14,30-Sep-15
-WYLIETEXAS.GOV,City,Non-Federal Agency,Wylie,TX,ACTIVE,19-Feb-13,7-Feb-14
-WYOMINGMI.GOV,City,Non-Federal Agency,Wyoming,MI,ACTIVE,15-Jan-15,18-Feb-16
-WYOMINGOHIO.GOV,City,Non-Federal Agency,Wyoming,OH,ACTIVE,10-May-13,4-Jun-14
-XENIA-OH.GOV,City,Non-Federal Agency,Xenia,OH,ACTIVE,3-Oct-14,30-Sep-15
-YAKIMAWA.GOV,City,Non-Federal Agency,Yakima,WA,ACTIVE,5-Dec-14,6-Feb-16
-YONKERSNY.GOV,City,Non-Federal Agency,Yonkers,NY,ACTIVE,16-Nov-11,8-Nov-12
-YORKTOWNTX.GOV,City,Non-Federal Agency,Yorktown,TX,ACTIVE,26-Sep-11,18-Nov-12
-YOUNGSVILLELA.GOV,City,Non-Federal Agency,Youngsville,LA,ACTIVE,2-May-14,2-May-15
-YUMAAZ.GOV,City,Non-Federal Agency,Yuma,AZ,ACTIVE,13-Aug-14,12-Oct-15
-ZILWAUKEEMICHIGAN.GOV,City,Non-Federal Agency,Zilwaukee,MI,ACTIVE,26-Aug-14,10-Sep-15
-ADAMSCOUNTYOH.GOV,County,Non-Federal Agency,West Union,OH,ACTIVE,9-Jan-15,28-Jan-16
-AIKENCOUNTYSC.GOV,County,Non-Federal Agency,Aiken,SC,ACTIVE,8-Sep-14,30-Sep-15
-ALEXANDERCOUNTY-NC.GOV,County,Non-Federal Agency,Taylorsville,NC,ACTIVE,31-Oct-14,30-Sep-15
-ALLEGHANYCOUNTY-NC.GOV,County,Non-Federal Agency,Sparta,NC,ACTIVE,11-Sep-14,30-Sep-15
-ALLEGHENYCOUNTYPA.GOV,County,Non-Federal Agency,Pittsburgh,PA,ACTIVE,30-Sep-14,18-Dec-15
-ALPINECOUNTYCA.GOV,County,Non-Federal Agency,Markleeville,CA,ACTIVE,15-May-13,24-Jul-14
-ANDROSCOGGINCOUNTYMAINE.GOV,County,Non-Federal Agency,Auburn,ME,ACTIVE,4-Jun-14,21-Aug-15
-ANOKACOUNTYMN.GOV,County,Non-Federal Agency,Anoka,MN,ACTIVE,8-Sep-14,8-Oct-15
-APPOMATTOXCOUNTYVA.GOV,County,Non-Federal Agency,Appomattox,VA,ACTIVE,17-Dec-13,15-Feb-15
-ARANSASCOUNTYTX.GOV,County,Non-Federal Agency,Rockport,TX,ACTIVE,8-Jan-15,16-Jan-16
-AUGUSTACOUNTY-VA.GOV,County,Non-Federal Agency,Verona,VA,ACTIVE,28-Jan-15,17-Mar-16
-AUGUSTACOUNTYVA.GOV,County,Non-Federal Agency,Verona,VA,ACTIVE,28-Jan-15,17-Mar-16
-AVERYCOUNTYNC.GOV,County,Non-Federal Agency,Newland,NC,ACTIVE,8-Dec-14,27-Jan-16
-BACACOUNTYCO.GOV,County,Non-Federal Agency,Springfield,CO,ACTIVE,18-Nov-13,14-Dec-14
-BALDWINCOUNTYAL.GOV,County,Non-Federal Agency,Bay Minette,AL,ACTIVE,26-Jan-15,17-Mar-16
-BALTIMORECOUNTYMD.GOV,County,Non-Federal Agency,Towson,MD,ACTIVE,19-Jun-14,5-Aug-15
-BAMBERGCOUNTYSC.GOV,County,Non-Federal Agency,Bamberg,SC,ACTIVE,14-Aug-13,11-Jun-14
-BARNSTABLECOUNTY-MA.GOV,County,Non-Federal Agency,Barnstable,MA,ACTIVE,27-Oct-14,27-Oct-15
-BARRONCOUNTYWI.GOV,County,Non-Federal Agency,Barron,WI,ACTIVE,26-Sep-14,13-Oct-15
-BASTROPCOUNTYTEXAS.GOV,County,Non-Federal Agency,Bastrop,TX,ACTIVE,27-Jan-15,27-Jan-16
-BAYCOUNTY911-MI.GOV,County,Non-Federal Agency,Bay City,MI,ACTIVE,3-Sep-14,2-Dec-15
-BAYCOUNTYFL.GOV,County,Non-Federal Agency,Panama City,FL,ACTIVE,26-Jun-14,23-Sep-15
-BEAVERCOUNTYPA.GOV,County,Non-Federal Agency,Beaver,PA,ACTIVE,17-Sep-14,30-Sep-15
-BEDFORDCOUNTYVA.GOV,County,Non-Federal Agency,Bedford,VA,ACTIVE,20-Jan-11,5-Jan-12
-BENTONCOUNTYAR.GOV,County,Non-Federal Agency,Bentonville,AR,ACTIVE,9-Oct-14,9-Oct-15
-BENTONCOUNTYMS.GOV,County,Non-Federal Agency,Ashland,MS,ACTIVE,9-Jul-14,30-Sep-15
-BENTONCOUNTYTN.GOV,County,Non-Federal Agency,Camden,TN,ACTIVE,22-Aug-12,22-Aug-13
-BERKELEYCOUNTYSC.GOV,County,Non-Federal Agency,Moncks Corner,SC,ACTIVE,17-Jul-14,14-Oct-15
-BERRIENCOUNTY-MI.GOV,County,Non-Federal Agency,St. Joseph,MI,ACTIVE,6-Aug-14,30-Sep-15
-BIGHORNCOUNTYMT.GOV,County,Non-Federal Agency,Hardin,MT,ACTIVE,28-Jul-14,28-Jul-15
-BILLINGSCOUNTYND.GOV,County,Non-Federal Agency,Medora,ND,ACTIVE,27-Oct-14,24-Jan-16
-BLAINECOUNTY-MT.GOV,County,Non-Federal Agency,CHINOOK,MT,ACTIVE,7-Apr-14,7-Apr-15
-BLANDCOUNTYVA.GOV,County,Non-Federal Agency,Bland,VA,ACTIVE,19-May-14,17-Jun-15
-BLUEEARTHCOUNTYMN.GOV,County,Non-Federal Agency,Mankato,MN,ACTIVE,10-Jul-13,7-Aug-14
-BONNERCOUNTYID.GOV,County,Non-Federal Agency,Sandpoint,ID,ACTIVE,7-Oct-14,7-Oct-15
-BOONECOUNTY-AR.GOV,County,Non-Federal Agency,Harrison,AR,ACTIVE,22-Aug-12,2-Sep-13
-BOSSIERPARISHLA.GOV,County,Non-Federal Agency,Benton ,LA,ACTIVE,15-Jul-13,26-Oct-13
-BOTETOURTVA.GOV,County,Non-Federal Agency,Fincastle,VA,ACTIVE,16-Sep-14,15-Aug-15
-BOULDERCOUNTYCOLORADO.GOV,County,Non-Federal Agency,Boulder,CO,ACTIVE,8-Apr-14,5-Jun-15
-BOWMANCOUNTYND.GOV,County,Non-Federal Agency,Bismarck,ND,ACTIVE,20-Jan-15,17-Apr-16
-BOYDCOUNTYKY.GOV,County,Non-Federal Agency,Catlettsburg,KY,ACTIVE,21-Nov-14,16-Dec-15
-BRADFORDCOUNTYFL.GOV,County,Non-Federal Agency,Starke,FL,ACTIVE,16-Feb-15,15-May-16
-BRANCHCOUNTYMI.GOV,County,Non-Federal Agency,Coldwater,MI,ACTIVE,29-May-14,26-Jul-15
-BRAZORIACOUNTY-TX.GOV,County,Non-Federal Agency,Angleton,TX,ACTIVE,30-Oct-14,30-Oct-15
-BRAZOSCOUNTYTX.GOV,County,Non-Federal Agency,Bryan,TX,ACTIVE,23-Apr-14,29-Apr-15
-BROOMECOUNTYNY.GOV,County,Non-Federal Agency,Binghamton,NY,ACTIVE,17-Oct-12,17-Oct-13
-BROWNCOUNTY-IN.GOV,County,Non-Federal Agency,Nashville,IN,ACTIVE,18-Nov-14,16-Feb-16
-BROWNCOUNTYOHIO.GOV,County,Non-Federal Agency,Georgetown,OH,ACTIVE,14-Feb-13,5-Feb-14
-BROWNCOUNTYWI.GOV,County,Non-Federal Agency,Green Bay,WI,ACTIVE,30-Sep-14,26-Oct-15
-BRUNSWICKCOUNTYNC.GOV,County,Non-Federal Agency,Bolivia,NC,ACTIVE,8-Apr-14,1-Jul-15
-BUCHANANCOUNTY-VA.GOV,County,Non-Federal Agency,Grundy,VA,ACTIVE,29-Jun-10,5-Jul-11
-BUNCOMBECOUNTYNC.GOV,County,Non-Federal Agency,Asheville,NC,ACTIVE,7-Jul-14,5-Sep-15
-BUREAUCOUNTY-IL.GOV,County,Non-Federal Agency,Princeton,IL,ACTIVE,6-Oct-14,2-Dec-15
-CABARRUSCOUNTYNC.GOV,County,Non-Federal Agency,Concord,NC,ACTIVE,1-Aug-12,30-Sep-13
-CALHOUNCOUNTYAL.GOV,County,Non-Federal Agency,Anniston,AL,ACTIVE,17-Feb-15,21-Feb-16
-CALHOUNCOUNTYMI.GOV,County,Non-Federal Agency,Marshall,MI,ACTIVE,21-Jul-14,30-Sep-15
-CALLOWAYCOUNTY-KY.GOV,County,Non-Federal Agency,Murray,KY,ACTIVE,8-Sep-14,24-Sep-15
-CAMBRIACOUNTYPA.GOV,County,Non-Federal Agency,Ebensburg,PA,ACTIVE,17-Jul-14,13-Aug-15
-CAMDENCOUNTYNC.GOV,County,Non-Federal Agency,Camden,NC,ACTIVE,2-Jul-14,30-Sep-15
-CAMPBELLCOUNTYKY.GOV,County,Non-Federal Agency,Newport,KY,ACTIVE,16-Jul-14,10-Apr-15
-CAMPBELLCOUNTYTN.GOV,County,Non-Federal Agency,Jacksboro,TN,ACTIVE,27-Mar-14,6-Apr-15
-CAMPBELLCOUNTYVA.GOV,County,Non-Federal Agency,Rustburg,VA,ACTIVE,5-May-14,3-May-15
-CANDLERCO-GA.GOV,County,Non-Federal Agency,Metter,GA,ACTIVE,22-Nov-13,22-Nov-14
-CAPECOD-MA.GOV,County,Non-Federal Agency,Barnstable,MA,ACTIVE,27-Oct-14,27-Oct-15
-CAPEMAYCOUNTYNJ.GOV,County,Non-Federal Agency,Cape May Court House,NJ,ACTIVE,18-Aug-14,18-Aug-15
-CAPITALALERT.GOV,County,Non-Federal Agency,Fairfax,VA,ACTIVE,25-Mar-14,15-Apr-15
-CAPITALERT.GOV,County,Non-Federal Agency,Fairfax,VA,ACTIVE,25-Mar-14,15-Apr-15
-CARROLLCOUNTYIN.GOV,County,Non-Federal Agency,Delphi,IN,ACTIVE,25-Aug-14,30-Sep-15
-CARTERCOUNTYTN.GOV,County,Non-Federal Agency,Elizabethton,TN,ACTIVE,3-Sep-14,2-Dec-15
-CARTERETCOUNTYNC.GOV,County,Non-Federal Agency,Beaufort,NC,ACTIVE,7-May-14,21-May-15
-CASCADECOUNTYMT.GOV,County,Non-Federal Agency,Great Falls,MT,ACTIVE,12-Nov-14,9-Jan-16
-CASSCOUNTYND.GOV,County,Non-Federal Agency,Bismarck,ND,ACTIVE,3-Feb-15,2-May-16
-CATAWBACOUNTYNC.GOV,County,Non-Federal Agency,Newton,NC,ACTIVE,1-Aug-14,30-Sep-15
-CATRONCOUNTYNM.GOV,County,Non-Federal Agency,Reserve,NM,ACTIVE,30-Apr-14,30-Apr-15
-CEDARCOUNTYMO.GOV,County,Non-Federal Agency,Stockton,MO,ACTIVE,2-Dec-14,8-Dec-15
-CENTRECOUNTYPA.GOV,County,Non-Federal Agency,Bellefonte,PA,ACTIVE,3-Sep-14,31-Jul-15
-CHAMBERSCOUNTYAL.GOV,County,Non-Federal Agency,Lafayette,AL,ACTIVE,25-Mar-14,24-May-15
-CHAMBERSTX.GOV,County,Non-Federal Agency,Anahuac,TX,ACTIVE,22-Jul-14,23-Aug-15
-CHARLESCOUNTYMD.GOV,County,Non-Federal Agency,La Plata,MD,ACTIVE,20-Jun-14,3-Aug-15
-CHARLOTTECOUNTYFL.GOV,County,Non-Federal Agency,Port Charlotte,FL,ACTIVE,4-Mar-15,23-May-16
-CHEATHAMCOUNTYTN.GOV,County,Non-Federal Agency,Ashland City,TN,ACTIVE,30-Sep-14,30-Sep-15
-CHELANCOUNTYWA.GOV,County,Non-Federal Agency,Wenatchee,WA,ACTIVE,27-May-14,21-Aug-15
-CHEROKEECOUNTY-AL.GOV,County,Non-Federal Agency,Centre,AL,ACTIVE,23-Oct-14,16-Sep-15
-CHEROKEECOUNTY-KS.GOV,County,Non-Federal Agency,Columbus,KS,ACTIVE,28-Jul-14,30-Sep-15
-CHEROKEECOUNTYKS.GOV,County,Non-Federal Agency,Columbus,KS,ACTIVE,28-Jul-14,28-Jul-15
-CHEYENNECOUNTY-CO.GOV,County,Non-Federal Agency,CHEYENNE WELLS,CO,ACTIVE,2-Jul-13,30-Sep-14
-CHRISTIANCOUNTYKY.GOV,County,Non-Federal Agency,Hopkinsville,KY,ACTIVE,26-Dec-13,24-Feb-15
-CHRISTIANCOUNTYMO.GOV,County,Non-Federal Agency,Ozark,MO,ACTIVE,3-Sep-14,30-Sep-15
-CLARKCOUNTYNV.GOV,County,Non-Federal Agency,Las Vegas,NV,ACTIVE,17-Jul-14,30-Sep-15
-CLARKCOUNTYOHIO.GOV,County,Non-Federal Agency,Springfield,OH,ACTIVE,19-Aug-14,8-Sep-15
-CLARKECOUNTYMS.GOV,County,Non-Federal Agency,Quitman,MS,ACTIVE,23-Oct-14,16-Dec-15
-CLAYCOUNTYMN.GOV,County,Non-Federal Agency,Moorhead,MN,ACTIVE,25-Feb-15,20-Dec-15
-CLAYCOUNTYMO.GOV,County,Non-Federal Agency,Liberty,MO,ACTIVE,26-Jan-15,30-Mar-16
-CLAYTONCOUNTYGA.GOV,County,Non-Federal Agency,Jonesboro,GA,ACTIVE,27-Feb-15,19-Mar-16
-CLAYTONCOUNTYIA.GOV,County,Non-Federal Agency,Elkader,IA,ACTIVE,25-Apr-12,19-Jul-13
-CLERMONTCOUNTYOHIO.GOV,County,Non-Federal Agency,Batavia,OH,ACTIVE,28-Aug-14,16-Sep-15
-CLINTONCOUNTY-IA.GOV,County,Non-Federal Agency,Clinton,IA,ACTIVE,10-Jul-14,30-Jul-15
-COLUMBIACOUNTYGA.GOV,County,Non-Federal Agency,Evans,GA,ACTIVE,4-Aug-14,2-Sep-15
-COLUMBIACOUNTYNY.GOV,County,Non-Federal Agency,Hudson,NY,ACTIVE,30-Jul-14,20-Sep-15
-CONVERSECOUNTYWY.GOV,County,Non-Federal Agency,Douglas,WY,ACTIVE,12-Apr-13,2-May-14
-COOKCOUNTYIL.GOV,County,Non-Federal Agency,Chicago,IL,ACTIVE,15-Apr-14,16-Apr-15
-COOPERCOUNTYMO.GOV,County,Non-Federal Agency,Boonville,MO,ACTIVE,3-Nov-14,14-Nov-15
-CORONADOCA.GOV,County,Non-Federal Agency,Coronado,CA,ACTIVE,24-Jun-14,18-Aug-15
-COSCPINALCOUNTYAZ.GOV,County,Non-Federal Agency,Florence,AZ,ACTIVE,5-Dec-14,5-Dec-15
-COSTILLACOUNTY-CO.GOV,County,Non-Federal Agency,San Luis,CO,ACTIVE,19-Feb-13,9-Jan-14
-COUNTYOFPITT-NC.GOV,County,Non-Federal Agency,Greenville,NC,ACTIVE,14-Sep-10,14-Sep-11
-COVINGTONCOUNTYMS.GOV,County,Non-Federal Agency,Collins,MS,ACTIVE,23-Oct-14,30-Sep-15
-CRAIGCOUNTYVA.GOV,County,Non-Federal Agency,New Castle,VA,ACTIVE,2-Jul-14,26-Jul-15
-CRAVENCOUNTYNC.GOV,County,Non-Federal Agency,New Bern,NC,ACTIVE,30-Jan-15,4-Mar-16
-CRAWFORDCOUNTYKANSAS.GOV,County,Non-Federal Agency,Girard,KS,ACTIVE,15-Jul-13,6-Jul-13
-CULPEPERCOUNTY.GOV,County,Non-Federal Agency,Culpeper,VA,ACTIVE,7-Jul-14,30-Sep-15
-CUMBERLANDCOUNTYTN.GOV,County,Non-Federal Agency,Crossville,TN,ACTIVE,16-Jan-15,15-Mar-16
-CURRITUCKCOUNTYNC.GOV,County,Non-Federal Agency,Currituck,NC,ACTIVE,1-Aug-14,30-Sep-15
-DADECOUNTY-GA.GOV,County,Non-Federal Agency,Trenton,GA,ACTIVE,6-Mar-15,14-Apr-15
-DAKOTACOUNTYMN.GOV,County,Non-Federal Agency,Hastings,MN,ACTIVE,7-Aug-14,14-Sep-15
-DALLASCOUNTY-TX.GOV,County,Non-Federal Agency,Dallas,TX,ACTIVE,11-Apr-14,23-Apr-15
-DALLASCOUNTYIOWA.GOV,County,Non-Federal Agency,Adel,IA,ACTIVE,9-Jan-15,9-Apr-16
-DAVIDSONCOUNTYNC.GOV,County,Non-Federal Agency,Lexington,NC,ACTIVE,13-Jun-14,7-Dec-14
-DAVIECOUNTYNC.GOV,County,Non-Federal Agency,Mocksville,NC,ACTIVE,27-Aug-14,26-Sep-15
-DAVISCOUNTYUT4HEALTH.GOV,County,Non-Federal Agency,Farmington,UT,ACTIVE,5-Nov-14,5-Nov-15
-DAVISUT4HEALTH.GOV,County,Non-Federal Agency,Farmington,UT,ACTIVE,5-Nov-14,5-Nov-15
-DAWSONCOUNTYNE.GOV,County,Non-Federal Agency,Lexington,NE,ACTIVE,14-Oct-14,27-Jul-15
-DCONC.GOV,County,Non-Federal Agency,Durham,NC,ACTIVE,13-Oct-14,12-Oct-15
-DECATURCOUNTYGA.GOV,County,Non-Federal Agency,Bainbridge,GA,ACTIVE,5-Aug-14,5-Aug-15
-DEKALBCOUNTYGA.GOV,County,Non-Federal Agency,Decatur,GA,ACTIVE,18-Mar-14,10-Apr-15
-DEKALBCOUNTYIL.GOV,County,Non-Federal Agency,Sycamore,IL,ACTIVE,6-Mar-15,6-May-16
-DESOTOCOUNTYMS.GOV,County,Non-Federal Agency,HERNANDO,MS,ACTIVE,17-Oct-14,8-Dec-15
-DICKINSONCOUNTYMI.GOV,County,Non-Federal Agency,Iron Mountain,MI,ACTIVE,16-Dec-14,3-Mar-16
-DICKSONCOUNTYTN.GOV,County,Non-Federal Agency,Charlotte,TN,ACTIVE,4-Jun-14,20-Jun-15
-DOUGLASCOUNTY-NE.GOV,County,Non-Federal Agency,Omaha,NE,ACTIVE,23-Jul-13,21-Oct-14
-DOUGLASCOUNTYNV.GOV,County,Non-Federal Agency,Minden,NV,ACTIVE,9-Jan-15,28-Mar-16
-DUNNCOUNTYWI.GOV,County,Non-Federal Agency,Menomonie,WI,ACTIVE,16-Feb-15,15-Dec-15
-DURHAMCOUNTYNC.GOV,County,Non-Federal Agency,Durham,NC,ACTIVE,13-Nov-14,12-Jan-16
-ECTORCOUNTYTX.GOV,County,Non-Federal Agency,Odessa,TX,ACTIVE,19-Feb-15,14-May-16
-ERIE.GOV,County,Non-Federal Agency,Buffalo,NY,ACTIVE,28-Jul-14,26-Aug-15
-FAIRFAXCOUNTYVIRGINIA.GOV,County,Non-Federal Agency,Fairfax,VA,ACTIVE,2-Jun-14,30-Aug-15
-FAUQUIERCOUNTY.GOV,County,Non-Federal Agency,Warrenton,VA,ACTIVE,16-Sep-14,10-Nov-15
-FENTRESSCOUNTYTN.GOV,County,Non-Federal Agency,Jamestown,TN,ACTIVE,11-Feb-14,11-Feb-15
-FOARDCOUNTYTX.GOV,County,Non-Federal Agency,Crowell,TX,ACTIVE,25-Mar-14,25-Mar-15
-FORTBENDCOUNTYTX.GOV,County,Non-Federal Agency,Richmond,TX,ACTIVE,13-Nov-14,29-Nov-15
-FRANKLINCOUNTYGA.GOV,County,Non-Federal Agency,Carnesville,GA,ACTIVE,19-Jun-14,19-Jun-15
-FRANKLINCOUNTYIL.GOV,County,Non-Federal Agency,Benton,IL,ACTIVE,29-May-14,27-Aug-15
-FRANKLINCOUNTYMAINE.GOV,County,Non-Federal Agency,Farmington,ME,ACTIVE,4-Jun-14,4-Jun-15
-FRANKLINCOUNTYOHIO.GOV,County,Non-Federal Agency,Columbus,OH,ACTIVE,13-Aug-14,30-Sep-15
-FRANKLINCOUNTYPA.GOV,County,Non-Federal Agency,Chambersburg,PA,ACTIVE,8-Dec-14,7-Dec-15
-FRANKLINCOUNTYVA.GOV,County,Non-Federal Agency,Rocky Mount,VA,ACTIVE,8-May-13,7-Aug-14
-FREDERICKCOUNTYMD.GOV,County,Non-Federal Agency,Frederick,MD,ACTIVE,18-Feb-15,16-Apr-16
-FREDERICKCOUNTYVA.GOV,County,Non-Federal Agency,Winchester,VA,ACTIVE,19-Mar-14,17-Jun-15
-FRIOCOUNTY-TX.GOV,County,Non-Federal Agency,Pearsall,TX,ACTIVE,26-Nov-14,27-Nov-15
-FULTONCOUNTYGA.GOV,County,Non-Federal Agency,Atlanta,GA,ACTIVE,14-Apr-14,9-May-15
-FULTONCOUNTYNY.GOV,County,Non-Federal Agency,Johnstown,NY,ACTIVE,11-Sep-14,8-Dec-15
-GADSDENCOUNTYFL.GOV,County,Non-Federal Agency,Quincy,FL,ACTIVE,20-Jul-14,21-Jul-15
-GALVESTONCOUNTYTX.GOV,County,Non-Federal Agency,Galveston,TX,ACTIVE,27-May-14,5-Jun-15
-GARFIELDCOUNTY-CO.GOV,County,Non-Federal Agency,Glenwood Springs,CO,ACTIVE,21-Jan-15,20-Feb-16
-GATESCOUNTYNC.GOV,County,Non-Federal Agency,Gatesville,NC,ACTIVE,28-May-14,24-Jun-15
-GEORGECOUNTYMS.GOV,County,Non-Federal Agency,Lucedale,MS,ACTIVE,14-Sep-12,30-Sep-13
-GGSC.GOV,County,Non-Federal Agency,Greenville,SC,ACTIVE,29-Sep-14,31-Oct-15
-GIBSONCOUNTY-IN.GOV,County,Non-Federal Agency,Princeton,IN,ACTIVE,12-Aug-14,30-Sep-15
-GILACOUNTYAZ.GOV,County,Non-Federal Agency,Globe,AZ,ACTIVE,16-Jul-12,30-Sep-13
-GILMERCOUNTY-GA.GOV,County,Non-Federal Agency,Ellijay,GA,ACTIVE,3-Feb-15,2-Mar-16
-GILMERCOUNTYWV.GOV,County,Non-Federal Agency,GLENVILLE,WV,ACTIVE,19-Jun-14,19-Jun-15
-GLOUCESTERCOUNTYNJ.GOV,County,Non-Federal Agency,Woodbury,NJ,ACTIVE,23-Apr-14,12-Jun-15
-GOGEBICCOUNTYMI.GOV,County,Non-Federal Agency,Bessemer,MI,ACTIVE,8-Jun-12,8-Jun-13
-GOLIADCOUNTYTX.GOV,County,Non-Federal Agency,Goliad,TX,ACTIVE,4-Mar-15,29-May-16
-GRADYCOUNTYGA.GOV,County,Non-Federal Agency,Cairo,GA,ACTIVE,15-Jul-13,12-Jul-14
-GRANTCOUNTY-OR.GOV,County,Non-Federal Agency,Canyon City,OR,ACTIVE,3-Sep-14,30-Sep-15
-GRANTCOUNTYWA.GOV,County,Non-Federal Agency,Ephrata,WA,ACTIVE,29-Jul-14,29-Jul-15
-GREENECOUNTYGA.GOV,County,Non-Federal Agency,Greensboro,GA,ACTIVE,18-Jun-14,16-Sep-15
-GREENECOUNTYMS.GOV,County,Non-Federal Agency,Leaksville,MS,ACTIVE,27-Jan-15,31-Jan-16
-GREENECOUNTYNC.GOV,County,Non-Federal Agency,Snow Hill,NC,ACTIVE,9-Dec-14,9-Dec-15
-GREENHARRISCOUNTYTX.GOV,County,Non-Federal Agency,Houston,TX,ACTIVE,2-Jul-14,22-Jul-15
-GREENMCHENRYCOUNTYIL.GOV,County,Non-Federal Agency,Woodstock,IL,ACTIVE,2-Apr-14,8-Apr-15
-GREENMCHENRYCOUNTYILLINOIS.GOV,County,Non-Federal Agency,Woodstock,IL,ACTIVE,2-Apr-14,8-Apr-15
-GREENVILLECOUNTYSC.GOV,County,Non-Federal Agency,Greenville,SC,ACTIVE,11-Aug-14,30-Sep-15
-GREENWOODSC.GOV,County,Non-Federal Agency,Greenwood,SC,ACTIVE,8-Sep-14,6-Dec-15
-GRIGGSCOUNTYND.GOV,County,Non-Federal Agency,Bismarck,ND,ACTIVE,28-Mar-14,9-Jun-15
-GULFCOUNTY-FL.GOV,County,Non-Federal Agency,Port St. Joe,FL,ACTIVE,13-Oct-14,13-Oct-15
-GWINNETTCOUNTYGA.GOV,County,Non-Federal Agency,Lawrenceville,GA,ACTIVE,23-Jan-15,13-Apr-16
-HABERSHAMCOUNTY-GA.GOV,County,Non-Federal Agency,Clarkesville,GA,ACTIVE,19-Dec-14,29-Dec-15
-HAINESALASKA.GOV,County,Non-Federal Agency,Haines,AK,ACTIVE,9-Feb-15,9-May-16
-HALIFAXCOUNTYVA.GOV,County,Non-Federal Agency,Halifax,VA,ACTIVE,11-Dec-14,14-Dec-15
-HALLCOUNTYGA.GOV,County,Non-Federal Agency,Gainesville,GA,ACTIVE,20-Feb-15,9-Mar-16
-HALLCOUNTYNE.GOV,County,Non-Federal Agency,Grand Island,NE,ACTIVE,3-Sep-14,27-Sep-15
-HAMBLENCOUNTYTN.GOV,County,Non-Federal Agency,Morristown,TN,ACTIVE,3-Nov-14,3-Nov-15
-HAMILTONCOUNTYFLORIDA.GOV,County,Non-Federal Agency,Jasper,FL,ACTIVE,4-Jun-14,31-Aug-15
-HAMILTONCOUNTYNY.GOV,County,Non-Federal Agency,Lake Pleasent,NY,ACTIVE,9-Jan-15,9-Jan-16
-HAMILTONCOUNTYOHIO.GOV,County,Non-Federal Agency,Cincinnati,OH,ACTIVE,9-Sep-14,28-Sep-15
-HANCOCKCOUNTY-IL.GOV,County,Non-Federal Agency,Carthage,IL,ACTIVE,19-Feb-15,19-Feb-16
-HANCOCKCOUNTYGA.GOV,County,Non-Federal Agency,Sparta,GA,ACTIVE,15-Oct-13,13-Dec-14
-HANCOCKCOUNTYMS.GOV,County,Non-Federal Agency,Bay St. Louis,MS,ACTIVE,15-Jul-13,23-Feb-14
-HARALSONCOUNTYGA.GOV,County,Non-Federal Agency,Buchanan,GA,ACTIVE,26-Aug-13,15-Nov-14
-HARDINCOUNTYIA.GOV,County,Non-Federal Agency,Eldora,IA,ACTIVE,15-Dec-14,16-Sep-15
-HARRISCOUNTYGA.GOV,County,Non-Federal Agency,Hamilton,GA,ACTIVE,15-Jul-13,27-Sep-14
-HARRISCOUNTYTX.GOV,County,Non-Federal Agency,Houston,TX,ACTIVE,25-Aug-14,13-Sep-15
-HARTCOUNTYGA.GOV,County,Non-Federal Agency,Hartwell,GA,ACTIVE,2-Jul-14,30-Sep-15
-HAWAIICOUNTY.GOV,County,Non-Federal Agency,Hilo,HI,ACTIVE,1-Jul-14,29-Sep-15
-HAWKINSCOUNTYTN.GOV,County,Non-Federal Agency,Rogersville,TN,ACTIVE,6-Mar-14,5-May-15
-HAYWOODCOUNTYNC.GOV,County,Non-Federal Agency,Waynesville,NC,ACTIVE,3-Nov-14,3-Nov-15
-HENDERSONCOUNTYTN.GOV,County,Non-Federal Agency,Lexington,TN,ACTIVE,19-Nov-14,17-Feb-16
-HENRYCOUNTYVA.GOV,County,Non-Federal Agency,Martinsville,VA,ACTIVE,16-Oct-14,17-Dec-15
-HERTFORDCOUNTYNC.GOV,County,Non-Federal Agency,Winton,NC,ACTIVE,4-Jun-14,8-Jun-15
-HINSDALECOUNTY-CO.GOV,County,Non-Federal Agency,Lake City,CO,ACTIVE,10-Nov-14,9-Dec-15
-HOWARDCOUNTYMARYLAND.GOV,County,Non-Federal Agency,Ellicott City,MD,ACTIVE,24-Sep-14,11-Dec-15
-HOWARDCOUNTYMD.GOV,County,Non-Federal Agency,Ellicott City,MD,ACTIVE,24-Sep-14,8-Dec-15
-HURONCOUNTY-OH.GOV,County,Non-Federal Agency,Norwalk,OH,ACTIVE,21-Jan-15,18-Mar-16
-HYDECOUNTYNC.GOV,County,Non-Federal Agency,Swanquarter,NC,ACTIVE,10-Sep-14,6-Oct-15
-ISSAQUENACOUNTYMS.GOV,County,Non-Federal Agency,Mayersville,MS,ACTIVE,27-Jan-15,11-Apr-16
-JACKSONCOGA.GOV,County,Non-Federal Agency,Jefferson,GA,ACTIVE,9-Sep-13,9-Sep-14
-JACKSONCOUNTY-IL.GOV,County,Non-Federal Agency,Murphysboro,IL,ACTIVE,20-Aug-13,30-Sep-14
-JAMESCITYCOUNTYVA.GOV,County,Non-Federal Agency,Williamsburg,VA,ACTIVE,7-Nov-12,1-Feb-14
-JASPERCOUNTYIN.GOV,County,Non-Federal Agency,Rensselaer,IN,ACTIVE,21-Mar-14,23-Mar-15
-JASPERCOUNTYSC.GOV,County,Non-Federal Agency,Ridgeland,SC,ACTIVE,4-Aug-14,30-Sep-15
-JEFFERSONCOUNTY-MT.GOV,County,Non-Federal Agency,Boulder,MT,ACTIVE,20-Dec-12,20-Dec-13
-JEFFERSONCOUNTYFL.GOV,County,Non-Federal Agency,Monticello,FL,ACTIVE,12-Aug-14,25-Aug-15
-JEFFERSONCOUNTYGA.GOV,County,Non-Federal Agency,LOUISVILLE,GA,ACTIVE,1-Jul-14,8-Jun-15
-JEFFERSONCOUNTYMS.GOV,County,Non-Federal Agency,Fayette,MS,ACTIVE,27-Jan-15,22-Mar-16
-JEFFERSONCOUNTYTN.GOV,County,Non-Federal Agency,Dandridge,TN,ACTIVE,30-Apr-14,5-Jul-15
-JEFFERSONCOUNTYWI.GOV,County,Non-Federal Agency,Jefferson,WI,ACTIVE,12-Jan-15,11-Apr-16
-JENNINGSCOUNTY-IN.GOV,County,Non-Federal Agency,Vernon,IN,ACTIVE,3-Sep-13,30-Sep-14
-JIMWELLSCOUNTY-TX.GOV,County,Non-Federal Agency,Alice,TX,ACTIVE,9-Jan-14,26-Mar-15
-JONESCOUNTYNC.GOV,County,Non-Federal Agency,Trenton,NC,ACTIVE,7-Aug-14,3-Aug-15
-KAUAI.GOV,County,Non-Federal Agency,Lihue,HI,ACTIVE,13-Nov-14,10-Feb-16
-KENNEBECCOUNTY-ME.GOV,County,Non-Federal Agency,Augusta,ME,ACTIVE,9-Sep-13,2-Nov-14
-KERNCOG-CA.GOV,County,Non-Federal Agency,Bakersfield,CA,ACTIVE,4-Nov-14,31-Oct-15
-KINGCOUNTY.GOV,County,Non-Federal Agency,Seattle,WA,ACTIVE,9-Jan-15,28-Feb-16
-KINGGEORGECOUNTYVA.GOV,County,Non-Federal Agency,King George,VA,ACTIVE,8-Oct-14,10-Oct-15
-KINGSBURYNY.GOV,County,Non-Federal Agency,Hudson Falls,NY,ACTIVE,8-Jul-14,26-Aug-15
-KNOXCOUNTYMAINE.GOV,County,Non-Federal Agency,Rockland,ME,ACTIVE,4-Mar-15,4-Mar-16
-LACOUNTY.GOV,County,Non-Federal Agency,Downey,CA,ACTIVE,5-Feb-13,4-May-14
-LAKECOUNTYCA.GOV,County,Non-Federal Agency,Lakeport,CA,ACTIVE,10-Oct-14,9-Dec-15
-LAKECOUNTYIL.GOV,County,Non-Federal Agency,Waukegan,IL,ACTIVE,23-Sep-14,20-Dec-15
-LAKECOUNTYOHIO.GOV,County,Non-Federal Agency,Painesville,OH,ACTIVE,10-Sep-14,30-Sep-15
-LAKEMT.GOV,County,Non-Federal Agency,Polson,MT,ACTIVE,25-Mar-14,6-May-15
-LAPAZCOUNTYAZ.GOV,County,Non-Federal Agency,Parker,AZ,ACTIVE,17-Dec-12,17-Dec-13
-LAUDERDALECOUNTYAL.GOV,County,Non-Federal Agency,Florence,AL,ACTIVE,29-Jan-15,4-Feb-16
-LAWRENCECOUNTYTN.GOV,County,Non-Federal Agency,Lawrenceburg,TN,ACTIVE,28-Apr-14,25-Feb-15
-LCCOUNTYMT.GOV,County,Non-Federal Agency,Helena,MT,ACTIVE,17-Feb-15,13-Mar-16
-LEE-COUNTY-FL.GOV,County,Non-Federal Agency,Fort Myers,FL,ACTIVE,9-Mar-15,26-May-16
-LEECOUNTYNC.GOV,County,Non-Federal Agency,Sanford,NC,ACTIVE,14-Apr-14,25-Apr-15
-LEONCOUNTYFL.GOV,County,Non-Federal Agency,Tallahassee,FL,ACTIVE,15-Sep-14,30-Sep-15
-LEWISCOUNTYWA.GOV,County,Non-Federal Agency,Chehalis,WA,ACTIVE,2-Sep-14,23-Oct-15
-LIBERTYCOUNTY-GA.GOV,County,Non-Federal Agency,Hinesville,GA,ACTIVE,2-Oct-14,31-Oct-15
-LIMESTONECOUNTY-AL.GOV,County,Non-Federal Agency,Athens,AL,ACTIVE,19-Dec-14,5-Feb-16
-LIMESTONECOUNTYEMA-AL.GOV,County,Non-Federal Agency,Athens,AL,ACTIVE,20-Jan-15,21-Mar-16
-LINCOLNCOUNTYNM.GOV,County,Non-Federal Agency,Carrizozo,NM,ACTIVE,2-Jul-14,25-Sep-15
-LIVINGSTONCOUNTYIL.GOV,County,Non-Federal Agency,Pontiac,IL,ACTIVE,8-Oct-14,6-Jan-16
-LIVINGSTONPARISHLA.GOV,County,Non-Federal Agency,Livingston,LA,ACTIVE,30-Sep-14,30-Sep-15
-LOGANCOUNTYCO.GOV,County,Non-Federal Agency,Sterling,CO,ACTIVE,17-Dec-14,14-Feb-16
-LOUDONCOUNTY-TN.GOV,County,Non-Federal Agency,Loudon,TN,ACTIVE,11-Feb-15,27-Feb-16
-LOUDOUN.GOV,County,Non-Federal Agency,Leesburg,VA,ACTIVE,30-Sep-14,30-Sep-15
-LOWNDESCOUNTYGA.GOV,County,Non-Federal Agency,Valdosta,GA,ACTIVE,16-Jul-14,15-Aug-15
-LUCASCOUNTYOH.GOV,County,Non-Federal Agency,Toledo,OH,ACTIVE,31-Jul-14,10-Sep-15
-LUMPKINCOUNTY.GOV,County,Non-Federal Agency,Dahlonega,GA,ACTIVE,22-Sep-14,30-Sep-15
-MACOMBCOUNTYMI.GOV,County,Non-Federal Agency,Mount Clemens,MI,ACTIVE,25-Sep-12,24-Sep-13
-MACONBIBBCOUNTYGA.GOV,County,Non-Federal Agency,Macon,GA,ACTIVE,25-Oct-12,25-Oct-13
-MACONCOUNTYGA.GOV,County,Non-Federal Agency,Oglethorpe,GA,ACTIVE,19-Mar-14,2-Apr-15
-MACONCOUNTYTN.GOV,County,Non-Federal Agency,Lafayette,TN,ACTIVE,15-Apr-14,15-Apr-15
-MACOUPINCOUNTYIL.GOV,County,Non-Federal Agency,Carlinville,IL,ACTIVE,10-Nov-14,10-Nov-15
-MADISONCOUNTYAL.GOV,County,Non-Federal Agency,Huntsville,AL,ACTIVE,22-Jan-15,1-Mar-16
-MADISONCOUNTYNC.GOV,County,Non-Federal Agency,Marshall,NC,ACTIVE,7-Jan-14,1-Mar-15
-MAHONINGCOUNTYOH.GOV,County,Non-Federal Agency,Youngstown,OH,ACTIVE,10-Sep-14,17-Sep-15
-MANISTEECOUNTYMI.GOV,County,Non-Federal Agency,Manistee,MI,ACTIVE,4-Sep-14,12-Sep-14
-MARIONCOUNTY-MO.GOV,County,Non-Federal Agency,Hannibal,MO,ACTIVE,15-Jul-14,12-Oct-15
-MARSHALLCOUNTYKY.GOV,County,Non-Federal Agency,Benton,KY,ACTIVE,8-Dec-14,20-Nov-15
-MATHEWSCOUNTYVA.GOV,County,Non-Federal Agency,Mathews,VA,ACTIVE,15-Jan-15,14-Apr-16
-MAUICOUNTY-HI.GOV,County,Non-Federal Agency,Wailuku,HI,ACTIVE,25-Aug-14,22-Oct-15
-MAUICOUNTY.GOV,County,Non-Federal Agency,Wailuku,HI,ACTIVE,13-Nov-14,10-Feb-16
-MCCRACKENCOUNTYKY.GOV,County,Non-Federal Agency,Paducah,KY,ACTIVE,18-Oct-10,31-Aug-11
-MCDONALDCOUNTYMO.GOV,County,Non-Federal Agency,Pineville,MO,ACTIVE,6-Jan-15,31-Mar-16
-MCHENRYCOUNTYIL.GOV,County,Non-Federal Agency,Woodstock,IL,ACTIVE,13-Jan-15,31-Jan-16
-MCHENRYCOUNTYILLINOIS.GOV,County,Non-Federal Agency,Woodstock,IL,ACTIVE,13-Jan-15,31-Jan-16
-MCINTOSHCOUNTY-GA.GOV,County,Non-Federal Agency,Darien,GA,ACTIVE,8-Apr-14,13-Mar-15
-MCLEANCOUNTYIL.GOV,County,Non-Federal Agency,Bloomington,IL,ACTIVE,2-Jul-14,30-Sep-15
-MCLEANCOUNTYND.GOV,County,Non-Federal Agency,Washburn,ND,ACTIVE,9-Oct-14,9-Oct-15
-MCMINNCOUNTYTN.GOV,County,Non-Federal Agency,Athens,TN,ACTIVE,13-Oct-14,30-Nov-15
-MEADEKY.GOV,County,Non-Federal Agency,Brandenburg,KY,ACTIVE,4-Sep-14,3-Dec-15
-MECKLENBURGCOUNTYNC.GOV,County,Non-Federal Agency,Charlotte,NC,ACTIVE,5-Mar-15,29-Mar-16
-MEETEETSECD-WY.GOV,County,Non-Federal Agency,Meeteetse,WY,ACTIVE,2-Dec-14,6-Dec-15
-MERCEDCOUNTYCA.GOV,County,Non-Federal Agency,Merced,CA,ACTIVE,10-Dec-14,23-Feb-16
-MERIWETHERCOUNTYGA.GOV,County,Non-Federal Agency,Greenville,GA,ACTIVE,14-Jul-14,7-Jul-15
-MIAMI-DADE.GOV,County,Non-Federal Agency,Miami,FL,ACTIVE,20-Aug-14,14-Sep-15
-MIAMICOUNTYIN.GOV,County,Non-Federal Agency,Peru,IN,ACTIVE,18-Aug-14,30-Sep-15
-MIAMICOUNTYOHIO.GOV,County,Non-Federal Agency,Troy,OH,ACTIVE,3-Apr-14,3-Apr-15
-MIAMIDADE.GOV,County,Non-Federal Agency,Miami,FL,ACTIVE,20-Aug-14,14-Sep-15
-MIAMIDADECOUNTY-FL.GOV,County,Non-Federal Agency,Miami,FL,ACTIVE,20-Aug-14,14-Sep-15
-MIAMIDADECOUNTYFL.GOV,County,Non-Federal Agency,Miami,FL,ACTIVE,20-Aug-14,14-Sep-15
-MILWAUKEECOUNTY-WI.GOV,County,Non-Federal Agency,Milwaukee,WI,ACTIVE,10-Jul-14,30-Sep-15
-MILWAUKEECOUNTYWI.GOV,County,Non-Federal Agency,Milwaukee,WI,ACTIVE,10-Jul-14,30-Sep-15
-MOBILECOUNTYAL.GOV,County,Non-Federal Agency,Mobile,AL,ACTIVE,10-Jul-14,24-Aug-15
-MONROECOUNTY-FL.GOV,County,Non-Federal Agency,Key West,FL,ACTIVE,30-Sep-14,30-Sep-15
-MONROECOUNTY.GOV,County,Non-Federal Agency,Rochester,NY,ACTIVE,25-Sep-14,30-Sep-15
-MONROECOUNTYAL.GOV,County,Non-Federal Agency,Monroeville,AL,ACTIVE,25-Feb-15,26-Feb-16
-MONTGOMERYCOUNTYGA.GOV,County,Non-Federal Agency,mt. vernon,GA,ACTIVE,21-Oct-14,19-Sep-15
-MONTGOMERYCOUNTYMD.GOV,County,Non-Federal Agency,Rockville,MD,ACTIVE,6-Aug-14,30-Sep-15
-MONTGOMERYCOUNTYVA.GOV,County,Non-Federal Agency,Christiansburg,VA,ACTIVE,4-Aug-14,26-Aug-15
-MORGANCOUNTY-OH.GOV,County,Non-Federal Agency,McConnelsville,OH,ACTIVE,23-Feb-15,23-Feb-16
-MORGANCOUNTYTN.GOV,County,Non-Federal Agency,wartburg,TN,ACTIVE,8-May-14,8-May-15
-MORGANCOUNTYWV.GOV,County,Non-Federal Agency,Berkeley Springs,WV,ACTIVE,3-Mar-15,3-Mar-16
-MORRISCOUNTYNJ.GOV,County,Non-Federal Agency,Morristown,NJ,ACTIVE,25-Nov-14,25-Jan-16
-MORROWCOUNTYOHIO.GOV,County,Non-Federal Agency,Mount Gilead,OH,ACTIVE,7-Oct-14,7-Oct-15
-NAVAJOCOUNTYAZ.GOV,County,Non-Federal Agency,Holbrook,AZ,ACTIVE,5-May-14,1-Aug-15
-NOBLECOUNTYOHIO.GOV,County,Non-Federal Agency,Caldwell,OH,ACTIVE,2-Apr-14,5-Mar-15
-OAKLANDCOUNTYMI.GOV,County,Non-Federal Agency,Pontiac,MI,ACTIVE,15-Oct-14,30-Sep-15
-OGEMAWCOUNTYMI.GOV,County,Non-Federal Agency,West Branch,MI,ACTIVE,6-Oct-14,3-Jan-16
-OGLETHORPECOUNTYGA.GOV,County,Non-Federal Agency,Lexington,GA,ACTIVE,19-Dec-14,19-Dec-15
-OHIOCOUNTYKY.GOV,County,Non-Federal Agency,Hartford,KY,ACTIVE,4-Aug-14,24-Oct-15
-OHIOCOUNTYWV.GOV,County,Non-Federal Agency,Wheeling,WV,ACTIVE,17-Jan-15,18-Mar-16
-OLDHAMCOUNTYKY.GOV,County,Non-Federal Agency,La Grange,KY,ACTIVE,28-Jul-14,26-Aug-15
-ORANGECOUNTY-VA.GOV,County,Non-Federal Agency,ORANGE,VA,ACTIVE,1-Nov-12,16-Jul-13
-ORANGECOUNTYNC.GOV,County,Non-Federal Agency,Hillsborough,NC,ACTIVE,3-Oct-12,1-Dec-13
-ORANGECOUNTYVA.GOV,County,Non-Federal Agency,Orange,VA,ACTIVE,1-Nov-12,16-Jul-13
-ORLEANSCOUNTYNY.GOV,County,Non-Federal Agency,Albion,NY,ACTIVE,20-Oct-14,20-Oct-15
-OSWEGOCOUNTYNY.GOV,County,Non-Federal Agency,Oswego,NY,ACTIVE,29-Jan-14,29-Jan-15
-OTSEGOCOUNTYMI.GOV,County,Non-Federal Agency,Gaylord,MI,ACTIVE,2-Jul-14,30-Sep-15
-OURAYCOUNTYCO.GOV,County,Non-Federal Agency,Ouray,CO,ACTIVE,21-Aug-14,14-Sep-15
-PARKECOUNTY-IN.GOV,County,Non-Federal Agency,Rockville,IN,ACTIVE,5-Jan-15,5-Mar-16
-PENDERCOUNTYNC.GOV,County,Non-Federal Agency,Burgaw,NC,ACTIVE,22-Jul-14,3-Oct-15
-PERQUIMANSCOUNTYNC.GOV,County,Non-Federal Agency,Hertford,NC,ACTIVE,26-Feb-15,29-Apr-16
-PICKENSCOUNTYGA.GOV,County,Non-Federal Agency,Jasper,GA,ACTIVE,15-Aug-14,8-Nov-15
-PIERCECOUNTYGA.GOV,County,Non-Federal Agency,Blackshear,GA,ACTIVE,8-Apr-14,8-Apr-15
-PIERCECOUNTYND.GOV,County,Non-Federal Agency,Rugby,ND,ACTIVE,21-Apr-14,19-Jul-15
-PIERCECOUNTYWA.GOV,County,Non-Federal Agency,Tacoma,WA,ACTIVE,11-Sep-14,30-Sep-15
-PIKECOUNTY-MO.GOV,County,Non-Federal Agency,Bowling Green,MO,ACTIVE,18-Feb-15,19-Jan-16
-PIKECOUNTYKY.GOV,County,Non-Federal Agency,Pikeville,KY,ACTIVE,13-Oct-14,7-Jan-16
-PIMA.GOV,County,Non-Federal Agency,Tucson,AZ,ACTIVE,10-Jul-14,30-Sep-15
-PINALCOUNTYAZ.GOV,County,Non-Federal Agency,Florence,AZ,ACTIVE,5-Nov-14,20-Dec-15
-PINELLAS.GOV,County,Non-Federal Agency,Clearwater,FL,ACTIVE,26-Sep-14,26-Sep-15
-PITTCOUNTY-NC.GOV,County,Non-Federal Agency,Greenville,NC,ACTIVE,14-Sep-10,14-Sep-11
-PITTCOUNTYNC.GOV,County,Non-Federal Agency,Greenville,NC,ACTIVE,3-Sep-14,14-Sep-15
-PITTSYLVANIACOUNTYVA.GOV,County,Non-Federal Agency,Chatham,VA,ACTIVE,10-Oct-14,10-Oct-15
-PLYMOUTHCOUNTY-MA.GOV,County,Non-Federal Agency,Plymouth,MA,ACTIVE,25-Aug-14,22-Aug-15
-POLKCOUNTYIOWA.GOV,County,Non-Federal Agency,Des Moines,IA,ACTIVE,3-Jun-14,31-Aug-15
-PORTAGECOUNTYWI.GOV,County,Non-Federal Agency,Stevens Point,WI,ACTIVE,24-Jul-13,11-Dec-13
-POSEYCOUNTYIN.GOV,County,Non-Federal Agency,Mount Vernon,IN,ACTIVE,12-May-14,12-May-15
-POTTAWATTAMIECOUNTY-IA.GOV,County,Non-Federal Agency,COUNCIL BLUFFS,IA,ACTIVE,3-Feb-15,1-May-16
-POTTCOUNTY-IA.GOV,County,Non-Federal Agency,COUNCIL BLUFFS,IA,ACTIVE,3-Feb-15,1-May-16
-POWELLCOUNTYMT.GOV,County,Non-Federal Agency,Deer Lodge,MT,ACTIVE,17-Feb-15,1-Feb-16
-PRESTONCOUNTYWV.GOV,County,Non-Federal Agency,Kingwood,WV,ACTIVE,22-Sep-14,22-Sep-15
-PRINCEGEORGESCOUNTYMD.GOV,County,Non-Federal Agency,Largo,MD,ACTIVE,20-Aug-14,8-Sep-15
-PUEBLOCOUNTYCO.GOV,County,Non-Federal Agency,Pueblo,CO,ACTIVE,8-May-14,6-Aug-15
-PUTNAMCOUNTYNY.GOV,County,Non-Federal Agency,Carmel,NY,ACTIVE,9-Oct-14,18-Dec-15
-PUTNAMCOUNTYOHIO.GOV,County,Non-Federal Agency,Ottawa,OH,ACTIVE,28-Oct-14,5-Jan-16
-QUAYCOUNTY-NM.GOV,County,Non-Federal Agency,Tucumcari,NM,ACTIVE,15-Apr-14,15-May-15
-RANDOLPHCOUNTY-MO.GOV,County,Non-Federal Agency,Huntsville,MO,ACTIVE,2-Jun-14,29-Jan-15
-RANDOLPHCOUNTYALABAMA.GOV,County,Non-Federal Agency,Wedowee,AL,ACTIVE,25-Sep-12,25-Sep-13
-RANDOLPHCOUNTYNC.GOV,County,Non-Federal Agency,Asheboro,NC,ACTIVE,3-Mar-15,1-Jun-16
-RAPPAHANNOCKCOUNTYVA.GOV,County,Non-Federal Agency,Washington,VA,ACTIVE,8-Jan-15,8-Apr-16
-READYALBANYCOUNTY-NY.GOV,County,Non-Federal Agency,Albany,NY,ACTIVE,23-May-14,21-Aug-15
-READYHARRISCOUNTYTX.GOV,County,Non-Federal Agency,Houston,TX,ACTIVE,2-Jul-14,22-Jul-15
-READYMCHENRYCOUNTYIL.GOV,County,Non-Federal Agency,Woodstock,IL,ACTIVE,2-Apr-14,8-Apr-15
-READYMCHENRYCOUNTYILLINOIS.GOV,County,Non-Federal Agency,Woodstock,IL,ACTIVE,2-Apr-14,8-Apr-15
-REYNOLDSCOUNTY-MO.GOV,County,Non-Federal Agency,Centerville,MO,ACTIVE,18-Sep-14,14-Nov-15
-RILEYCOUNTYKS.GOV,County,Non-Federal Agency,Manhattan,KS,ACTIVE,30-Jun-14,28-Sep-15
-ROANECOUNTYTN.GOV,County,Non-Federal Agency,Kingston,TN,ACTIVE,26-Aug-14,25-Sep-15
-ROCKCOUNTY-WI.GOV,County,Non-Federal Agency,Janesville,WI,ACTIVE,14-Jul-14,15-Sep-15
-ROCKDALECOUNTYGA.GOV,County,Non-Federal Agency,Conyers,GA,ACTIVE,19-Nov-14,5-Jan-16
-ROSEBUDCOUNTYMT.GOV,County,Non-Federal Agency,Forsyth,MT,ACTIVE,29-Oct-14,27-Dec-15
-ROSSCOUNTYOHIO.GOV,County,Non-Federal Agency,Chillicothe,OH,ACTIVE,14-Jul-14,15-Aug-15
-RUTHERFORDCOUNTYNC.GOV,County,Non-Federal Agency,Rutherfordton,NC,ACTIVE,10-Jul-14,8-Sep-15
-RUTHERFORDCOUNTYTN.GOV,County,Non-Federal Agency,Murfreesboro,TN,ACTIVE,9-Dec-14,29-Jan-16
-SAGUACHECOUNTY-CO.GOV,County,Non-Federal Agency,Saguache,CO,ACTIVE,8-Apr-13,8-Apr-14
-SALEMCOUNTYNJ.GOV,County,Non-Federal Agency,Salem,NJ,ACTIVE,30-Sep-14,30-Sep-15
-SANDIEGOCOUNTY.GOV,County,Non-Federal Agency,San Diego,CA,ACTIVE,11-Aug-14,11-Aug-15
-SANDOVALCOUNTYNM.GOV,County,Non-Federal Agency,Bernalillo,NM,ACTIVE,5-Dec-14,27-Feb-16
-SANMIGUELCOUNTYCO.GOV,County,Non-Federal Agency,TELLURIDE,CO,ACTIVE,9-Dec-14,9-Dec-15
-SANPETECOUNTY-UT.GOV,County,Non-Federal Agency,Manti,UT,ACTIVE,2-Sep-14,30-Sep-15
-SANTACLARACOUNTYCA.GOV,County,Non-Federal Agency,San Jose,CA,ACTIVE,11-Feb-14,8-May-15
-SANTACRUZCOUNTYAZ.GOV,County,Non-Federal Agency,Nogales,AZ,ACTIVE,23-Oct-14,15-Oct-15
-SANTAFECOUNTYNM.GOV,County,Non-Federal Agency,Santa Fe,NM,ACTIVE,2-May-14,15-May-15
-SARATOGACOUNTYNY.GOV,County,Non-Federal Agency,Ballston Spa,NY,ACTIVE,16-Jan-15,16-Apr-16
-SBCOUNTY.GOV,County,Non-Federal Agency,San Bernardino,CA,ACTIVE,24-Jul-14,30-Sep-15
-SCOTTCOUNTY-TN.GOV,County,Non-Federal Agency,Huntsville,TN,ACTIVE,10-Jun-11,6-Jun-12
-SEBASTIANCOUNTYAR.GOV,County,Non-Federal Agency,Fort Smith,AR,ACTIVE,17-Apr-13,17-Apr-14
-SEQUATCHIECOUNTY-TN.GOV,County,Non-Federal Agency,Dunlap,TN,ACTIVE,11-Apr-13,22-Sep-13
-SEVIERCOUNTYTN.GOV,County,Non-Federal Agency,Sevierville,TN,ACTIVE,16-Aug-14,16-Aug-15
-SHARKEYCOUNTYMS.GOV,County,Non-Federal Agency,Rolling Fork,MS,ACTIVE,27-Jan-15,25-Mar-16
-SHELBYCOUNTYTN.GOV,County,Non-Federal Agency,Memphis,TN,ACTIVE,1-Aug-14,30-Sep-15
-SIERRACOUNTYNM.GOV,County,Non-Federal Agency,Truth or Consequences,NM,ACTIVE,20-Sep-12,9-Jul-12
-SONOMACOUNTYCA.GOV,County,Non-Federal Agency,Santa Rosa,CA,ACTIVE,2-Sep-14,1-Nov-15
-SPENCERCOUNTYKY.GOV,County,Non-Federal Agency,Taylorsville,KY,ACTIVE,12-Sep-14,30-Sep-15
-SPOTSYLVANIACOUNTY-VA.GOV,County,Non-Federal Agency,Spotsylvania,VA,ACTIVE,18-Sep-14,16-Sep-15
-SPOTSYLVANIACOUNTYVA.GOV,County,Non-Federal Agency,Spotsylvania,VA,ACTIVE,18-Sep-14,16-Sep-15
-STAFFORDCOUNTYVA.GOV,County,Non-Federal Agency,Stafford,VA,ACTIVE,25-Nov-14,8-Feb-16
-STANLYCOUNTYNC.GOV,County,Non-Federal Agency,Albemarle,NC,ACTIVE,16-Jul-14,14-Oct-15
-STARKCOUNTYND.GOV,County,Non-Federal Agency,Bismarck,ND,ACTIVE,11-Mar-15,9-Jun-16
-STARKCOUNTYOHIO.GOV,County,Non-Federal Agency,Canton,OH,ACTIVE,16-Oct-14,15-Nov-15
-STCHARLESPARISH-LA.GOV,County,Non-Federal Agency,Hahnville,LA,ACTIVE,4-Feb-14,1-May-15
-STCLAIRCOUNTYIL.GOV,County,Non-Federal Agency,Belleville,IL,ACTIVE,5-Jan-15,16-Jan-16
-STEARNSCOUNTYMN.GOV,County,Non-Federal Agency,Saint Cloud,MN,ACTIVE,2-Sep-14,2-Sep-15
-STEWARTCOUNTYGA.GOV,County,Non-Federal Agency,Lumpkin,GA,ACTIVE,25-Feb-14,8-Feb-15
-STLOUISCOUNTYMN.GOV,County,Non-Federal Agency,Duluth,MN,ACTIVE,7-Jan-15,22-Jan-16
-STMARYPARISHLA.GOV,County,Non-Federal Agency,FRANKLIN,LA,ACTIVE,5-Nov-14,31-Jan-16
-STOKESCOUNTYNC.GOV,County,Non-Federal Agency,Danbury,NC,ACTIVE,15-Jan-15,4-Feb-16
-STORYCOUNTYIOWA.GOV,County,Non-Federal Agency,Nevada,IA,ACTIVE,13-Jun-14,13-Jul-15
-SULLIVANCOUNTYTN.GOV,County,Non-Federal Agency,Blountville,TN,ACTIVE,18-Jun-14,13-Jun-15
-SUMMITCOUNTYCO.GOV,County,Non-Federal Agency,Breckenridge,CO,ACTIVE,4-Dec-14,4-Dec-15
-SUMTERCOUNTYFL.GOV,County,Non-Federal Agency,Bushnell,FL,ACTIVE,28-Mar-14,9-Jun-15
-SURRYCOUNTYVA.GOV,County,Non-Federal Agency,Surry,VA,ACTIVE,15-Dec-14,13-Jan-16
-SUSSEXCOUNTYDE.GOV,County,Non-Federal Agency,Georgetown,DE,ACTIVE,3-Jul-14,30-Sep-15
-SUSSEXCOUNTYVA.GOV,County,Non-Federal Agency,Sussex,VA,ACTIVE,20-Jan-15,14-Oct-15
-SWAINCOUNTYNC.GOV,County,Non-Federal Agency,Bryson City,NC,ACTIVE,8-Dec-14,6-Dec-15
-TALBOTCOUNTYMD.GOV,County,Non-Federal Agency,Easton,MD,ACTIVE,15-Jan-14,3-Apr-15
-TAMACOUNTYIOWA.GOV,County,Non-Federal Agency,Toledo,IA,ACTIVE,16-Dec-13,28-Jan-15
-TARRANTCOUNTYTX.GOV,County,Non-Federal Agency,Fort Worth,TX,ACTIVE,3-Sep-14,3-Aug-15
-TETONCOUNTYIDAHO.GOV,County,Non-Federal Agency,Driggs,ID,ACTIVE,18-Jul-13,30-Sep-13
-TEXASCOUNTYMISSOURI.GOV,County,Non-Federal Agency,Houston,MO,ACTIVE,13-May-14,30-Jul-15
-THAYERCOUNTYNE.GOV,County,Non-Federal Agency,Hebron,NE,ACTIVE,1-Dec-14,20-Feb-16
-THOMASCOUNTYGA.GOV,County,Non-Federal Agency,Thomasville,GA,ACTIVE,18-Jun-14,18-Jun-15
-TOMPKINSCOUNTYNY.GOV,County,Non-Federal Agency,Ithaca,NY,ACTIVE,17-Nov-14,16-Nov-15
-TOOELECOUNTYUT.GOV,County,Non-Federal Agency,Tooele,UT,ACTIVE,15-Jul-14,4-Sep-15
-TOOLECOUNTYMT.GOV,County,Non-Federal Agency,Shelby,MT,ACTIVE,30-Jul-14,23-Sep-15
-TOOMBSCOUNTYGA.GOV,County,Non-Federal Agency,Lyons,GA,ACTIVE,27-Feb-15,5-Mar-16
-TRAVISCOUNTYTX.GOV,County,Non-Federal Agency,Austin,TX,ACTIVE,11-Mar-15,23-May-16
-TROUSDALECOUNTYTN.GOV,County,Non-Federal Agency,Hartsville,TN,ACTIVE,17-Jun-14,17-Jun-15
-ULSTERCOUNTYNY.GOV,County,Non-Federal Agency,Kingston,NY,ACTIVE,29-Dec-14,10-Feb-16
-UNICOICOUNTYTN.GOV,County,Non-Federal Agency,Erwin,TN,ACTIVE,25-Sep-14,25-Oct-15
-UNIONCOUNTY-FL.GOV,County,Non-Federal Agency,Lake Butler,FL,ACTIVE,14-Dec-12,30-Nov-13
-UNIONCOUNTYGA.GOV,County,Non-Federal Agency,Blairsveille,GA,ACTIVE,3-Sep-14,30-Sep-15
-UNIONCOUNTYIL.GOV,County,Non-Federal Agency,Jonesboro,IL,ACTIVE,19-Aug-14,22-Jul-14
-UNIONCOUNTYIN.GOV,County,Non-Federal Agency,Liberty,IN,ACTIVE,21-May-14,28-Jun-15
-UNIONCOUNTYNC.GOV,County,Non-Federal Agency,Monroe,NC,ACTIVE,9-Feb-15,10-Apr-16
-UTAHCOUNTY.GOV,County,Non-Federal Agency,Provo,UT,ACTIVE,5-May-14,18-Jun-15
-VALLEYCOUNTYMT.GOV,County,Non-Federal Agency,Glasgow,MT,ACTIVE,11-Aug-14,28-Aug-15
-VANBURENCOUNTYIA.GOV,County,Non-Federal Agency,Keosauqua,IA,ACTIVE,20-Aug-14,20-Aug-15
-WARRENCOUNTYNC.GOV,County,Non-Federal Agency,Warrenton,NC,ACTIVE,14-Aug-14,14-Aug-15
-WARRENCOUNTYNY.GOV,County,Non-Federal Agency,Lake George,NY,ACTIVE,4-Dec-14,4-Mar-16
-WARRENCOUNTYTN.GOV,County,Non-Federal Agency,McMinnville,TN,ACTIVE,24-Sep-14,23-Dec-15
-WARRICKCOUNTY.GOV,County,Non-Federal Agency,Boonville,IN,ACTIVE,21-Aug-14,30-Sep-15
-WASHINGTONCOUNTYGA.GOV,County,Non-Federal Agency,Sandersville,GA,ACTIVE,6-Feb-13,2-May-14
-WAYNECOUNTYPA.GOV,County,Non-Federal Agency,Honesdale,PA,ACTIVE,16-Dec-14,29-Jan-16
-WEAKLEYCOUNTYTN.GOV,County,Non-Federal Agency,Dresden,TN,ACTIVE,14-Aug-14,30-Sep-15
-WEBSTERCOUNTYMO.GOV,County,Non-Federal Agency,Marshfield,MO,ACTIVE,18-Jul-14,6-Aug-15
-WESTFELICIANAPARISH-LA.GOV,County,Non-Federal Agency,St. Francisville,LA,ACTIVE,5-Mar-14,31-Mar-15
-WHITECOUNTYGA.GOV,County,Non-Federal Agency,Cleveland,GA,ACTIVE,5-Feb-15,26-Mar-16
-WHITECOUNTYTN.GOV,County,Non-Federal Agency,Sparta,TN,ACTIVE,11-Dec-14,25-Feb-16
-WHITEPINECOUNTYNV.GOV,County,Non-Federal Agency,Ely,NV,ACTIVE,11-Mar-15,7-May-16
-WILLCOUNTY-IL.GOV,County,Non-Federal Agency,Joliet,IL,ACTIVE,19-Dec-14,29-Dec-15
-WILLIAMSONCOUNTY-TN.GOV,County,Non-Federal Agency,Franklin,TN,ACTIVE,22-Aug-14,30-Sep-15
-WILLIAMSONCOUNTYIL.GOV,County,Non-Federal Agency,Marion,IL,ACTIVE,28-Jan-15,21-Mar-16
-WILSONCOUNTYTN.GOV,County,Non-Federal Agency,Lebanon,TN,ACTIVE,27-Jan-15,27-Jan-16
-WILSONCOUNTYTX.GOV,County,Non-Federal Agency,Floresville,TX,ACTIVE,10-Mar-15,10-Mar-16
-WINDHAMCOUNTYVT.GOV,County,Non-Federal Agency,Newfane,VT,ACTIVE,9-Mar-15,9-Mar-16
-WINNEBAGOCOUNTYIOWA.GOV,County,Non-Federal Agency,Forest City,IA,ACTIVE,8-Dec-14,7-Mar-16
-WORCESTERCOUNTYMD.GOV,County,Non-Federal Agency,Snow Hill,MD,ACTIVE,2-Jul-14,20-Jul-15
-YANCEYCOUNTYNC.GOV,County,Non-Federal Agency,Burnsville,NC,ACTIVE,4-Jun-14,10-Jul-15
-YAZOOCOUNTYMS.GOV,County,Non-Federal Agency,Yazoo City,MS,ACTIVE,27-Jan-15,19-Apr-16
-YCSOAZ.GOV,County,Non-Federal Agency,Prescott,AZ,ACTIVE,12-Feb-15,1-Mar-16
-YORKCOUNTY.GOV,County,Non-Federal Agency,Yorktown,VA,ACTIVE,18-Aug-14,30-Sep-15
-YORKCOUNTYME.GOV,County,Non-Federal Agency,Alfred,ME,ACTIVE,4-Sep-14,30-Sep-15
-YORKCOUNTYPA.GOV,County,Non-Federal Agency,York,PA,ACTIVE,18-Nov-13,9-Feb-15
-YUMACOUNTYARIZONA.GOV,County,Non-Federal Agency,Yuma,AZ,ACTIVE,21-Jan-15,21-Apr-16
-YUMACOUNTYAZ.GOV,County,Non-Federal Agency,Yuma,AZ,ACTIVE,21-Jan-15,21-Apr-16
-ACUS.GOV,Federal Agency,Administrative Conference of the United States,WASHINGTON,DC,ACTIVE,28-Apr-14,28-Apr-15
-ACHP.GOV,Federal Agency,Advisory Council on Historic Preservation,Washington,DC,ACTIVE,12-Sep-14,15-Sep-15
-PRESERVEAMERICA.GOV,Federal Agency,Advisory Council on Historic Preservation,Washington,DC,ACTIVE,12-Sep-14,15-Sep-15
-ADF.GOV,Federal Agency,African Development Foundation,Washington,DC,ACTIVE,8-Oct-14,30-Sep-15
-USADF.GOV,Federal Agency,African Development Foundation,Washington,DC,ACTIVE,4-Jun-14,1-Jul-15
-ABMC.GOV,Federal Agency,American Battle Monuments Commission,Arlington,VA,ACTIVE,15-Jul-14,9-Sep-15
-AMTRAKOIG.GOV,Federal Agency,AMTRAK,Washington,DC,ACTIVE,17-Apr-14,15-Jun-15
-ARC.GOV,Federal Agency,Appalachian Regional Commission,Washington,DC,ACTIVE,1-Oct-14,30-Sep-15
-ASC.GOV,Federal Agency,Appraisal Subcommittee,Washington,DC,ACTIVE,1-Aug-14,28-Sep-15
-AFRH.GOV,Federal Agency,Armed Forces Retirement Home,Washington,DC,ACTIVE,28-Aug-14,1-Sep-15
-CIA.GOV,Federal Agency,Central Intelligence Agency,Washington,DC,ACTIVE,3-Sep-14,10-Sep-15
-IC.GOV,Federal Agency,Central Intelligence Agency,Washington,DC,ACTIVE,3-Sep-14,10-Sep-15
-ISTAC.GOV,Federal Agency,Central Intelligence Agency,Washington,DC,ACTIVE,3-Sep-14,10-Sep-15
-NCTC.GOV,Federal Agency,Central Intelligence Agency,Washington,DC,ACTIVE,29-Jan-15,1-Feb-16
-ODCI.GOV,Federal Agency,Central Intelligence Agency,Washington,DC,ACTIVE,3-Sep-14,10-Sep-15
-OPENSOURCE.GOV,Federal Agency,Central Intelligence Agency,Washington,DC,ACTIVE,25-Nov-14,8-Dec-15
-OSDE.GOV,Federal Agency,Central Intelligence Agency,Reston,VA,ACTIVE,25-Nov-14,5-Jan-16
-TTIC.GOV,Federal Agency,Central Intelligence Agency,Washington,DC,ACTIVE,3-Sep-14,10-Sep-15
-UCIA.GOV,Federal Agency,Central Intelligence Agency,Washington,DC,ACTIVE,3-Sep-14,10-Sep-15
-CHRISTOPHERCOLUMBUSFOUNDATION.GOV,Federal Agency,Christopher Columbus Fellowship Foundation,Washington,DC,ACTIVE,8-May-14,24-May-15
-CAP.GOV,Federal Agency,Civil Air Patrol,BIRMINGHAM,MI,ACTIVE,5-Aug-14,30-Sep-15
-CAPNHQ.GOV,Federal Agency,Civil Air Patrol,MAXWELL AFB,AL,ACTIVE,9-Sep-14,30-Sep-15
-ABILITYONE.FED.US,Federal Agency,Comm for People Who Are Blind/Severly Disabled,Arlington,VA,ACTIVE,21-Jan-15,20-Apr-16
-ABILITYONE.GOV,Federal Agency,Comm for People Who Are Blind/Severly Disabled,Arlington,VA,ACTIVE,21-Jan-15,20-Apr-16
-JWOD.GOV,Federal Agency,Comm for People Who Are Blind/Severly Disabled,Arlington,VA,ACTIVE,7-Jul-14,30-Sep-15
-CFTC.GOV,Federal Agency,Commodity Futures Trading Commission,Washington,DC,ACTIVE,10-Jun-14,1-Sep-15
-SMARTCHECK.GOV,Federal Agency,Commodity Futures Trading Commission,Washington,DC,ACTIVE,20-Jan-15,20-Jan-16
-COMPLIANCE.GOV,Federal Agency,Congressional Office of Compliance,Washington,DC,ACTIVE,28-Aug-14,3-Sep-15
-BCFP.GOV,Federal Agency,Consumer Financial Protection Bureau,Washington,DC,ACTIVE,4-Aug-14,30-Aug-15
-CFPA.GOV,Federal Agency,Consumer Financial Protection Bureau,Washington,DC,ACTIVE,4-Aug-14,30-Aug-15
-CFPB.GOV,Federal Agency,Consumer Financial Protection Bureau,Washington,DC,ACTIVE,4-Aug-14,30-Aug-15
-CONSUMERBUREAU.GOV,Federal Agency,Consumer Financial Protection Bureau,Washington,DC,ACTIVE,14-Jan-15,5-Apr-16
-CONSUMERFINANCE.GOV,Federal Agency,Consumer Financial Protection Bureau,Washington,DC,ACTIVE,1-Dec-14,26-Jan-16
-CONSUMERFINANCIAL.GOV,Federal Agency,Consumer Financial Protection Bureau,Washington,DC,ACTIVE,14-Jan-15,5-Apr-16
-CONSUMERFINANCIALBUREAU.GOV,Federal Agency,Consumer Financial Protection Bureau,Washington,DC,ACTIVE,1-Dec-14,26-Jan-16
-CONSUMERFINANCIALPROTECTIONBUREAU.GOV,Federal Agency,Consumer Financial Protection Bureau,Washington,DC,ACTIVE,1-Dec-14,26-Jan-16
-CONSUMERPROTECTION.GOV,Federal Agency,Consumer Financial Protection Bureau,Washington,DC,ACTIVE,4-Aug-14,30-Aug-15
-CONSUMERPROTECTIONBUREAU.GOV,Federal Agency,Consumer Financial Protection Bureau,Washington,DC,ACTIVE,1-Dec-14,26-Jan-16
-ATVSAFETY.GOV,Federal Agency,Consumer Product Safety Commission,Bethesda,MD,ACTIVE,1-Aug-14,9-Aug-15
-CPSC.GOV,Federal Agency,Consumer Product Safety Commission,Bethesda,MD,ACTIVE,1-Aug-14,30-Sep-15
-DRYWALLRESPONSE.GOV,Federal Agency,Consumer Product Safety Commission,Bethesda,MD,ACTIVE,4-Apr-14,12-May-15
-POOLSAFELY.GOV,Federal Agency,Consumer Product Safety Commission,Bethesda,MD,ACTIVE,4-Apr-14,22-Apr-15
-POOLSAFETY.GOV,Federal Agency,Consumer Product Safety Commission,Bethesda,MD,ACTIVE,4-Apr-14,14-Apr-15
-RECALLS.GOV,Federal Agency,Consumer Product Safety Commission,Bethesda,MD,ACTIVE,1-Aug-14,30-Sep-15
-SAFERPRODUCT.GOV,Federal Agency,Consumer Product Safety Commission,Bethesda,MD,ACTIVE,1-Aug-14,1-Sep-15
-SAFERPRODUCTS.GOV,Federal Agency,Consumer Product Safety Commission,Bethesda,MD,ACTIVE,1-Aug-14,1-Sep-15
-SEGURIDADCONSUMIDOR.GOV,Federal Agency,Consumer Product Safety Commission,Bethesda,MD,ACTIVE,4-Apr-14,17-May-15
-AMERICORE.GOV,Federal Agency,Corporation for National & Community Service,Washington,DC,ACTIVE,17-Sep-14,27-Sep-15
-AMERICORP.GOV,Federal Agency,Corporation for National & Community Service,Washington,DC,ACTIVE,17-Sep-14,27-Sep-15
-AMERICORPS.GOV,Federal Agency,Corporation for National & Community Service,Washington,DC,ACTIVE,17-Sep-14,27-Sep-15
-AMERICORPSCONNECT.GOV,Federal Agency,Corporation for National & Community Service,Washington,DC,ACTIVE,13-Jun-14,29-Jul-15
-AMERICORPSWEEK.GOV,Federal Agency,Corporation for National & Community Service,Washington,DC,ACTIVE,19-Nov-14,28-Nov-15
-CNCS.GOV,Federal Agency,Corporation for National & Community Service,Washington,DC,ACTIVE,17-Sep-14,27-Sep-15
-CNCSOIG.GOV,Federal Agency,Corporation for National & Community Service,Washington,DC,ACTIVE,29-Aug-14,30-Sep-15
-CNS.GOV,Federal Agency,Corporation for National & Community Service,Washington,DC,ACTIVE,17-Sep-14,27-Sep-15
-FEDERALMENTORINGCOUNCIL.GOV,Federal Agency,Corporation for National & Community Service,Washington,DC,ACTIVE,7-Jan-15,7-Jan-16
-GETINVOLVED.GOV,Federal Agency,Corporation for National & Community Service,Washington ,DC,ACTIVE,19-Nov-14,1-Dec-15
-LEARNANDSERVE.GOV,Federal Agency,Corporation for National & Community Service,Washington,DC,ACTIVE,19-Feb-15,4-Mar-16
-MLKDAY.GOV,Federal Agency,Corporation for National & Community Service,Washington,DC,ACTIVE,19-Feb-15,4-Mar-16
-NATIONALSERVICE.GOV,Federal Agency,Corporation for National & Community Service,Washington,DC,ACTIVE,19-Feb-15,4-Mar-16
-NATIONALSERVICEGEAR.GOV,Federal Agency,Corporation for National & Community Service,Washington,DC,ACTIVE,23-Dec-14,22-Dec-15
-NATIONALSERVICERESOURCES.GOV,Federal Agency,Corporation for National & Community Service,Washington,DC,ACTIVE,13-Jun-14,29-Jul-15
-PRESIDENTIALSERVICEAWARDS.GOV,Federal Agency,Corporation for National & Community Service,Washington,DC,ACTIVE,17-Sep-14,27-Sep-15
-SENIORCORPS.GOV,Federal Agency,Corporation for National & Community Service,Washington,DC,ACTIVE,19-Feb-15,4-Mar-16
-SERVE.GOV,Federal Agency,Corporation for National & Community Service,Washington,DC,ACTIVE,17-Sep-14,27-Sep-15
-SERVICE.GOV,Federal Agency,Corporation for National & Community Service,Washington,DC,ACTIVE,9-Jun-14,9-Jun-15
-SERVICELEARNING.GOV,Federal Agency,Corporation for National & Community Service,Washington ,DC,ACTIVE,13-Jun-14,29-Jul-15
-SERVIR.GOV,Federal Agency,Corporation for National & Community Service,Washington,DC,ACTIVE,15-Jul-14,6-Aug-15
-VISTA.GOV,Federal Agency,Corporation for National & Community Service,Washington,DC,ACTIVE,19-Feb-15,22-Mar-16
-VISTACAMPUS.GOV,Federal Agency,Corporation for National & Community Service,Washington,DC,ACTIVE,13-Jun-14,29-Jul-15
-VOLUNTEERINGINAMERICA.GOV,Federal Agency,Corporation for National & Community Service,Washington,DC,ACTIVE,1-May-14,16-May-15
-CIGIE.GOV,Federal Agency,Council of Inspector General on Integrity and Efficiency,WASHINGTON,DC,ACTIVE,9-May-14,29-Jun-15
-IGNET.GOV,Federal Agency,Council of Inspector General on Integrity and Efficiency,Washington,DC,ACTIVE,11-Sep-14,22-Sep-15
-CSOSA.FED.US,Federal Agency,Court Services and Offender Supervision,Washington,DC,ACTIVE,22-Sep-14,30-Sep-15
-CSOSA.GOV,Federal Agency,Court Services and Offender Supervision,Washington,DC,ACTIVE,22-Sep-14,30-Sep-15
-DCPSA.GOV,Federal Agency,Court Services and Offender Supervision,Washington,DC,SERVER-HOLD,2-Jul-12,30-Sep-13
-PRETRIALSERVICES.GOV,Federal Agency,Court Services and Offender Supervision,Washington,DC,ACTIVE,26-Jun-14,24-Sep-15
-PSA.GOV,Federal Agency,Court Services and Offender Supervision,Washington,DC,ACTIVE,23-Oct-14,12-Jan-16
-DNFSB.GOV,Federal Agency,Defense Nuclear Facilities Safety Board,Washington,DC,ACTIVE,7-Aug-14,30-Sep-15
-DRA.GOV,Federal Agency,Delta Regional Authority,Clarksdale,MS,ACTIVE,29-Apr-14,30-Sep-14
-DENALI.GOV,Federal Agency,Denali Commission,Anchorage,AK,ACTIVE,17-Jun-14,14-Sep-15
-AFF.GOV,Federal Agency,Department of Agriculture,Boise,ID,ACTIVE,1-Oct-14,30-Sep-15
-AG.GOV,Federal Agency,Department of Agriculture,Fort Collins,CO,ACTIVE,2-Jul-14,30-Sep-15
-ARS-GRIN.GOV,Federal Agency,Department of Agriculture,Beltsville,MD,ACTIVE,17-Jul-14,15-Sep-15
-ARSUSDA.GOV,Federal Agency,Department of Agriculture,Beltsville,MD,ACTIVE,7-Jul-14,20-Sep-15
-ASKKAREN.GOV,Federal Agency,Department of Agriculture,Washington,DC,ACTIVE,29-Jul-14,19-Sep-15
-BEFOODSAFE.GOV,Federal Agency,Department of Agriculture,Washington,DC,ACTIVE,29-Jul-14,24-Aug-15
-BIOPREFERRED.GOV,Federal Agency,Department of Agriculture,Washington,DC,ACTIVE,22-Oct-14,22-Oct-15
-CHOOSEMYPLATE.GOV,Federal Agency,Department of Agriculture,Alexandria,VA,ACTIVE,11-Mar-15,31-May-16
-COASTALAMERICA.GOV,Federal Agency,Department of Agriculture,Washington,DC,ACTIVE,9-Sep-14,17-Sep-15
-DIETARYGUIDELINES.GOV,Federal Agency,Department of Agriculture,Alexandria,VA,ACTIVE,30-Apr-14,8-Jul-15
-EMPOWHR.GOV,Federal Agency,Department of Agriculture,New Orleans,LA,ACTIVE,17-Oct-14,26-Oct-15
-EXECSEC.GOV,Federal Agency,Department of Agriculture,Washington,DC,ACTIVE,12-Sep-14,30-Sep-15
-FARMERCLAIMS.GOV,Federal Agency,Department of Agriculture,St. Louis,MO,ACTIVE,13-Jun-14,12-Aug-15
-FEMALEFARMERCLAIMS.GOV,Federal Agency,Department of Agriculture,St. Louis,MO,ACTIVE,13-Jun-14,12-Aug-15
-FIREINSTITUTE.GOV,Federal Agency,Department of Agriculture,Tucson,AZ,ACTIVE,15-Oct-14,7-Dec-15
-FOODSAFETYJOBS.GOV,Federal Agency,Department of Agriculture,Washington,DC,ACTIVE,29-Aug-14,30-Sep-15
-FOODSAFETYWORKINGGROUP.GOV,Federal Agency,Department of Agriculture,Washington,DC,ACTIVE,29-Aug-14,23-Apr-15
-FORESTSANDRANGELANDS.GOV,Federal Agency,Department of Agriculture,Washington,DC,ACTIVE,2-Mar-15,23-May-16
-FS.FED.US,Federal Agency,Department of Agriculture,Washington,DC,ACTIVE,3-Sep-14,30-Sep-15
-FSWG.GOV,Federal Agency,Department of Agriculture,Washington,DC,ACTIVE,29-Aug-14,23-Apr-15
-GREEN.GOV,Federal Agency,Department of Agriculture,Washington,DC,ACTIVE,7-Jan-15,30-Sep-15
-HISPANICFARMERCLAIMS.GOV,Federal Agency,Department of Agriculture,St. Louis,MO,ACTIVE,13-Jun-14,12-Aug-15
-ICBEMP.GOV,Federal Agency,Department of Agriculture,Portland,OR,ACTIVE,9-Jul-14,30-Sep-15
-IIOG.GOV,Federal Agency,Department of Agriculture,Meridian,ID,ACTIVE,5-Dec-14,20-Jan-16
-INVASIVESPECIESINFO.GOV,Federal Agency,Department of Agriculture,Beltsville,MD,ACTIVE,29-Aug-14,23-Aug-15
-IPM.GOV,Federal Agency,Department of Agriculture,Washington,DC,ACTIVE,25-Nov-14,12-Jan-16
-ISITDONEYET.GOV,Federal Agency,Department of Agriculture,Washington,DC,ACTIVE,29-Jul-14,30-Sep-15
-ITAP.GOV,Federal Agency,Department of Agriculture,Beltsville,MD,ACTIVE,17-Jul-14,16-Jun-15
-JUNIORFORESTRANGER.GOV,Federal Agency,Department of Agriculture,Washington,DC,ACTIVE,1-Jul-14,20-Sep-15
-LATINOFARMERCLAIMS.GOV,Federal Agency,Department of Agriculture,St. Louis,MO,ACTIVE,13-Jun-14,12-Aug-15
-LCACOMMONS.GOV,Federal Agency,Department of Agriculture,Beltsville,MD,ACTIVE,14-May-14,28-Apr-15
-MTBS.GOV,Federal Agency,Department of Agriculture,Salt Lake City,UT,ACTIVE,25-Jul-14,17-Aug-15
-NAFRI.GOV,Federal Agency,Department of Agriculture,Tucson,AZ,ACTIVE,10-Jul-14,30-Aug-15
-NEL.GOV,Federal Agency,Department of Agriculture,Alexandria,VA,ACTIVE,4-Nov-14,25-Jan-16
-NSTL.GOV,Federal Agency,Department of Agriculture,Ames,IA,ACTIVE,10-Jul-14,30-Sep-15
-NUTRITION.GOV,Federal Agency,Department of Agriculture,Washington,DC,ACTIVE,29-Aug-14,30-Sep-15
-NUTRITIONEVIDENCELIBRARY.GOV,Federal Agency,Department of Agriculture,Alexandria,VA,ACTIVE,4-Nov-14,25-Jan-16
-NWCG.GOV,Federal Agency,Department of Agriculture,Boise,ID,ACTIVE,13-Aug-14,30-Sep-15
-PREGUNTELEAKAREN.GOV,Federal Agency,Department of Agriculture,Washington,DC,ACTIVE,29-Jul-14,20-Aug-15
-RECREATION.GOV,Federal Agency,Department of Agriculture,Ogden,UT,ACTIVE,2-Oct-14,30-Sep-15
-REO.GOV,Federal Agency,Department of Agriculture,Portland,OR,ACTIVE,22-Oct-13,30-Sep-14
-SMOKEYBEAR.GOV,Federal Agency,Department of Agriculture,Washington,DC,ACTIVE,1-Jul-14,20-Sep-15
-START2FARM.GOV,Federal Agency,Department of Agriculture,Beltsville,MD,ACTIVE,27-Jan-15,27-Jan-16
-SYMBOLS.GOV,Federal Agency,Department of Agriculture,Washington,DC,ACTIVE,1-Jul-14,20-Sep-15
-THEPEOPLESGARDEN.GOV,Federal Agency,Department of Agriculture,Wahington,DC,ACTIVE,4-Sep-14,14-Jun-15
-USDA.GOV,Federal Agency,Department of Agriculture,Ft. Collins,CO,ACTIVE,17-Oct-14,12-Oct-15
-USDAPII.GOV,Federal Agency,Department of Agriculture,Washington,DC,ACTIVE,17-Oct-14,12-Oct-15
-VALLESCALDERA.GOV,Federal Agency,Department of Agriculture,Jemez Springs,NM,ACTIVE,25-Aug-14,30-Sep-15
-WILDFIRE.GOV,Federal Agency,Department of Agriculture,Boise,ID,ACTIVE,2-Mar-15,16-Apr-16
-WOMENFARMERCLAIMS.GOV,Federal Agency,Department of Agriculture,St. Louis,MO,ACTIVE,13-Jun-14,12-Aug-15
-WOODSY.GOV,Federal Agency,Department of Agriculture,Washington,DC,ACTIVE,1-Jul-14,20-Sep-15
-WOODSYOWL.GOV,Federal Agency,Department of Agriculture,Washington,DC,ACTIVE,1-Jul-14,20-Sep-15
-AP.GOV,Federal Agency,Department of Commerce,Washington,DC,ACTIVE,21-Aug-14,30-Sep-15
-AVIATIONWEATHER.GOV,Federal Agency,Department of Commerce,Silver Spring,MD,ACTIVE,9-Jul-14,3-Sep-15
-BEA.GOV,Federal Agency,Department of Commerce,Washington,DC,ACTIVE,26-Aug-14,23-Sep-15
-BLDRDOC.GOV,Federal Agency,Department of Commerce,Boulder,CO,ACTIVE,25-Jun-14,23-Sep-15
-BUYUSA.GOV,Federal Agency,Department of Commerce,Washington,DC,ACTIVE,3-Jul-14,30-Sep-15
-CBP.GOV,Federal Agency,Department of Commerce,Alexandria,VA,ACTIVE,30-Sep-14,30-Sep-15
-CENSUS.GOV,Federal Agency,Department of Commerce,Suitland,MD,ACTIVE,1-Aug-14,30-Sep-15
-CIVILRIGHTSUSA.GOV,Federal Agency,Department of Commerce,Alexandria,VA,ACTIVE,19-Nov-14,20-Oct-15
-CLIMATE.GOV,Federal Agency,Department of Commerce,Silver Spring,MD,ACTIVE,21-Jul-14,30-Sep-15
-CLIMATECHANGE.GOV,Federal Agency,Department of Commerce,Oak Ridge,TN,ACTIVE,21-Aug-14,27-Aug-15
-COMMERCE.GOV,Federal Agency,Department of Commerce,Washington,DC,ACTIVE,10-Sep-14,30-Sep-15
-COOP-USPTO.GOV,Federal Agency,Department of Commerce,Arlington,VA,ACTIVE,20-Aug-14,30-Sep-15
-DIGITALLITERACY.GOV,Federal Agency,Department of Commerce,Washington,DC,ACTIVE,12-Sep-14,7-Dec-15
-DNSOPS.GOV,Federal Agency,Department of Commerce,Gaithersburg,MD,ACTIVE,27-Feb-15,25-May-16
-DOC.GOV,Federal Agency,Department of Commerce,Washington,DC,ACTIVE,10-Sep-14,30-Sep-15
-DROUGHT.GOV,Federal Agency,Department of Commerce,Asheville,NC,ACTIVE,26-Aug-14,3-Nov-15
-E3.GOV,Federal Agency,Department of Commerce,Gaithersburg,MD,ACTIVE,24-Oct-14,21-Jan-16
-EDA.GOV,Federal Agency,Department of Commerce,Washington,DC,ACTIVE,29-Aug-14,14-Sep-15
-ESA.GOV,Federal Agency,Department of Commerce,Washington,DC,ACTIVE,2-Apr-14,21-Apr-15
-EXPORT.GOV,Federal Agency,Department of Commerce,Washington,DC,ACTIVE,3-Jul-14,30-Sep-15
-FCSM.GOV,Federal Agency,Department of Commerce,Suitland,MD,ACTIVE,9-Aug-13,30-Sep-14
-FEDSTATS.GOV,Federal Agency,Department of Commerce,Washington,DC,ACTIVE,25-Sep-13,30-Sep-14
-FIRSTNET.GOV,Federal Agency,Department of Commerce,Washington,DC,ACTIVE,12-Sep-14,21-Nov-15
-FISHWATCH.GOV,Federal Agency,Department of Commerce,Silver Spring,MD,ACTIVE,29-Aug-14,18-Oct-15
-GETYOUHOME.GOV,Federal Agency,Department of Commerce,Alexandria,VA,ACTIVE,30-Sep-14,2-Sep-15
-GLOBALENTRY.GOV,Federal Agency,Department of Commerce,Alexandria,VA,ACTIVE,13-Jun-14,10-Jun-15
-GOES-R.GOV,Federal Agency,Department of Commerce,Greenbelt,MD,ACTIVE,7-Nov-14,5-Feb-16
-GPS.GOV,Federal Agency,Department of Commerce,Washington,DC,ACTIVE,22-Jul-14,15-Sep-15
-HURRICANES.GOV,Federal Agency,Department of Commerce,Miami,FL,ACTIVE,8-Aug-14,10-Oct-15
-ITDS.GOV,Federal Agency,Department of Commerce,Springfield,VA,ACTIVE,30-Sep-14,30-Sep-15
-MANUFACTURING.GOV,Federal Agency,Department of Commerce,Washington,DC,ACTIVE,2-Jul-14,30-Sep-15
-MAPSTATS.GOV,Federal Agency,Department of Commerce,Washington,DC,ACTIVE,25-Sep-13,30-Sep-14
-MARINECADASTRE.GOV,Federal Agency,Department of Commerce,Charleston,SC,ACTIVE,1-Jul-14,30-Aug-15
-MBDA.GOV,Federal Agency,Department of Commerce,Washington,DC,ACTIVE,10-Sep-14,30-Sep-15
-NEHRP.GOV,Federal Agency,Department of Commerce,Gaithersburg,MD,ACTIVE,9-Dec-14,9-Mar-16
-NIST.GOV,Federal Agency,Department of Commerce,Gaithersburg,MD,ACTIVE,25-Jun-14,23-Sep-15
-NOAA.GOV,Federal Agency,Department of Commerce,Silver Spring,MD,ACTIVE,12-Aug-14,17-Sep-15
-NOAAWATCH.GOV,Federal Agency,Department of Commerce,Silver Spring,MD,ACTIVE,5-Jun-14,25-May-15
-NTIS.GOV,Federal Agency,Department of Commerce,Alexandria,VA,ACTIVE,19-Nov-14,16-Nov-15
-OFCM.GOV,Federal Agency,Department of Commerce,Silver Spring,MD,ACTIVE,19-Aug-14,28-Sep-15
-PAPAHANAUMOKUAKEA.GOV,Federal Agency,Department of Commerce,Silver Spring,MD,ACTIVE,18-Feb-15,3-Apr-16
-PSCR.GOV,Federal Agency,Department of Commerce,Boulder,CO,ACTIVE,11-Aug-14,3-Aug-15
-RESTORETHEGULF.GOV,Federal Agency,Department of Commerce,Silver Spring,MD,ACTIVE,13-Aug-14,15-Jun-15
-SDR.GOV,Federal Agency,Department of Commerce,Washington,DC,ACTIVE,1-Jul-14,30-Sep-15
-SELECTUSA.GOV,Federal Agency,Department of Commerce,Washington,DC,ACTIVE,10-Sep-14,16-Sep-15
-SPACEWEATHER.GOV,Federal Agency,Department of Commerce,Boulder,CO,ACTIVE,7-Jul-14,30-Sep-15
-SPECTRUM.GOV,Federal Agency,Department of Commerce,Washington,DC,ACTIVE,25-Nov-14,13-Dec-15
-STANDARDS.GOV,Federal Agency,Department of Commerce,Gaithersburg,MD,ACTIVE,25-Jun-14,23-Sep-15
-TIME.GOV,Federal Agency,Department of Commerce,Boulder,CO,ACTIVE,2-Jul-14,30-Sep-15
-TRADE.GOV,Federal Agency,Department of Commerce,Washington,DC,ACTIVE,3-Jul-14,30-Sep-15
-TSUNAMI.GOV,Federal Agency,Department of Commerce,Palmer,AK,ACTIVE,1-Aug-14,30-Sep-15
-USPTO.GOV,Federal Agency,Department of Commerce,Washington,DC,ACTIVE,20-Aug-14,30-Sep-15
-WDOL.GOV,Federal Agency,Department of Commerce,Alexandria,VA,ACTIVE,30-Sep-14,30-Sep-15
-WEATHER.GOV,Federal Agency,Department of Commerce,Silver Spring,MD,ACTIVE,1-Aug-14,30-Sep-15
-ADLNET.GOV,Federal Agency,Department of Defense,Washington,DC,ACTIVE,22-Jan-15,14-Dec-15
-AFTAC.GOV,Federal Agency,Department of Defense,Patrick AFB,FL,ACTIVE,7-Aug-14,30-Sep-15
-ALTUSANDC.GOV,Federal Agency,Department of Defense,"patrick, afb",FL,ACTIVE,7-Aug-14,30-Sep-15
-BRAC.GOV,Federal Agency,Department of Defense,Alexandria,VA,ACTIVE,26-Mar-14,10-May-15
-CMTS.GOV,Federal Agency,Department of Defense,Mobile,AL,ACTIVE,17-Jul-14,5-Jul-15
-CNSS.GOV,Federal Agency,Department of Defense,Ft George G. Meade,MD,ACTIVE,1-May-14,15-Feb-15
-CTTSO.GOV,Federal Agency,Department of Defense,Arlington,VA,ACTIVE,10-Sep-14,30-Sep-15
-DEFENSE.GOV,Federal Agency,Department of Defense,Fort Meade,MD,ACTIVE,4-Sep-14,30-Sep-15
-DOD.GOV,Federal Agency,Department of Defense,Fort Meade,MD,ACTIVE,4-Sep-14,30-Sep-15
-EACLEARINGHOUSE.GOV,Federal Agency,Department of Defense,Arlington,VA,ACTIVE,4-Nov-14,30-Dec-15
-ERDC.GOV,Federal Agency,Department of Defense,Vicksburg,MS,ACTIVE,6-Aug-14,6-Aug-15
-FVAP.GOV,Federal Agency,Department of Defense,Alexandria,VA,ACTIVE,3-Oct-14,30-Sep-15
-IAD.GOV,Federal Agency,Department of Defense,Ft Meade,MD,ACTIVE,5-Dec-14,29-Sep-15
-IOSS.GOV,Federal Agency,Department of Defense,Greenbelt,MD,ACTIVE,20-Aug-14,30-Sep-15
-ITC.GOV,Federal Agency,Department of Defense,Ft. Washington,MD,ACTIVE,19-Nov-14,30-Sep-15
-JCCS.GOV,Federal Agency,Department of Defense,Alexandria,VA,ACTIVE,9-Apr-14,11-May-15
-MCRMC.GOV,Federal Agency,Department of Defense,Arlington,VA,ACTIVE,2-Sep-14,18-Sep-15
-MOJAVEDATA.GOV,Federal Agency,Department of Defense,Barstow,CA,ACTIVE,4-Nov-14,4-Nov-15
-MTMC.GOV,Federal Agency,Department of Defense,Alexandria,VA,ACTIVE,28-Jul-14,28-Jul-15
-MYPAY.GOV,Federal Agency,Department of Defense,Pensacola,FL,ACTIVE,4-Sep-14,30-Sep-15
-NCR.GOV,Federal Agency,Department of Defense,Washington,DC,ACTIVE,3-Oct-14,3-Sep-15
-NRO.GOV,Federal Agency,Department of Defense,Chantilly,VA,ACTIVE,14-Aug-14,30-Sep-15
-NROJR.GOV,Federal Agency,Department of Defense,Chantilly,VA,ACTIVE,14-Aug-14,30-Sep-15
-NSA.GOV,Federal Agency,Department of Defense,Ft. Meade,MD,ACTIVE,3-Jul-14,30-Sep-15
-NSEP.GOV,Federal Agency,Department of Defense,Arlington,VA,ACTIVE,6-Nov-14,6-Dec-15
-OEA.GOV,Federal Agency,Department of Defense,Arlington,VA,ACTIVE,12-Aug-14,30-Sep-15
-OSDBU.GOV,Federal Agency,Department of Defense,Washington,DC,ACTIVE,24-Oct-14,30-Sep-15
-PENTAGON.GOV,Federal Agency,Department of Defense,Fort Meade,MD,ACTIVE,4-Sep-14,30-Sep-15
-SAFEXCHANGE.GOV,Federal Agency,Department of Defense,Falls Church,VA,ACTIVE,17-Jul-14,30-Sep-15
-SITEIDIQ.GOV,Federal Agency,Department of Defense,Arlington,VA,ACTIVE,11-Dec-14,9-Nov-15
-TSWG.GOV,Federal Agency,Department of Defense,Arlington,VA,ACTIVE,10-Sep-14,15-Nov-15
-USANDC.GOV,Federal Agency,Department of Defense,Patrick AFB,FL,ACTIVE,7-Aug-14,30-Sep-15
-AAPI.GOV,Federal Agency,Department of Education,Washington,DC,ACTIVE,12-Mar-15,23-Mar-16
-BFELOB.GOV,Federal Agency,Department of Education,Washington,DC,ACTIVE,22-Oct-14,23-Oct-15
-CHILDSTATS.GOV,Federal Agency,Department of Education,Washington,DC,ACTIVE,9-Jul-14,30-Sep-15
-COLLEGE.GOV,Federal Agency,Department of Education,Washington,DC,ACTIVE,12-Mar-14,18-Mar-15
-COLLEGENAVIGATOR.GOV,Federal Agency,Department of Education,Washington,DC,ACTIVE,26-Jan-15,27-Feb-16
-ED.GOV,Federal Agency,Department of Education,Washington,DC,ACTIVE,9-Jul-14,30-Sep-15
-EDPUBS.GOV,Federal Agency,Department of Education,Washington ,DC,ACTIVE,22-Oct-14,10-Nov-15
-EDUCATION.GOV,Federal Agency,Department of Education,Washington,DC,ACTIVE,26-Jan-15,27-Feb-16
-FAFSA.GOV,Federal Agency,Department of Education,Washington,DC,ACTIVE,26-Jan-15,27-Feb-16
-FSAPUBS.GOV,Federal Agency,Department of Education,Washington,DC,ACTIVE,22-Oct-14,20-Oct-15
-G5.GOV,Federal Agency,Department of Education,Washington,DC,ACTIVE,12-Mar-15,11-Apr-16
-NAGB.GOV,Federal Agency,Department of Education,Washington,DC,ACTIVE,12-Mar-15,24-Mar-16
-NATIONSREPORTCARD.GOV,Federal Agency,Department of Education,Washington,DC,ACTIVE,12-Mar-15,11-Apr-16
-OPPORTUNITY.GOV,Federal Agency,Department of Education,Washington,DC,ACTIVE,10-Sep-14,1-May-15
-STUDENTAID.GOV,Federal Agency,Department of Education,Washington,DC,ACTIVE,28-May-14,12-Jul-15
-STUDENTLOANS.GOV,Federal Agency,Department of Education,Washington,DC,ACTIVE,26-Jan-15,27-Feb-16
-AMESLAB.GOV,Federal Agency,Department of Energy,Ames,IA,ACTIVE,15-Sep-14,30-Sep-15
-ANL.GOV,Federal Agency,Department of Energy,Argonne,IL,ACTIVE,23-Jul-14,30-Sep-15
-ARM.GOV,Federal Agency,Department of Energy,Richland,WA,ACTIVE,30-Jul-14,30-Sep-15
-BIOMASSBOARD.GOV,Federal Agency,Department of Energy,Washington,DC,ACTIVE,18-Dec-14,19-Dec-15
-BNL.GOV,Federal Agency,Department of Energy,Upton,NY,ACTIVE,11-Aug-14,30-Sep-15
-BPA.GOV,Federal Agency,Department of Energy,Portland,OR,ACTIVE,17-Jul-14,2-Sep-15
-BRC.GOV,Federal Agency,Department of Energy,Washington,DC,ACTIVE,6-Feb-15,6-Apr-16
-BUILDINGAMERICA.GOV,Federal Agency,Department of Energy,Golden,CO,ACTIVE,28-Aug-14,30-Sep-15
-CASL.GOV,Federal Agency,Department of Energy,Oak Ridge,TN,ACTIVE,1-Apr-14,29-Jun-15
-CEBAF.GOV,Federal Agency,Department of Energy,Newport News,VA,ACTIVE,5-Aug-14,30-Sep-15
-CENDI.GOV,Federal Agency,Department of Energy,Oak Ridge,TN,ACTIVE,14-Nov-14,16-Nov-15
-CRT2014-2024REVIEW.GOV,Federal Agency,Department of Energy,Portland,OR,ACTIVE,16-Jan-15,5-Mar-16
-DOE.GOV,Federal Agency,Department of Energy,Washington,DC,ACTIVE,26-Aug-14,30-Sep-15
-DOEAL.GOV,Federal Agency,Department of Energy,Albuquerque,NM,ACTIVE,27-Aug-14,30-Sep-15
-EIA.GOV,Federal Agency,Department of Energy,Washington,DC,ACTIVE,17-Jul-14,8-Oct-15
-ENERGY.GOV,Federal Agency,Department of Energy,Washington,DC,ACTIVE,26-Aug-14,30-Sep-15
-ENERGYCODES.GOV,Federal Agency,Department of Energy,Richland,WA,ACTIVE,15-Jul-14,30-Sep-15
-ENERGYPLUS.GOV,Federal Agency,Department of Energy,Washington,DC,ACTIVE,28-Aug-14,28-Aug-15
-ENERGYSAVER.GOV,Federal Agency,Department of Energy,Washington,DC,ACTIVE,28-Aug-14,30-Sep-15
-ENERGYSAVERS.GOV,Federal Agency,Department of Energy,Washington,DC,ACTIVE,28-Aug-14,30-Sep-15
-FNAL.GOV,Federal Agency,Department of Energy,Batavia,IL,ACTIVE,8-Jul-14,30-Sep-15
-FUELECONOMY.GOV,Federal Agency,Department of Energy,Oak Ridge,TN,ACTIVE,2-Jun-14,31-Aug-15
-HANFORD.GOV,Federal Agency,Department of Energy,Richland,WA,ACTIVE,20-Aug-14,31-Aug-15
-HIGHPERFORMANCEBUILDINGS.GOV,Federal Agency,Department of Energy,Golden,CO,ACTIVE,28-Aug-14,30-Sep-15
-HOMEENERGYSCORE.GOV,Federal Agency,Department of Energy,Washington,DC,ACTIVE,9-Jul-14,20-Jul-15
-HYDROGEN.GOV,Federal Agency,Department of Energy,Washington,DC,ACTIVE,28-Aug-14,30-Sep-15
-INEL.GOV,Federal Agency,Department of Energy,Idaho Falls,ID,ACTIVE,24-Jul-14,16-Sep-15
-INL.GOV,Federal Agency,Department of Energy,Idaho Falls,ID,ACTIVE,29-Oct-14,19-Jan-16
-ISCIENCE.GOV,Federal Agency,Department of Energy,Oak Ridge,TN,ACTIVE,26-Feb-14,9-May-15
-ISOTOPE.GOV,Federal Agency,Department of Energy,Oak Ridge,TN,ACTIVE,3-Feb-15,11-Apr-16
-ISOTOPES.GOV,Federal Agency,Department of Energy,Oak Ridge,TN,ACTIVE,3-Feb-15,11-Apr-16
-KAPL.GOV,Federal Agency,Department of Energy,Schenectady,NY,ACTIVE,27-Aug-14,30-Sep-15
-LANL.GOV,Federal Agency,Department of Energy,Los Alamos,NM,ACTIVE,27-Aug-14,30-Sep-15
-LBL.GOV,Federal Agency,Department of Energy,Berkeley,CA,ACTIVE,4-Aug-14,22-Oct-15
-LLNL.GOV,Federal Agency,Department of Energy,Livermore,CA,ACTIVE,27-Aug-14,30-Sep-15
-NCCRC.GOV,Federal Agency,Department of Energy,Oak Ridge,TN,ACTIVE,5-Jan-15,26-Feb-16
-NCCS.GOV,Federal Agency,Department of Energy,Oak Ridge,TN,ACTIVE,3-Jun-14,31-Aug-15
-NCRC.GOV,Federal Agency,Department of Energy,Oak Ridge,TN,ACTIVE,5-Jan-15,26-Feb-16
-NERSC.GOV,Federal Agency,Department of Energy,Berkeley,CA,ACTIVE,12-Aug-14,30-Sep-15
-NEUP.GOV,Federal Agency,Department of Energy,Washington,DC,ACTIVE,7-Aug-14,5-Nov-15
-NREL.GOV,Federal Agency,Department of Energy,Golden,CO,ACTIVE,18-Aug-14,30-Sep-15
-NRELHUB.GOV,Federal Agency,Department of Energy,Golden,CO,ACTIVE,3-Dec-14,16-Dec-15
-NTRC.GOV,Federal Agency,Department of Energy,Knoxville,TN,ACTIVE,5-Jun-14,31-Aug-15
-NUCLEAR.GOV,Federal Agency,Department of Energy,Washington,DC,ACTIVE,7-Aug-14,30-Sep-15
-ORAU.GOV,Federal Agency,Department of Energy,Oak Ridge,TN,ACTIVE,10-Jul-14,8-Oct-15
-ORNL.GOV,Federal Agency,Department of Energy,Oak Ridge,TN,ACTIVE,2-Jun-14,31-Aug-15
-OSTI.GOV,Federal Agency,Department of Energy,Oak Ridge,TN,ACTIVE,11-Jul-14,8-Sep-15
-PNL.GOV,Federal Agency,Department of Energy,Richland,WA,ACTIVE,3-Jul-14,30-Sep-15
-PNNL.GOV,Federal Agency,Department of Energy,Richland,WA,ACTIVE,9-Dec-14,8-Mar-16
-RL.GOV,Federal Agency,Department of Energy,Richland,WA,ACTIVE,20-Aug-14,31-Aug-15
-SALMONRECOVERY.GOV,Federal Agency,Department of Energy,Portland,OR,ACTIVE,17-Jul-14,2-Sep-15
-SANDIA.GOV,Federal Agency,Department of Energy,Albuquerque,NM,ACTIVE,27-Aug-14,30-Sep-15
-SCIDAC.GOV,Federal Agency,Department of Energy,Oak Ridge,TN,ACTIVE,2-Jun-14,22-Aug-15
-SCIENCE.GOV,Federal Agency,Department of Energy,Oak Ridge,TN,ACTIVE,11-Jul-14,8-Sep-15
-SCIENCEACCELERATOR.GOV,Federal Agency,Department of Energy,Oak Ridge,TN,ACTIVE,12-Jan-15,10-Jan-16
-SCIENCEEDUCATION.GOV,Federal Agency,Department of Energy,Oak Ridge,TN,ACTIVE,12-Jan-15,12-Apr-16
-SMARTGRID.GOV,Federal Agency,Department of Energy,Washington,DC,ACTIVE,15-Oct-14,16-Oct-15
-SNS.GOV,Federal Agency,Department of Energy,Oak Ridge,TN,ACTIVE,2-Jun-14,31-Aug-15
-SOLARDECATHLON.GOV,Federal Agency,Department of Energy,Golden,CO,ACTIVE,9-Jul-14,7-Jul-15
-SRS.GOV,Federal Agency,Department of Energy,Aiken,SC,ACTIVE,14-Aug-14,20-Sep-15
-SWPA.GOV,Federal Agency,Department of Energy,Tulsa,OK,ACTIVE,24-Jun-14,20-Sep-15
-UNNPP.GOV,Federal Agency,Department of Energy,West Mifflin,PA,ACTIVE,29-Oct-14,7-Jan-16
-UNRPNET.GOV,Federal Agency,Department of Energy,Washington,DC,ACTIVE,7-May-14,15-Jul-15
-WAPA.GOV,Federal Agency,Department of Energy,Lakewood,CO,ACTIVE,9-Jul-14,30-Sep-15
-WINDPOWERINGAMERICA.GOV,Federal Agency,Department of Energy,Golden,CO,ACTIVE,28-Aug-14,30-Sep-15
-YMP.GOV,Federal Agency,Department of Energy,Las Vegas,NV,ACTIVE,3-Jul-14,30-Sep-15
-ACF.GOV,Federal Agency,Department of Health And Human Services,Washington,DC,ACTIVE,23-Jul-14,22-Sep-15
-ACL.GOV,Federal Agency,Department of Health And Human Services,Washington,DC,ACTIVE,21-Aug-14,14-Nov-15
-AFTERSCHOOL.GOV,Federal Agency,Department of Health And Human Services,Washington,DC,ACTIVE,23-Jul-14,22-Sep-15
-AGINGSTATS.GOV,Federal Agency,Department of Health And Human Services,Washington,DC,ACTIVE,23-Jul-14,22-Sep-15
-AHCPR.GOV,Federal Agency,Department of Health And Human Services,Rockville,MD,ACTIVE,28-May-14,26-Aug-15
-AHRQ.GOV,Federal Agency,Department of Health And Human Services,Rockville,MD,ACTIVE,28-May-14,26-Aug-15
-AIDS.GOV,Federal Agency,Department of Health And Human Services,Washington,DC,ACTIVE,23-Jul-14,30-Sep-15
-ALZHEIMERS.GOV,Federal Agency,Department of Health And Human Services,Washington,DC,ACTIVE,19-Feb-15,14-May-16
-AOA.GOV,Federal Agency,Department of Health And Human Services,Washington,DC,ACTIVE,23-Jul-14,22-Sep-15
-BAM.GOV,Federal Agency,Department of Health And Human Services,Atlanta,GA,ACTIVE,27-Jun-14,22-Sep-15
-BESTBONESFOREVER.GOV,Federal Agency,Department of Health And Human Services,Washington,DC,ACTIVE,18-Jun-14,27-Aug-15
-BETOBACCOFREE.GOV,Federal Agency,Department of Health And Human Services,Washington,DC,ACTIVE,21-Aug-14,14-Nov-15
-BIOETHICS.GOV,Federal Agency,Department of Health And Human Services,Washington,DC,ACTIVE,23-Jul-14,22-Sep-15
-BIOSECURITYBOARD.GOV,Federal Agency,Department of Health And Human Services,Washington,DC,ACTIVE,23-Jul-14,22-Sep-15
-CANCER.GOV,Federal Agency,Department of Health And Human Services,Rockville,MD,ACTIVE,12-Aug-14,22-Sep-15
-CANCERNET.GOV,Federal Agency,Department of Health And Human Services,Rockville,MD,ACTIVE,12-Aug-14,22-Sep-15
-CDC.GOV,Federal Agency,Department of Health And Human Services,Atlanta,GA,ACTIVE,27-Jun-14,20-Sep-15
-CHILDWELFARE.GOV,Federal Agency,Department of Health And Human Services,Washington,DC,ACTIVE,19-Feb-15,26-Apr-16
-CLINICALTRIAL.GOV,Federal Agency,Department of Health And Human Services,Bethesda,MD,ACTIVE,23-Jul-14,22-Sep-15
-CLINICALTRIALS.GOV,Federal Agency,Department of Health And Human Services,Bethesda,MD,ACTIVE,23-Jul-14,22-Sep-15
-CLUBDRUGS.GOV,Federal Agency,Department of Health And Human Services,Bethesda,MD,ACTIVE,23-Jul-14,22-Sep-15
-CMS.GOV,Federal Agency,Department of Health And Human Services,Baltimore,MD,ACTIVE,23-Jul-14,22-Sep-15
-COLLEGEDRINKINGPREVENTION.GOV,Federal Agency,Department of Health And Human Services,Bethesda,MD,ACTIVE,23-Jul-14,22-Sep-15
-CUIDADODESALUD.GOV,Federal Agency,Department of Health And Human Services,Baltimore,MD,ACTIVE,18-Jun-14,18-Aug-15
-DHHS.GOV,Federal Agency,Department of Health And Human Services,Washington,DC,ACTIVE,23-Jul-14,22-Sep-15
-DIABETESCOMMITTEE.GOV,Federal Agency,Department of Health And Human Services,Washington,DC,ACTIVE,19-Feb-15,25-Mar-16
-DOCLINE.GOV,Federal Agency,Department of Health And Human Services,Bethesda,MD,ACTIVE,18-Sep-14,22-Sep-15
-DRUGABUSE.GOV,Federal Agency,Department of Health And Human Services,Baltimore,MD,ACTIVE,29-Jul-14,22-Sep-15
-DRUGFREEWORKPLACE.GOV,Federal Agency,Department of Health And Human Services,Rockville,MD,ACTIVE,29-Jul-14,22-Sep-15
-EDISON.GOV,Federal Agency,Department of Health And Human Services,Bethesda,MD,ACTIVE,23-Jun-14,17-Sep-15
-ELDERCARE.GOV,Federal Agency,Department of Health And Human Services,Washington,DC,ACTIVE,29-Jul-14,22-Sep-15
-ENDINGTHEDOCUMENTGAME.GOV,Federal Agency,Department of Health And Human Services,Washington,DC,ACTIVE,29-Jul-14,27-Sep-15
-ERRP.GOV,Federal Agency,Department of Health And Human Services,Baltimore,MD,ACTIVE,18-Jun-14,28-Jul-15
-FATHERHOOD.GOV,Federal Agency,Department of Health And Human Services,Washington,DC,ACTIVE,31-Mar-14,8-Jun-15
-FDA.GOV,Federal Agency,Department of Health And Human Services,Rockville,MD,ACTIVE,18-Jun-14,15-Sep-15
-FINDYOUTHINFO.GOV,Federal Agency,Department of Health And Human Services,Rockville,MD,ACTIVE,27-Oct-14,1-Dec-15
-FITNESS.GOV,Federal Agency,Department of Health And Human Services,Washington,DC,ACTIVE,29-Jul-14,22-Sep-15
-FLU.GOV,Federal Agency,Department of Health And Human Services,Washington ,DC,ACTIVE,29-Jul-14,27-Sep-15
-FOODSAFETY.GOV,Federal Agency,Department of Health And Human Services,Washington,DC,ACTIVE,18-Jun-14,16-Sep-15
-FRUITSANDVEGGIESMATTER.GOV,Federal Agency,Department of Health And Human Services,Washington,DC,ACTIVE,2-Mar-15,20-Mar-16
-GENBANK.GOV,Federal Agency,Department of Health And Human Services,Bethesda,MD,ACTIVE,18-Sep-14,17-Sep-15
-GENOME.GOV,Federal Agency,Department of Health And Human Services,Bethesda,MD,ACTIVE,29-Jul-14,22-Sep-15
-GIRLSHEALTH.GOV,Federal Agency,Department of Health And Human Services,Washington,DC,ACTIVE,11-Aug-14,22-Sep-15
-GLOBALHEALTH.GOV,Federal Agency,Department of Health And Human Services,Rockville,MD,ACTIVE,11-Aug-14,22-Sep-15
-GRANTS.GOV,Federal Agency,Department of Health And Human Services,Washington,DC,ACTIVE,11-Aug-14,22-Sep-15
-GRANTSOLUTIONS.GOV,Federal Agency,Department of Health And Human Services,Washington,DC,ACTIVE,10-Jun-14,8-Sep-15
-GUIDELINE.GOV,Federal Agency,Department of Health And Human Services,Rockville,MD,ACTIVE,28-May-14,26-Aug-15
-GUIDELINES.GOV,Federal Agency,Department of Health And Human Services,Rockville,MD,ACTIVE,28-May-14,26-Aug-15
-HCQUALITYCOMMISSION.GOV,Federal Agency,Department of Health And Human Services,Rockville,MD,ACTIVE,29-Jul-14,22-Sep-15
-HEALTH.GOV,Federal Agency,Department of Health And Human Services,Washington,DC,ACTIVE,29-Jul-14,22-Sep-15
-HEALTHCARE.GOV,Federal Agency,Department of Health And Human Services,Baltimore,MD,ACTIVE,18-Jun-14,29-Jun-15
-HEALTHDATA.GOV,Federal Agency,Department of Health And Human Services,Washington,DC,ACTIVE,19-Feb-15,16-Feb-16
-HEALTHFINDER.GOV,Federal Agency,Department of Health And Human Services,Washington,DC,ACTIVE,29-Jul-14,22-Sep-15
-HEALTHINDICATORS.GOV,Federal Agency,Department of Health And Human Services,Washington,DC,ACTIVE,27-Oct-14,19-Jan-16
-HEALTHIT.GOV,Federal Agency,Department of Health And Human Services,Washington,DC,ACTIVE,19-Feb-15,18-Feb-16
-HEALTHREFORM.GOV,Federal Agency,Department of Health And Human Services,Washington,DC,ACTIVE,19-Feb-15,4-Mar-16
-HEALTHYPEOPLE.GOV,Federal Agency,Department of Health And Human Services,Washington,DC,ACTIVE,29-Jul-14,22-Sep-15
-HEARTTRUTH.GOV,Federal Agency,Department of Health And Human Services,Bethesda,MD,ACTIVE,21-Aug-14,22-Sep-15
-HHS.GOV,Federal Agency,Department of Health And Human Services,Washington,DC,ACTIVE,29-Jul-14,22-Sep-15
-HHSOIG.GOV,Federal Agency,Department of Health And Human Services,Washington,DC,ACTIVE,29-Jul-14,22-Sep-15
-HHSOPS.GOV,Federal Agency,Department of Health And Human Services,Rockville,MD,ACTIVE,19-Feb-15,24-Mar-16
-HIV.GOV,Federal Agency,Department of Health And Human Services,Washington,DC,ACTIVE,4-Sep-14,4-Sep-15
-HRSA.GOV,Federal Agency,Department of Health And Human Services,Rockville,MD,ACTIVE,11-Aug-14,22-Sep-15
-IEDISON.GOV,Federal Agency,Department of Health And Human Services,Bethesda,MD,ACTIVE,23-Jun-14,17-Sep-15
-IHS.GOV,Federal Agency,Department of Health And Human Services,Albuquerque,NM,ACTIVE,11-Aug-14,22-Sep-15
-INSUREKIDSNOW.GOV,Federal Agency,Department of Health And Human Services,Baltimore,MD,ACTIVE,11-Aug-14,22-Sep-15
-LOCATORPLUS.GOV,Federal Agency,Department of Health And Human Services,Bethesda,MD,ACTIVE,11-Aug-14,22-Sep-15
-LONGTERMCARE.GOV,Federal Agency,Department of Health And Human Services,Washington,DC,ACTIVE,18-Jun-14,17-Aug-15
-MEDICAID.GOV,Federal Agency,Department of Health And Human Services,Baltimore,MD,ACTIVE,19-Feb-15,31-Mar-16
-MEDICALCOUNTERMEASURES.GOV,Federal Agency,Department of Health And Human Services,Washington,DC,ACTIVE,19-Feb-15,9-Mar-16
-MEDICALRESERVECORPS.GOV,Federal Agency,Department of Health And Human Services,Washington,DC,ACTIVE,11-Aug-14,22-Sep-15
-MEDICARE.GOV,Federal Agency,Department of Health And Human Services,Baltimore,MD,ACTIVE,11-Aug-14,22-Sep-15
-MEDLINE.GOV,Federal Agency,Department of Health And Human Services,Bethesda,MD,ACTIVE,18-Sep-14,17-Sep-15
-MEDLINEPLUS.GOV,Federal Agency,Department of Health And Human Services,Bethesda,MD,ACTIVE,11-Aug-14,22-Sep-15
-MENTALHEALTH.GOV,Federal Agency,Department of Health And Human Services,Bethesda,MD,ACTIVE,11-Aug-14,22-Sep-15
-MESH.GOV,Federal Agency,Department of Health And Human Services,Bethesda,MD,ACTIVE,18-Sep-14,17-Sep-15
-MIMEDICARE.GOV,Federal Agency,Department of Health And Human Services,Baltimore,MD,ACTIVE,19-Feb-15,29-Mar-16
-MYMEDICARE.GOV,Federal Agency,Department of Health And Human Services,Baltimore,MD,ACTIVE,18-Jun-14,24-Aug-15
-NATIONALCHILDRENSSTUDY.GOV,Federal Agency,Department of Health And Human Services,Bethesda,MD,ACTIVE,11-Aug-14,22-Sep-15
-NCIFCRF.GOV,Federal Agency,Department of Health And Human Services,Frederick,MD,ACTIVE,25-Jun-14,20-Sep-15
-NGC.GOV,Federal Agency,Department of Health And Human Services,Rockville,MD,ACTIVE,28-May-14,26-Aug-15
-NIH.GOV,Federal Agency,Department of Health And Human Services,Bethesda,MD,ACTIVE,12-Aug-14,21-Sep-15
-NIHSENIORHEALTH.GOV,Federal Agency,Department of Health And Human Services,Bethesda,MD,ACTIVE,11-Aug-14,22-Sep-15
-NIOSH.GOV,Federal Agency,Department of Health And Human Services,Atlanta,GA,ACTIVE,9-Jun-14,29-Jul-15
-NLM.GOV,Federal Agency,Department of Health And Human Services,Bethesda,MD,ACTIVE,18-Sep-14,17-Sep-15
-NNLM.GOV,Federal Agency,Department of Health And Human Services,Bethesda,MD,ACTIVE,11-Aug-14,22-Sep-15
-ORGANDONOR.GOV,Federal Agency,Department of Health And Human Services,Rockville,MD,ACTIVE,11-Aug-14,22-Sep-15
-PANDEMICFLU.GOV,Federal Agency,Department of Health And Human Services,Washington,DC,ACTIVE,11-Aug-14,27-Sep-15
-PAPERWORKREDUCTION.GOV,Federal Agency,Department of Health And Human Services,Washington,DC,ACTIVE,11-Aug-14,22-Sep-15
-PCIP.GOV,Federal Agency,Department of Health And Human Services,New Orleans,LA,ACTIVE,17-Jul-14,29-Jun-15
-PHE.GOV,Federal Agency,Department of Health And Human Services,Washington,DC,ACTIVE,31-Mar-14,3-Jun-15
-PSC.GOV,Federal Agency,Department of Health And Human Services,Rockville,MD,ACTIVE,11-Aug-14,22-Sep-15
-PUBMED.GOV,Federal Agency,Department of Health And Human Services,Bethesda,MD,ACTIVE,18-Sep-14,17-Sep-15
-PUBMEDCENTRAL.GOV,Federal Agency,Department of Health And Human Services,Bethesda,MD,ACTIVE,11-Aug-14,22-Sep-15
-QUIC.GOV,Federal Agency,Department of Health And Human Services,Rockville,MD,ACTIVE,11-Aug-14,22-Sep-15
-QUICK.GOV,Federal Agency,Department of Health And Human Services,Rockville,MD,ACTIVE,28-May-14,26-Aug-15
-RECOVERYMONTH.GOV,Federal Agency,Department of Health And Human Services,Rockville,MD,ACTIVE,11-Aug-14,22-Sep-15
-SAFEYOUTH.GOV,Federal Agency,Department of Health And Human Services,Atlanta,GA,ACTIVE,30-Oct-14,7-Jan-16
-SAMHSA.GOV,Federal Agency,Department of Health And Human Services,Rockville,MD,ACTIVE,11-Aug-14,22-Sep-15
-SELECTAGENTS.GOV,Federal Agency,Department of Health And Human Services,Washington,DC,ACTIVE,27-Jun-14,22-Sep-15
-SMOKEFREE.GOV,Federal Agency,Department of Health And Human Services,Rockville,MD,ACTIVE,11-Aug-14,22-Sep-15
-STEROIDABUSE.GOV,Federal Agency,Department of Health And Human Services,Bethesda,MD,ACTIVE,11-Aug-14,22-Sep-15
-STOPALCOHOLABUSE.GOV,Federal Agency,Department of Health And Human Services,Washington,DC,ACTIVE,21-Aug-14,13-Oct-15
-STOPBULLYING.GOV,Federal Agency,Department of Health And Human Services,Washington,DC,ACTIVE,19-Feb-15,8-Mar-16
-STOPMEDICAREFRAUD.GOV,Federal Agency,Department of Health And Human Services,Washington,DC,ACTIVE,18-Jun-14,2-Jul-15
-SURGEONGENERAL.GOV,Federal Agency,Department of Health And Human Services,Washington,DC,ACTIVE,11-Aug-14,22-Sep-15
-THECOOLSPOT.GOV,Federal Agency,Department of Health And Human Services,Rockville,MD,ACTIVE,11-Aug-14,22-Sep-15
-THEREALCOST.GOV,Federal Agency,Department of Health And Human Services,Washington,DC,ACTIVE,30-Oct-14,6-Jan-16
-TISSUEENGINEERING.GOV,Federal Agency,Department of Health And Human Services,Bethesda,MD,ACTIVE,2-Sep-14,30-Sep-15
-TOBACCO.GOV,Federal Agency,Department of Health And Human Services,Washington,DC,ACTIVE,21-Aug-14,14-Nov-15
-USABILITY.GOV,Federal Agency,Department of Health And Human Services,Washington,DC,ACTIVE,21-Aug-14,22-Sep-15
-USBM.GOV,Federal Agency,Department of Health And Human Services,Atlanta,GA,ACTIVE,8-Jul-14,30-Sep-15
-USPHS.GOV,Federal Agency,Department of Health And Human Services,Rockville,MD,ACTIVE,21-Aug-14,22-Sep-15
-VACCINES.GOV,Federal Agency,Department of Health And Human Services,Washington,DC,ACTIVE,19-Feb-15,24-Mar-16
-WHAGING.GOV,Federal Agency,Department of Health And Human Services,Washington,DC,ACTIVE,4-Sep-14,4-Sep-15
-WHITEHOUSECONFERENCEONAGING.GOV,Federal Agency,Department of Health And Human Services,Washington,DC,ACTIVE,4-Sep-14,4-Sep-15
-WOMENSHEALTH.GOV,Federal Agency,Department of Health And Human Services,Washington,DC,ACTIVE,21-Aug-14,22-Sep-15
-BIOMETRICS.GOV,Federal Agency,Department of Homeland Security,Arlington,VA,ACTIVE,30-Jun-14,3-Aug-15
-CITIZENCORPS.GOV,Federal Agency,Department of Homeland Security,Washington,DC,ACTIVE,5-Aug-14,30-Sep-15
-CPNIREPORTING.GOV,Federal Agency,Department of Homeland Security,Washington,DC,ACTIVE,2-Dec-14,4-Dec-15
-DHS.GOV,Federal Agency,Department of Homeland Security,Washington,DC,ACTIVE,13-Aug-14,30-Sep-15
-DISASTERASSISTANCE.GOV,Federal Agency,Department of Homeland Security,Bluemont,VA,ACTIVE,18-Aug-14,3-Nov-15
-FEMA.GOV,Federal Agency,Department of Homeland Security,Washington,DC,ACTIVE,29-Oct-14,30-Sep-15
-FERO.GOV,Federal Agency,Department of Homeland Security,Washington,DC,SERVER-HOLD,3-May-13,27-Jul-14
-FIRSTRESPONDER.GOV,Federal Agency,Department of Homeland Security,Washington,DC,ACTIVE,5-Dec-14,11-Jan-16
-FIRSTRESPONDERTRAINING.GOV,Federal Agency,Department of Homeland Security,Washington,DC,ACTIVE,2-Feb-15,2-Feb-16
-FLETA.GOV,Federal Agency,Department of Homeland Security,Glynco,GA,ACTIVE,9-Jul-14,31-Aug-15
-FLETC.GOV,Federal Agency,Department of Homeland Security,Glynco,GA,ACTIVE,9-Jul-14,30-Sep-15
-FLIGHTSCHOOLCANDIDATES.GOV,Federal Agency,Department of Homeland Security,Rockville,MD,ACTIVE,7-Aug-14,7-Sep-15
-FLOODSMART.GOV,Federal Agency,Department of Homeland Security,Bluemont,VA,ACTIVE,4-Aug-14,30-Sep-15
-HOMELANDSECURITY.GOV,Federal Agency,Department of Homeland Security,Washington,DC,ACTIVE,13-Aug-14,30-Sep-15
-ICE.GOV,Federal Agency,Department of Homeland Security,Washington,DC,ACTIVE,22-Jul-14,2-Sep-14
-LISTO.GOV,Federal Agency,Department of Homeland Security,Washington,DC,ACTIVE,29-Oct-14,30-Sep-15
-LLIS.GOV,Federal Agency,Department of Homeland Security,Washington,DC,ACTIVE,30-Sep-14,30-Sep-15
-NMSC.GOV,Federal Agency,Department of Homeland Security,St Augustine,FL,ACTIVE,18-Aug-14,15-Sep-15
-READY.GOV,Federal Agency,Department of Homeland Security,Washington,DC,ACTIVE,29-Oct-14,30-Sep-15
-READYBUSINESS.GOV,Federal Agency,Department of Homeland Security,Washington,DC,ACTIVE,29-Oct-14,29-Dec-15
-SAFECOMPROGRAM.GOV,Federal Agency,Department of Homeland Security,Washington,DC,ACTIVE,11-Feb-15,30-Sep-15
-SAFETYACT.GOV,Federal Agency,Department of Homeland Security,Washington,DC,ACTIVE,11-Feb-15,30-Sep-15
-SECRETSERVICE.GOV,Federal Agency,Department of Homeland Security,Washington D.C.,DC,ACTIVE,16-Jul-14,30-Sep-15
-TSA.GOV,Federal Agency,Department of Homeland Security,Arlington,VA,ACTIVE,4-Sep-14,30-Sep-15
-US-CERT.GOV,Federal Agency,Department of Homeland Security,Washington,DC,ACTIVE,25-Jul-14,30-Sep-15
-USCG.GOV,Federal Agency,Department of Homeland Security,Alexandria,VA,ACTIVE,8-Jul-14,26-Aug-15
-USCIS.GOV,Federal Agency,Department of Homeland Security,Washington,DC,ACTIVE,30-Jun-14,30-Sep-15
-USSS.GOV,Federal Agency,Department of Homeland Security,Washington,DC,ACTIVE,16-Jul-14,30-Sep-15
-DISASTERHOUSING.GOV,Federal Agency,Department of Housing And Urban Development,Washington,DC,ACTIVE,19-May-14,7-Jul-15
-FHA.GOV,Federal Agency,Department of Housing And Urban Development,Washington,DC,ACTIVE,18-Aug-14,27-Jul-15
-GINNIEMAE.GOV,Federal Agency,Department of Housing And Urban Development,Washington,DC,ACTIVE,17-Sep-14,30-Sep-15
-HOMESALES.GOV,Federal Agency,Department of Housing And Urban Development,Washington,DC,ACTIVE,22-Sep-14,9-Sep-15
-HUD.GOV,Federal Agency,Department of Housing And Urban Development,Washington,DC,ACTIVE,3-Sep-14,27-Aug-15
-HUDOIG.GOV,Federal Agency,Department of Housing And Urban Development,Washington,DC,ACTIVE,30-Jul-14,22-Sep-15
-NATIONALHOUSING.GOV,Federal Agency,Department of Housing And Urban Development,Washington,DC,ACTIVE,20-Nov-13,23-Jan-15
-NATIONALHOUSINGLOCATOR.GOV,Federal Agency,Department of Housing And Urban Development,Washington,DC,ACTIVE,20-Nov-13,23-Jan-15
-NHL.GOV,Federal Agency,Department of Housing And Urban Development,Washington,DC,ACTIVE,20-Nov-13,23-Jan-15
-NLS.GOV,Federal Agency,Department of Housing And Urban Development,Washington,DC,ACTIVE,19-Mar-14,17-Feb-15
-ADA.GOV,Federal Agency,Department of Justice,Rockville,MD,ACTIVE,5-Aug-14,7-Sep-15
-ADR.GOV,Federal Agency,Department of Justice,Rockville,MD,ACTIVE,5-Aug-14,7-Sep-15
-AMBERALERT.GOV,Federal Agency,Department of Justice,Potomac,MD,ACTIVE,5-Aug-14,7-Sep-15
-ATF.GOV,Federal Agency,Department of Justice,Washington,DC,ACTIVE,5-Aug-14,7-Sep-15
-BIOMETRICCOE.GOV,Federal Agency,Department of Justice,Clarksburg,WV,ACTIVE,28-Nov-14,17-Dec-15
-BJA.GOV,Federal Agency,Department of Justice,Washington ,DC,ACTIVE,28-Nov-14,24-Jan-16
-BJS.GOV,Federal Agency,Department of Justice,Washington,DC,ACTIVE,28-Nov-14,24-Jan-16
-BOP.GOV,Federal Agency,Department of Justice,Washington,DC,ACTIVE,5-Aug-14,7-Sep-15
-CRIMESOLUTIONS.GOV,Federal Agency,Department of Justice,Washinton ,DC,ACTIVE,17-Jun-14,11-Jun-15
-CRIMEVICTIMS.GOV,Federal Agency,Department of Justice,Potomac,MD,ACTIVE,5-Aug-14,20-Sep-15
-CYBERCRIME.GOV,Federal Agency,Department of Justice,Washington,DC,ACTIVE,5-Aug-14,7-Sep-15
-DEA.GOV,Federal Agency,Department of Justice,Rockville,MD,ACTIVE,5-Aug-14,7-Sep-15
-DEADIVERSION.GOV,Federal Agency,Department of Justice,Potomac,MD,ACTIVE,5-Aug-14,7-Sep-15
-DEALS.GOV,Federal Agency,Department of Justice,Washington,DC,ACTIVE,28-Nov-14,8-Jan-16
-DNA.GOV,Federal Agency,Department of Justice,Potomac,MD,ACTIVE,5-Aug-14,20-Sep-15
-DSAC.GOV,Federal Agency,Department of Justice,Potomac,MD,ACTIVE,5-Aug-14,2-Sep-15
-ESPANOLFORLAWENFORCEMENT.GOV,Federal Agency,Department of Justice,Potomac,MD,ACTIVE,17-Jun-14,11-Jul-15
-FARA.GOV,Federal Agency,Department of Justice,potomac,MD,ACTIVE,5-Aug-14,6-Sep-15
-FBI.GOV,Federal Agency,Department of Justice,Washington,DC,ACTIVE,5-Aug-14,7-Sep-15
-FBIJOBS.GOV,Federal Agency,Department of Justice,Washington,DC,ACTIVE,5-Aug-14,20-Sep-15
-FIRSTFREEDOM.GOV,Federal Agency,Department of Justice,Potomac,MD,ACTIVE,5-Aug-14,14-Sep-15
-FOIA.GOV,Federal Agency,Department of Justice,Washington,DC,ACTIVE,28-Feb-14,4-May-15
-FORFEITURE.GOV,Federal Agency,Department of Justice,Potomac,MD,ACTIVE,7-Oct-14,5-Oct-15
-GETSMARTABOUTDRUGS.GOV,Federal Agency,Department of Justice,Potomac,MD,ACTIVE,24-Feb-15,17-Mar-16
-HELPINGAMERICASYOUTH.GOV,Federal Agency,Department of Justice,Potomac,MD,ACTIVE,7-Oct-14,19-Oct-15
-IC3.GOV,Federal Agency,Department of Justice,Fairmont,WV,ACTIVE,5-Aug-14,7-Sep-15
-INTERPOL.GOV,Federal Agency,Department of Justice,Potomac,MD,ACTIVE,9-Sep-14,30-Sep-15
-IPRCENTER.GOV,Federal Agency,Department of Justice,Washington,DC,ACTIVE,8-Jan-15,24-Mar-16
-JUSTICE.GOV,Federal Agency,Department of Justice,Rockville,MD,ACTIVE,5-Aug-14,7-Sep-15
-JUSTTHINKTWICE.GOV,Federal Agency,Department of Justice,Potomac,MD,ACTIVE,5-Aug-14,18-Aug-15
-JUVENILECOUNCIL.GOV,Federal Agency,Department of Justice,Potomac,MD,ACTIVE,9-Sep-14,7-Sep-15
-LEP.GOV,Federal Agency,Department of Justice,Rockville,MD,ACTIVE,9-Sep-14,7-Sep-15
-LOOKSTOOGOODTOBETRUE.GOV,Federal Agency,Department of Justice,Fairmont,WV,ACTIVE,5-Aug-14,7-Sep-15
-MALWAREINVESTIGATOR.GOV,Federal Agency,Department of Justice,Washington,DC,ACTIVE,15-Oct-14,12-Nov-15
-MEDALOFVALOR.GOV,Federal Agency,Department of Justice,Potomac,MD,ACTIVE,9-Sep-14,25-Sep-15
-NAMUS.GOV,Federal Agency,Department of Justice,Potomac,MD,ACTIVE,17-Jun-14,29-Jun-15
-NATIONALGANGCENTER.GOV,Federal Agency,Department of Justice,Tallahassee,FL,ACTIVE,5-Aug-14,6-Sep-15
-NCIRC.GOV,Federal Agency,Department of Justice,Tallahassee,FL,ACTIVE,17-Jun-14,5-Jul-15
-NCJRS.GOV,Federal Agency,Department of Justice,Potomac,MD,ACTIVE,5-Aug-14,30-Aug-15
-NIBIN.GOV,Federal Agency,Department of Justice,Washington,DC,ACTIVE,9-Sep-14,30-Sep-15
-NICIC.GOV,Federal Agency,Department of Justice,Washington,DC,ACTIVE,28-Nov-14,13-Feb-16
-NIEM.GOV,Federal Agency,Department of Justice,Tallahassee,FL,ACTIVE,9-Sep-14,24-Sep-15
-NIJ.GOV,Federal Agency,Department of Justice,Washington,DC,ACTIVE,28-Nov-14,24-Jan-16
-NMVTIS.GOV,Federal Agency,Department of Justice,Washington,DC,ACTIVE,7-Oct-14,25-Nov-15
-NSOPW.GOV,Federal Agency,Department of Justice,Washington,DC,ACTIVE,7-Oct-14,25-Nov-15
-NVTC.GOV,Federal Agency,Department of Justice,Washington,DC,ACTIVE,5-Aug-14,7-Sep-15
-OJJDP.GOV,Federal Agency,Department of Justice,Potomac,MD,ACTIVE,17-Jun-14,7-Jun-15
-OJP.GOV,Federal Agency,Department of Justice,Washington,DC,ACTIVE,5-Aug-14,7-Sep-15
-OVC.GOV,Federal Agency,Department of Justice,Potomac,MD,ACTIVE,5-Aug-14,7-Sep-15
-OVCTTAC.GOV,Federal Agency,Department of Justice,Potomac,MD,ACTIVE,7-Oct-14,5-Nov-15
-PROJECTSAFECHILDHOOD.GOV,Federal Agency,Department of Justice,Potomac,MD,ACTIVE,17-Jun-14,7-Jul-15
-PROJECTSAFENEIGHBORHOODS.GOV,Federal Agency,Department of Justice,Rockville,MD,ACTIVE,5-Aug-14,7-Sep-15
-PSOB.GOV,Federal Agency,Department of Justice,Potomac,MD,ACTIVE,5-Aug-14,25-Sep-15
-RCFL.GOV,Federal Agency,Department of Justice,McLean,VA,ACTIVE,5-Aug-14,27-Aug-15
-REENTRY.GOV,Federal Agency,Department of Justice,Potomac,MD,ACTIVE,5-Aug-14,29-Sep-15
-SCRA.GOV,Federal Agency,Department of Justice,Potomac,MD,ACTIVE,5-Aug-14,9-Aug-15
-SERVICEMEMBERS.GOV,Federal Agency,Department of Justice,Potomac,MD,ACTIVE,5-Aug-14,9-Aug-15
-SMART.GOV,Federal Agency,Department of Justice,Washington,DC,ACTIVE,5-Aug-14,30-Sep-15
-STOPFRAUD.GOV,Federal Agency,Department of Justice,Rockville,MD,ACTIVE,24-Feb-15,18-Mar-16
-TRIBALJUSTICEANDSAFETY.GOV,Federal Agency,Department of Justice,Potomac,MD,ACTIVE,5-Aug-14,5-Sep-15
-UCRDATATOOL.GOV,Federal Agency,Department of Justice,Washington,DC,ACTIVE,28-Nov-14,7-Jan-16
-UNICOR.GOV,Federal Agency,Department of Justice,Washington,DC,ACTIVE,5-Aug-14,7-Sep-15
-USDOJ.GOV,Federal Agency,Department of Justice,Rockville,MD,ACTIVE,5-Aug-14,7-Sep-15
-USERRA.GOV,Federal Agency,Department of Justice,Potpmac,MD,ACTIVE,5-Aug-14,9-Aug-15
-USMARSHALS.GOV,Federal Agency,Department of Justice,Rockville,MD,ACTIVE,5-Aug-14,7-Sep-15
-VCF.GOV,Federal Agency,Department of Justice,Washington,DC,ACTIVE,5-Aug-14,16-Sep-15
-VEHICLEHISTORY.GOV,Federal Agency,Department of Justice,Potomac,MD,ACTIVE,5-Aug-14,2-Sep-15
-AMERICASHEROESATWORK.GOV,Federal Agency,Department of Labor,Washington,DC,ACTIVE,22-Sep-14,26-Nov-15
-AUTOCOMMUNITIES.GOV,Federal Agency,Department of Labor,Washington,DC,ACTIVE,22-Sep-14,20-Nov-15
-BENEFITS.GOV,Federal Agency,Department of Labor,Washington,DC,ACTIVE,6-Aug-14,30-Sep-15
-BLS.GOV,Federal Agency,Department of Labor,Washington,DC,ACTIVE,2-Jul-14,30-Sep-15
-DISABILITY.GOV,Federal Agency,Department of Labor,Washington,DC,ACTIVE,21-Jul-14,30-Sep-15
-DOL-ESA.GOV,Federal Agency,Department of Labor,Washington,DC,ACTIVE,2-Jul-14,21-Sep-15
-DOL.GOV,Federal Agency,Department of Labor,Washington,DC,ACTIVE,2-Jul-14,30-Sep-15
-DOLETA.GOV,Federal Agency,Department of Labor,Washington,DC,ACTIVE,22-Sep-14,30-Sep-15
-GOVBENEFITS.GOV,Federal Agency,Department of Labor,Washington,DC,ACTIVE,6-Aug-14,30-Sep-15
-GOVLOANS.GOV,Federal Agency,Department of Labor,Washington,DC,ACTIVE,6-Aug-14,30-Sep-15
-JOBCORPS.GOV,Federal Agency,Department of Labor,Austin,TX,ACTIVE,1-Jul-14,30-Aug-15
-LABOR.GOV,Federal Agency,Department of Labor,Washington,DC,ACTIVE,2-Jul-14,30-Sep-15
-MSHA.GOV,Federal Agency,Department of Labor,Arlington,VA,ACTIVE,2-Jul-14,19-Aug-15
-MYNEXTMOVE.GOV,Federal Agency,Department of Labor,Washington,DC,ACTIVE,20-Jan-15,14-Feb-16
-OSHA.GOV,Federal Agency,Department of Labor,Washington,DC,ACTIVE,2-Jul-14,30-Sep-15
-UNIONREPORTS.GOV,Federal Agency,Department of Labor,Washington,DC,ACTIVE,14-Apr-14,12-Jul-15
-VETERANS.GOV,Federal Agency,Department of Labor,Washington,DC,ACTIVE,14-Aug-14,10-Nov-15
-WHISTLEBLOWERS.GOV,Federal Agency,Department of Labor,Washington,DC,ACTIVE,27-Mar-14,16-Apr-15
-WRP.GOV,Federal Agency,Department of Labor,Washington,DC,ACTIVE,21-Jul-14,20-Mar-15
-YOUTHRULES.GOV,Federal Agency,Department of Labor,Washington,DC,ACTIVE,16-Sep-14,11-Oct-15
-AMERICA.GOV,Federal Agency,Department of State,Washington,DC,ACTIVE,14-Jan-15,20-Nov-15
-CIVILIANRESPONSECORPS.GOV,Federal Agency,Department of State,Washington,DC,ACTIVE,14-Jan-15,21-Nov-15
-CONTINENTALSHELF.GOV,Federal Agency,Department of State,Washington,DC,ACTIVE,14-May-14,30-Jun-15
-CWC.GOV,Federal Agency,Department of State,Washington,DC,ACTIVE,2-Jul-14,30-Sep-15
-ECOPARTNERSHIPS.GOV,Federal Agency,Department of State,Washington,DC,ACTIVE,14-Jan-15,3-Dec-15
-FAN.GOV,Federal Agency,Department of State,Washington,DC,ACTIVE,12-Jun-14,12-Jun-15
-FOREIGNASSISTANCE.GOV,Federal Agency,Department of State,Washington,DC,ACTIVE,14-Jan-15,9-Dec-15
-FSGB.GOV,Federal Agency,Department of State,Washington,DC,ACTIVE,2-Jul-14,30-Sep-15
-GHI.GOV,Federal Agency,Department of State,Washington,DC,ACTIVE,22-Aug-14,21-Sep-15
-HUMANRIGHTS.GOV,Federal Agency,Department of State,Washington ,DC,ACTIVE,27-Jun-14,17-Sep-15
-IAWG.GOV,Federal Agency,Department of State,Washington,DC,ACTIVE,2-Jul-14,30-Sep-15
-IBWC.GOV,Federal Agency,Department of State,El Paso,TX,ACTIVE,26-Feb-15,17-Mar-16
-ICASS.GOV,Federal Agency,Department of State,Washington,DC,ACTIVE,2-Jul-14,30-Sep-15
-OSAC.GOV,Federal Agency,Department of State,Washington,DC,ACTIVE,14-May-14,12-Aug-15
-PEPFAR.GOV,Federal Agency,Department of State,Washington,DC,ACTIVE,14-Jan-15,29-Nov-15
-STATE.GOV,Federal Agency,Department of State,Washington,DC,ACTIVE,2-Jul-14,30-Sep-15
-USCONSULATE.GOV,Federal Agency,Department of State,Washington,DC,ACTIVE,2-Jul-14,30-Sep-15
-USEMBASSY-MEXICO.GOV,Federal Agency,Department of State,Mexico City,11,ACTIVE,2-Jul-14,30-Sep-15
-USEMBASSY.GOV,Federal Agency,Department of State,Washington,DC,ACTIVE,2-Jul-14,30-Sep-15
-USINT.GOV,Federal Agency,Department of State,Washington,DC,ACTIVE,26-Feb-15,26-Feb-16
-USMISSION.GOV,Federal Agency,Department of State,Washington,DC,ACTIVE,2-Jul-14,30-Sep-15
-USVPP.GOV,Federal Agency,Department of State,Washington,DC,ACTIVE,2-Jul-14,30-Sep-15
-ABANDONEDMINES.GOV,Federal Agency,Department of the Interior,Washington,DC,ACTIVE,8-May-14,2-Jul-15
-ACWI.GOV,Federal Agency,Department of the Interior,Reston,VA,ACTIVE,19-Nov-14,10-Feb-16
-ALASKACENTERS.GOV,Federal Agency,Department of the Interior,Washington,DC,ACTIVE,5-May-14,14-Jul-15
-AMERICANLATINOMUSEUM.GOV,Federal Agency,Department of the Interior,Washington,WV,ACTIVE,29-Jan-15,26-Mar-16
-AMERICASGREATOUTDOORS.GOV,Federal Agency,Department of the Interior,Washington,DC,ACTIVE,6-Feb-15,14-Feb-16
-ANSTASKFORCE.GOV,Federal Agency,Department of the Interior,Arlington,VA,ACTIVE,15-Sep-14,30-Sep-15
-BIA.GOV,Federal Agency,Department of the Interior,Reston,VA,ACTIVE,26-Aug-14,12-Oct-15
-BIOECO.GOV,Federal Agency,Department of the Interior,Denver,CO,ACTIVE,12-Sep-14,30-Sep-15
-BLM.GOV,Federal Agency,Department of the Interior,Denver,CO,ACTIVE,30-Sep-14,22-Oct-15
-BLMNTL.GOV,Federal Agency,Department of the Interior,Denver,CO,ACTIVE,30-Sep-14,30-Sep-15
-BOEM.GOV,Federal Agency,Department of the Interior,Herndon,VA,ACTIVE,18-Jul-14,4-Oct-15
-BOEMRE.GOV,Federal Agency,Department of the Interior,Herndon,VA,ACTIVE,18-Jul-14,6-Jul-15
-BOR.GOV,Federal Agency,Department of the Interior,Denver,CO,ACTIVE,4-Nov-14,30-Sep-15
-BSEE.GOV,Federal Agency,Department of the Interior,Herndon,VA,ACTIVE,18-Jul-14,4-Oct-15
-C3.GOV,Federal Agency,Department of the Interior,POrtland,OR,ACTIVE,22-Aug-14,20-Jul-15
-COAST2050.GOV,Federal Agency,Department of the Interior,Lafayette,LA,ACTIVE,6-Mar-15,30-Sep-15
-CONSERVATION.GOV,Federal Agency,Department of the Interior,Washington ,DC,SERVER-HOLD,10-Jan-11,17-Mar-12
-CORALREEF.GOV,Federal Agency,Department of the Interior,Denver,CO,ACTIVE,12-Sep-14,30-Sep-15
-CUPCAO.GOV,Federal Agency,Department of the Interior,Denver,CO,ACTIVE,5-Mar-15,29-May-16
-DOI.GOV,Federal Agency,Department of the Interior,Washington,DC,ACTIVE,21-Jul-14,12-Oct-15
-DOIOIG.GOV,Federal Agency,Department of the Interior,RESTON,VA,ACTIVE,29-Jan-15,28-Mar-16
-EARTHQUAKE.GOV,Federal Agency,Department of the Interior,Menlo Park,CA,ACTIVE,2-Jul-14,30-Sep-15
-EVERGLADESRESTORATION.GOV,Federal Agency,Department of the Interior,Davie,FL,ACTIVE,26-Feb-15,24-Jan-16
-FCG.GOV,Federal Agency,Department of the Interior,Denver,CO,ACTIVE,28-Aug-14,7-Oct-15
-FGDC.GOV,Federal Agency,Department of the Interior,Reston,VA,ACTIVE,4-Sep-14,30-Sep-15
-FIRECODE.GOV,Federal Agency,Department of the Interior,Boise,ID,ACTIVE,29-Jan-15,30-Sep-15
-FIRELEADERSHIP.GOV,Federal Agency,Department of the Interior,Boise,ID,ACTIVE,29-Jan-15,30-Sep-15
-FIRENET.GOV,Federal Agency,Department of the Interior,Boise,ID,ACTIVE,9-Feb-15,16-Apr-16
-FIRESCIENCE.GOV,Federal Agency,Department of the Interior,Boise,ID,ACTIVE,6-Jan-14,2-Mar-15
-FRCC.GOV,Federal Agency,Department of the Interior,Sioux Falls,SD,ACTIVE,25-Jul-14,30-Sep-15
-FWS.GOV,Federal Agency,Department of the Interior,Lakewood,CO,ACTIVE,30-Jan-15,30-Sep-15
-GCDAMP.GOV,Federal Agency,Department of the Interior,Denver,CO,ACTIVE,4-Nov-14,28-Nov-15
-GCMRC.GOV,Federal Agency,Department of the Interior,Flagstaff,AZ,ACTIVE,2-Jul-14,30-Sep-15
-GEOCOMMUNICATOR.GOV,Federal Agency,Department of the Interior,Denver,CO,ACTIVE,30-Sep-14,30-Sep-15
-GEOMAC.GOV,Federal Agency,Department of the Interior,Denver,CO,ACTIVE,9-Jul-13,30-Sep-14
-GEOPLATFORM.GOV,Federal Agency,Department of the Interior,Washington,DC,ACTIVE,3-Apr-14,28-May-15
-IAT.GOV,Federal Agency,Department of the Interior,Boise,ID,ACTIVE,30-Sep-14,30-Sep-15
-INDIANAFFAIRS.GOV,Federal Agency,Department of the Interior,Reston,VA,ACTIVE,5-Jun-14,25-Jun-15
-INTERIOR.GOV,Federal Agency,Department of the Interior,Washington,DC,ACTIVE,21-Jul-14,12-Oct-15
-INVASIVESPECIES.GOV,Federal Agency,Department of the Interior,Washington,DC,ACTIVE,18-Aug-14,27-Sep-15
-JEM.GOV,Federal Agency,Department of the Interior,Lafayett,LA,ACTIVE,6-Mar-15,31-May-16
-KLAMATHRESTORATION.GOV,Federal Agency,Department of the Interior,Yreka,CA,ACTIVE,22-Jul-14,11-May-15
-LACOAST.GOV,Federal Agency,Department of the Interior,Lafayette,LA,ACTIVE,27-Feb-15,30-Sep-15
-LANDFIRE.GOV,Federal Agency,Department of the Interior,Sioux Falls,SD,ACTIVE,25-Jul-14,30-Sep-15
-LANDIMAGING.GOV,Federal Agency,Department of the Interior,Reston,VA,ACTIVE,21-Feb-14,17-Apr-15
-LCA.GOV,Federal Agency,Department of the Interior,Lafayette,LA,ACTIVE,6-Mar-15,30-Sep-15
-LCRMSCP.GOV,Federal Agency,Department of the Interior,Denver,CO,ACTIVE,4-Nov-14,1-Nov-15
-LMVSCI.GOV,Federal Agency,Department of the Interior,Lafayette,LA,ACTIVE,6-Mar-15,25-Sep-15
-LOWERMISSISSIPPIVALLEYSCIENCE.GOV,Federal Agency,Department of the Interior,Lafayette,LA,ACTIVE,6-Mar-15,22-Sep-15
-MAPAPLANET.GOV,Federal Agency,Department of the Interior,Flagstaff,AZ,ACTIVE,5-Nov-14,9-Nov-15
-MARINE.GOV,Federal Agency,Department of the Interior,Camarillo,CA,ACTIVE,2-Jul-14,30-Sep-15
-MITIGATIONCOMMISSION.GOV,Federal Agency,Department of the Interior,Denver,CO,ACTIVE,4-Nov-14,30-Sep-15
-MMS.GOV,Federal Agency,Department of the Interior,Herndon,VA,ACTIVE,27-Aug-14,26-Oct-15
-MRGO.GOV,Federal Agency,Department of the Interior,Lafayette,LA,ACTIVE,6-Mar-15,21-Apr-16
-MRLC.GOV,Federal Agency,Department of the Interior,Sioux Falls,SD,ACTIVE,26-Jan-15,30-Sep-15
-NATIONALATLAS.GOV,Federal Agency,Department of the Interior,Reston,VA,ACTIVE,17-Sep-14,30-Sep-15
-NATIONALMAP.GOV,Federal Agency,Department of the Interior,Reston,VA,ACTIVE,17-Sep-14,30-Sep-15
-NBC.GOV,Federal Agency,Department of the Interior,Denver,CO,ACTIVE,28-Aug-14,30-Sep-15
-NDEP.GOV,Federal Agency,Department of the Interior,Reston,VA,ACTIVE,17-Sep-14,30-Sep-15
-NDOP.GOV,Federal Agency,Department of the Interior,Reston,VA,ACTIVE,17-Sep-14,30-Sep-15
-NEMI.GOV,Federal Agency,Department of the Interior,Middleton,WI,ACTIVE,2-Sep-14,30-Sep-15
-NFPORS.GOV,Federal Agency,Department of the Interior,Washington,DC,ACTIVE,27-Jan-15,30-Sep-15
-NIFC.GOV,Federal Agency,Department of the Interior,Boise,ID,ACTIVE,6-Aug-14,30-Sep-15
-NIFTT.GOV,Federal Agency,Department of the Interior,Boise,ID,ACTIVE,8-May-14,7-Jun-15
-NOLAENVIRONMENTAL.GOV,Federal Agency,Department of the Interior,Lafayette,LA,ACTIVE,6-Mar-15,9-Apr-16
-NPS.GOV,Federal Agency,Department of the Interior,WASHINGTON DC,DC,ACTIVE,8-Jul-14,30-Sep-15
-ONHIR.GOV,Federal Agency,Department of the Interior,Flagstaff,AZ,ACTIVE,19-Aug-14,8-Oct-15
-ONRR.GOV,Federal Agency,Department of the Interior,Herndon,VA,ACTIVE,18-Jul-14,4-Oct-15
-OSM.GOV,Federal Agency,Department of the Interior,Washington,DC,ACTIVE,18-Aug-14,12-Oct-15
-OSMRE.GOV,Federal Agency,Department of the Interior,Washington,DC,ACTIVE,18-Aug-14,12-Oct-15
-PIEDRASBLANCAS.GOV,Federal Agency,Department of the Interior,Sacramento,CA,ACTIVE,4-Nov-14,24-Nov-15
-REPORTBAND.GOV,Federal Agency,Department of the Interior,Laurel,MD,ACTIVE,15-Jul-14,3-Oct-15
-RIVERS.GOV,Federal Agency,Department of the Interior,Burbank,WA,ACTIVE,14-Nov-14,14-Dec-15
-SAFECOM.GOV,Federal Agency,Department of the Interior,Boise,ID,ACTIVE,1-Oct-14,30-Sep-15
-SCIENCEBASE.GOV,Federal Agency,Department of the Interior,Denver,CO,ACTIVE,3-Jul-14,31-Aug-15
-SIERRAWILD.GOV,Federal Agency,Department of the Interior,Yosemite,CA,ACTIVE,9-Apr-14,16-Apr-15
-SNAP.GOV,Federal Agency,Department of the Interior,Washington,DC,ACTIVE,2-Dec-14,29-Jan-16
-USBR.GOV,Federal Agency,Department of the Interior,Denver,CO,ACTIVE,20-Aug-14,12-Oct-15
-USGS.GOV,Federal Agency,Department of the Interior,Reston,VA,ACTIVE,4-Aug-14,30-Sep-15
-UTAHFIREINFO.GOV,Federal Agency,Department of the Interior,Denver,CO,ACTIVE,30-Sep-14,30-Sep-15
-VOLCANO.GOV,Federal Agency,Department of the Interior,Anchorage,AK,ACTIVE,23-Dec-14,23-Dec-15
-VOLUNTEER.GOV,Federal Agency,Department of the Interior,Reston,VA,ACTIVE,11-Aug-14,30-Sep-15
-WATERMONITOR.GOV,Federal Agency,Department of the Interior,Reston,VA,ACTIVE,28-Jul-14,27-Aug-15
-WILDLIFEADAPTATIONSTRATEGY.GOV,Federal Agency,Department of the Interior,Arlington,VA,ACTIVE,23-Jan-15,22-Feb-16
-WLCI.GOV,Federal Agency,Department of the Interior,Denver,CO,ACTIVE,17-Nov-14,17-Nov-15
-YOUTHGO.GOV,Federal Agency,Department of the Interior,Shepherdstown,WV,ACTIVE,3-Dec-14,28-Dec-15
-AMA.GOV,Federal Agency,Department of the Treasury,Washington,DC,ACTIVE,15-Oct-14,30-Sep-15
-AMERICATHEBEAUTIFULQUARTERS.GOV,Federal Agency,Department of the Treasury,Washington,DC,ACTIVE,13-Jan-15,22-Mar-16
-ASAP.GOV,Federal Agency,Department of the Treasury,Washington,DC,ACTIVE,15-Oct-14,30-Sep-15
-AYUDACONMIBANCO.GOV,Federal Agency,Department of the Treasury,Washington,DC,ACTIVE,21-Nov-14,4-Feb-16
-BANKANSWERS.GOV,Federal Agency,Department of the Treasury,Washington,DC,ACTIVE,16-Jul-14,18-Jun-15
-BANKCUSTOMER.GOV,Federal Agency,Department of the Treasury,Washington,DC,ACTIVE,16-Jul-14,18-Jun-15
-BANKCUSTOMERASSISTANCE.GOV,Federal Agency,Department of the Treasury,Washington,DC,ACTIVE,16-Jul-14,18-Jun-15
-BANKHELP.GOV,Federal Agency,Department of the Treasury,Washington,DC,ACTIVE,16-Jul-14,18-Jun-15
-BANKNET.GOV,Federal Agency,Department of the Treasury,Washington,DC,ACTIVE,14-Oct-14,30-Sep-15
-BEP.GOV,Federal Agency,Department of the Treasury,Washington,DC,ACTIVE,16-Jul-14,7-May-15
-BFEM.GOV,Federal Agency,Department of the Treasury,Washington,DC,ACTIVE,16-Jul-14,16-May-15
-BONDPRO.GOV,Federal Agency,Department of the Treasury,Washington,DC,ACTIVE,15-Oct-14,30-Sep-15
-CCAC.GOV,Federal Agency,Department of the Treasury,Washington,DC,ACTIVE,15-Oct-14,30-Sep-15
-CDFIFUND.GOV,Federal Agency,Department of the Treasury,Washington,DC,ACTIVE,24-Oct-14,7-Oct-15
-COMPLAINTREFERRALEXPRESS.GOV,Federal Agency,Department of the Treasury,Washington,DC,ACTIVE,21-Nov-14,12-Feb-16
-COMPTROLLEROFTHECURRENCY.GOV,Federal Agency,Department of the Treasury,Washington,DC,ACTIVE,29-Oct-14,14-Dec-15
-DIRECTOASUCUENTA.GOV,Federal Agency,Department of the Treasury,Washington,DC,ACTIVE,29-Oct-14,21-Nov-15
-EFTPS.GOV,Federal Agency,Department of the Treasury,Washington,DC,ACTIVE,24-Oct-14,7-Oct-15
-ETA-FIND.GOV,Federal Agency,Department of the Treasury,DALLAS,TX,ACTIVE,9-Jul-14,7-Oct-15
-ETHICSBURG.GOV,Federal Agency,Department of the Treasury,Parkersburg,WV,ACTIVE,5-Aug-14,1-Sep-15
-EYENOTE.GOV,Federal Agency,Department of the Treasury,Washington,DC,ACTIVE,29-Oct-14,21-Dec-15
-FEDERALINVESTMENTS.GOV,Federal Agency,Department of the Treasury,Pakersburg,WV,ACTIVE,14-Oct-14,30-Sep-15
-FEDINVEST.GOV,Federal Agency,Department of the Treasury,Parkersburg,WV,ACTIVE,24-Oct-14,7-Oct-15
-FINANCIALRESEARCH.GOV,Federal Agency,Department of the Treasury,Washington,DC,ACTIVE,18-Dec-14,18-Dec-15
-FINANCIALSTABILITY.GOV,Federal Agency,Department of the Treasury,Washington,DC,ACTIVE,21-Nov-14,6-Feb-16
-FINCEN.GOV,Federal Agency,Department of the Treasury,Vienna,VA,ACTIVE,2-Oct-14,7-Oct-15
-FSOC.GOV,Federal Agency,Department of the Treasury,Washington,DC,ACTIVE,21-Nov-14,7-Feb-16
-FTTESTTWAI.GOV,Federal Agency,Department of the Treasury,Hyattsville,MD,ACTIVE,29-Oct-14,4-Dec-15
-GODIRECT.GOV,Federal Agency,Department of the Treasury,Washington,DC,ACTIVE,29-Oct-14,21-Nov-15
-GWA.GOV,Federal Agency,Department of the Treasury,Hyattsville,MD,ACTIVE,15-Oct-14,30-Sep-15
-HELPWITHMYBANK.GOV,Federal Agency,Department of the Treasury,Washington,DC,ACTIVE,28-Oct-14,26-Oct-15
-HELPWITHMYCHECKINGACCOUNT.GOV,Federal Agency,Department of the Treasury,Washington,DC,ACTIVE,12-Dec-14,6-Feb-16
-HELPWITHMYCREDITCARD.GOV,Federal Agency,Department of the Treasury,Washington,DC,ACTIVE,12-Dec-14,6-Feb-16
-HELPWITHMYCREDITCARDBANK.GOV,Federal Agency,Department of the Treasury,Washington,DC,ACTIVE,12-Dec-14,6-Feb-16
-HELPWITHMYMORTGAGE.GOV,Federal Agency,Department of the Treasury,Washington,DC,ACTIVE,29-Oct-14,19-Dec-15
-HELPWITHMYMORTGAGEBANK.GOV,Federal Agency,Department of the Treasury,Washington,DC,ACTIVE,29-Oct-14,19-Dec-15
-IPAC.GOV,Federal Agency,Department of the Treasury,Boston,MA,ACTIVE,15-Oct-14,30-Sep-15
-IPP.GOV,Federal Agency,Department of the Treasury,McLean,VA,ACTIVE,15-Oct-14,30-Sep-15
-IRS.GOV,Federal Agency,Department of the Treasury,McLean,VA,ACTIVE,14-Oct-14,30-Sep-15
-IRSAUCTIONS.GOV,Federal Agency,Department of the Treasury,McLean,VA,ACTIVE,21-Jul-14,6-Jul-15
-IRSNET.GOV,Federal Agency,Department of the Treasury,McLean,VA,ACTIVE,28-Oct-14,27-Nov-15
-IRSSALES.GOV,Federal Agency,Department of the Treasury,McLean,VA,ACTIVE,21-Jul-14,6-Jul-15
-IRSVIDEOS.GOV,Federal Agency,Department of the Treasury,Washington,DC,ACTIVE,21-Jul-14,3-May-15
-ITS.GOV,Federal Agency,Department of the Treasury,McLean,VA,ACTIVE,13-Jan-15,1-Apr-16
-MAKINGHOMEAFFORDABLE.GOV,Federal Agency,Department of the Treasury,Washington,DC,ACTIVE,12-Dec-14,10-Mar-16
-MHA.GOV,Federal Agency,Department of the Treasury,Washington,DC,ACTIVE,21-Nov-14,7-Feb-16
-MONEYFACTORY.GOV,Federal Agency,Department of the Treasury,Washington,DC,ACTIVE,24-Oct-14,7-Oct-15
-MONEYFACTORYSTORE.GOV,Federal Agency,Department of the Treasury,Washington,DC,ACTIVE,29-Oct-14,23-Nov-15
-MSB.GOV,Federal Agency,Department of the Treasury,Vienna,VA,ACTIVE,2-Oct-14,7-Oct-15
-MYMONEY.GOV,Federal Agency,Department of the Treasury,Washington,DC,ACTIVE,14-Oct-14,14-Sep-15
-MYRA.GOV,Federal Agency,Department of the Treasury,Washington,DC,ACTIVE,12-Dec-14,12-Dec-15
-NATIONALBANK.GOV,Federal Agency,Department of the Treasury,McLean,VA,ACTIVE,24-Oct-14,7-Oct-15
-NATIONALBANKHELP.GOV,Federal Agency,Department of the Treasury,Washington,DC,ACTIVE,22-Jul-14,18-Jun-15
-NATIONALBANKNET.GOV,Federal Agency,Department of the Treasury,Washington,DC,ACTIVE,14-Oct-14,30-Sep-15
-NAVYCASH.GOV,Federal Agency,Department of the Treasury,McLean,VA,ACTIVE,21-Nov-14,7-Oct-15
-OCC.GOV,Federal Agency,Department of the Treasury,Washington,DC,ACTIVE,14-Oct-14,30-Sep-15
-OCCHELPS.GOV,Federal Agency,Department of the Treasury,Washington,DC,ACTIVE,5-Aug-14,12-Jul-15
-OCCNET.GOV,Federal Agency,Department of the Treasury,Landover,MD,ACTIVE,13-Jan-15,15-Mar-16
-OTS.GOV,Federal Agency,Department of the Treasury,McLean,VA,ACTIVE,12-Dec-14,1-Feb-16
-PATRIOTBONDS.GOV,Federal Agency,Department of the Treasury,Parkersburg,WV,ACTIVE,14-Oct-14,1-Sep-15
-PAY.GOV,Federal Agency,Department of the Treasury,Washington,DC,ACTIVE,14-Oct-14,30-Sep-15
-PRACOMMENT.GOV,Federal Agency,Department of the Treasury,Washington,DC,ACTIVE,22-Jul-14,11-Jun-15
-QATESTTWAI.GOV,Federal Agency,Department of the Treasury,Hyattsville,MD,ACTIVE,29-Oct-14,4-Dec-15
-SAVINGSBOND.GOV,Federal Agency,Department of the Treasury,Mclean,VA,ACTIVE,24-Oct-14,7-Oct-15
-SAVINGSBONDS.GOV,Federal Agency,Department of the Treasury,McLean,VA,ACTIVE,24-Oct-14,7-Oct-15
-SAVINGSBONDWIZARD.GOV,Federal Agency,Department of the Treasury,Mclean,VA,ACTIVE,5-Aug-14,30-Sep-15
-SIGTARP.GOV,Federal Agency,Department of the Treasury,Washington,DC,ACTIVE,21-Nov-14,14-Jan-16
-SLGS.GOV,Federal Agency,Department of the Treasury,Mclean,VA,ACTIVE,5-Aug-14,30-Sep-15
-TAAPS.GOV,Federal Agency,Department of the Treasury,Mclean,VA,ACTIVE,24-Oct-14,7-Oct-15
-TAX.GOV,Federal Agency,Department of the Treasury,McLean,VA,ACTIVE,24-Oct-14,7-Oct-15
-TCIS.GOV,Federal Agency,Department of the Treasury,Washington,DC,ACTIVE,15-Oct-14,30-Sep-15
-TIGTA.GOV,Federal Agency,Department of the Treasury,Washington,DC,ACTIVE,24-Oct-14,7-Oct-15
-TIGTANET.GOV,Federal Agency,Department of the Treasury,McLean,VA,ACTIVE,5-Aug-14,30-Sep-15
-TREAS.GOV,Federal Agency,Department of the Treasury,Washington,DC,ACTIVE,28-Oct-14,7-Oct-15
-TREASLOCKBOX.GOV,Federal Agency,Department of the Treasury,Washington,DC,ACTIVE,29-Oct-14,17-Nov-15
-TREASURY.FED.US,Federal Agency,Department of the Treasury,Washington,DC,ACTIVE,12-Dec-14,5-Feb-16
-TREASURY.GOV,Federal Agency,Department of the Treasury,Washington,DC,ACTIVE,15-Oct-14,7-Oct-15
-TREASURYAUCTION.GOV,Federal Agency,Department of the Treasury,Parkersburg,WV,ACTIVE,14-Oct-14,27-Sep-15
-TREASURYAUCTIONS.GOV,Federal Agency,Department of the Treasury,Mclean,VA,ACTIVE,28-Oct-14,7-Oct-15
-TREASURYDIRECT.GOV,Federal Agency,Department of the Treasury,McLean,VA,ACTIVE,28-Oct-14,7-Oct-15
-TREASURYECM.GOV,Federal Agency,Department of the Treasury,Washington,DC,ACTIVE,21-Nov-14,11-Jan-16
-TREASURYHUNT.GOV,Federal Agency,Department of the Treasury,Parkersburg,WV,ACTIVE,21-Nov-14,18-Feb-16
-TREASURYSCAMS.GOV,Federal Agency,Department of the Treasury,Mclean,VA,ACTIVE,28-Oct-14,7-Oct-15
-TRS.GOV,Federal Agency,Department of the Treasury,Washington,DC,ACTIVE,5-Aug-14,30-Sep-15
-TTB.GOV,Federal Agency,Department of the Treasury,Washington,DC,ACTIVE,5-Aug-14,30-Sep-15
-TTBONLINE.GOV,Federal Agency,Department of the Treasury,McLean,VA,ACTIVE,21-Nov-14,1-Feb-16
-TTLPLUS.GOV,Federal Agency,Department of the Treasury,St. Louis,MO,ACTIVE,5-Aug-14,30-Sep-15
-TWAI.GOV,Federal Agency,Department of the Treasury,Washington,DC,ACTIVE,5-Aug-14,30-Sep-15
-USASPENDING.GOV,Federal Agency,Department of the Treasury,Washington,DC,ACTIVE,23-Jul-14,13-Jun-15
-USDEBITCARD.GOV,Federal Agency,Department of the Treasury,Mclean,VA,ACTIVE,28-Oct-14,7-Oct-15
-USMINT.GOV,Federal Agency,Department of the Treasury,Washington,DC,ACTIVE,28-Oct-14,7-Oct-15
-USTREAS.GOV,Federal Agency,Department of the Treasury,McLean,VA,ACTIVE,28-Oct-14,7-Oct-15
-VERIFYPAYMENT.GOV,Federal Agency,Department of the Treasury,Parkersburg,WV,ACTIVE,28-Oct-14,15-Oct-15
-WIZARD.GOV,Federal Agency,Department of the Treasury,Mclean,VA,ACTIVE,15-Oct-14,30-Sep-15
-WORKPLACE.GOV,Federal Agency,Department of the Treasury,Washington,DC,ACTIVE,5-Aug-14,6-Aug-15
-911.GOV,Federal Agency,Department of Transportation,Washington,DC,ACTIVE,9-Mar-15,7-Jun-16
-BTS.GOV,Federal Agency,Department of Transportation,Washington,DC,ACTIVE,26-Dec-13,30-Sep-14
-CFLHD.GOV,Federal Agency,Department of Transportation,Lakewood,CO,ACTIVE,12-Aug-14,30-Sep-15
-DISTRACTEDDRIVING.GOV,Federal Agency,Department of Transportation,Washington,DC,ACTIVE,20-Mar-14,13-Jun-15
-DISTRACTION.GOV,Federal Agency,Department of Transportation,Washington,DC,ACTIVE,24-Sep-14,22-Dec-15
-DOT.GOV,Federal Agency,Department of Transportation,Washington,DC,ACTIVE,4-Sep-14,28-Sep-15
-DOTIDEAHUB.GOV,Federal Agency,Department of Transportation,Washington,DC,ACTIVE,13-Aug-14,23-Jun-15
-DOTTRAFFICRECORDS.GOV,Federal Agency,Department of Transportation,Room 2202,DC,ACTIVE,24-Apr-14,20-Jul-15
-DOTTRCC.GOV,Federal Agency,Department of Transportation,Washington,DC,ACTIVE,3-Sep-14,20-Jul-15
-EMS.GOV,Federal Agency,Department of Transportation,Washington,DC,ACTIVE,17-Jun-14,15-Sep-15
-ESC.GOV,Federal Agency,Department of Transportation,Oklahoma City,OK,ACTIVE,14-Jul-14,30-Sep-15
-FAA.GOV,Federal Agency,Department of Transportation,Washington,DC,ACTIVE,8-Jul-14,30-Sep-15
-FAASAFETY.GOV,Federal Agency,Department of Transportation,Washington,DC,ACTIVE,5-Sep-14,30-Sep-15
-FDR.GOV,Federal Agency,Department of Transportation,Washington,DC,ACTIVE,3-Dec-14,3-Dec-15
-FMIP.GOV,Federal Agency,Department of Transportation,Washington,DC,ACTIVE,15-May-14,3-May-15
-ITALLADDSUP.GOV,Federal Agency,Department of Transportation,Washington,DC,ACTIVE,1-Aug-14,16-Sep-15
-JCCBI.GOV,Federal Agency,Department of Transportation,Oklahoma City,OK,ACTIVE,20-Aug-14,30-Sep-15
-MARVIEW.GOV,Federal Agency,Department of Transportation,Washington,DC,ACTIVE,15-Aug-14,2-Nov-14
-MDA.GOV,Federal Agency,Department of Transportation,Washington,DC,ACTIVE,29-Jan-15,30-Sep-15
-NHTSA.GOV,Federal Agency,Department of Transportation,Washington,DC,ACTIVE,2-Jul-14,30-Sep-15
-NTDPROGRAM.GOV,Federal Agency,Department of Transportation,Washington,DC,ACTIVE,22-Jan-14,9-Feb-15
-PLAINLANGUAGE.GOV,Federal Agency,Department of Transportation,Washington,DC,ACTIVE,11-Sep-14,30-Sep-15
-PROTECTYOURMOVE.GOV,Federal Agency,Department of Transportation,Washington,DC,ACTIVE,20-Mar-14,8-Jun-15
-SAFERCAR.GOV,Federal Agency,Department of Transportation,Washington,DC,ACTIVE,2-Jul-14,30-Sep-15
-SAFERTRUCK.GOV,Federal Agency,Department of Transportation,Washington,DC,ACTIVE,3-Feb-15,21-Mar-16
-SHARETHEROADSAFELY.GOV,Federal Agency,Department of Transportation,Washington,DC,ACTIVE,20-Oct-14,20-Nov-15
-STRONGPORTS.GOV,Federal Agency,Department of Transportation,Washington,DC,ACTIVE,17-Sep-14,17-Sep-15
-SUSTAINABLECOMMUNITIES.GOV,Federal Agency,Department of Transportation,Washington,DC,ACTIVE,27-Feb-15,24-Feb-16
-TFHRC.GOV,Federal Agency,Department of Transportation,Mclean,VA,ACTIVE,22-Jul-14,30-Sep-15
-TRAFFICSAFETYMARKETING.GOV,Federal Agency,Department of Transportation,Washington,DC,ACTIVE,3-Nov-14,30-Jan-16
-TRANSPORTATION.GOV,Federal Agency,Department of Transportation,Washington,DC,ACTIVE,4-Sep-14,30-Sep-15
-TRANSPORTATIONRESEARCH.GOV,Federal Agency,Department of Transportation,Washington,DC,ACTIVE,14-Nov-14,6-Jan-16
-UNITEDWERIDE.GOV,Federal Agency,Department of Transportation,Washington,DC,ACTIVE,7-Jan-15,6-Jan-16
-CDCO.GOV,Federal Agency,Department of Veterans Affairs,Austin,TX,ACTIVE,7-Oct-14,15-Oct-15
-LASEGUNDACOSA.GOV,Federal Agency,Department of Veterans Affairs,Washington,DC,ACTIVE,28-May-14,28-May-15
-NATIONALRESOURCEDIRECTORY.GOV,Federal Agency,Department of Veterans Affairs,Washington,DC,ACTIVE,27-Aug-14,30-Jun-15
-NRD.GOV,Federal Agency,Department of Veterans Affairs,Washington,DC,ACTIVE,27-Aug-14,30-Sep-15
-THESECONDTHING.GOV,Federal Agency,Department of Veterans Affairs,Washington,DC,ACTIVE,2-Jul-14,26-Sep-15
-VA.GOV,Federal Agency,Department of Veterans Affairs,Washington,DC,ACTIVE,24-Jun-14,1-Sep-15
-VET-BIZ.GOV,Federal Agency,Department of Veterans Affairs,Washington,DC,SERVER-HOLD,16-Jul-10,30-Sep-11
-VETBIZ.GOV,Federal Agency,Department of Veterans Affairs,Washington,DC,ACTIVE,9-Oct-14,8-Oct-15
-VETSUCCESS.GOV,Federal Agency,Department of Veterans Affairs,Washington,DC,SERVER-HOLD,15-Jul-11,23-Aug-12
-BTO.GOV,Federal Agency,Director of National Intelligence,McLean,VA,SERVER-HOLD,1-Nov-10,27-Jan-12
-COUNTERWMD.GOV,Federal Agency,Director of National Intelligence,Washington,DC,ACTIVE,10-Sep-14,16-Mar-15
-DNI.GOV,Federal Agency,Director of National Intelligence,McLean,VA,ACTIVE,12-Aug-14,24-Feb-15
-IARPA-IDEAS.GOV,Federal Agency,Director of National Intelligence,Washington,DC,ACTIVE,4-Aug-14,30-Aug-15
-IARPA.GOV,Federal Agency,Director of National Intelligence,College Park,MD,ACTIVE,25-Nov-14,14-Feb-16
-ICJOINTDUTY.GOV,Federal Agency,Director of National Intelligence,Washington,DC,ACTIVE,21-May-14,22-Jun-15
-INTELINK.GOV,Federal Agency,Director of National Intelligence,Ft. George G. Meade,MD,ACTIVE,21-Oct-14,30-Sep-15
-INTELLIGENCE.GOV,Federal Agency,Director of National Intelligence,Washington,DC,ACTIVE,28-Aug-14,10-Sep-15
-ISE.GOV,Federal Agency,Director of National Intelligence,Washington ,DC,ACTIVE,20-Feb-14,6-Apr-15
-NCIX.GOV,Federal Agency,Director of National Intelligence,Washington,DC,ACTIVE,9-Mar-15,9-Sep-15
-NMIC.GOV,Federal Agency,Director of National Intelligence,Washington,DC,ACTIVE,14-Oct-14,6-Jan-16
-ODNI.GOV,Federal Agency,Director of National Intelligence,Washington,DC,ACTIVE,12-Aug-14,24-Feb-15
-OSIS.GOV,Federal Agency,Director of National Intelligence,Fort George G. Meade,MD,ACTIVE,21-Oct-14,30-Sep-15
-PIX.GOV,Federal Agency,Director of National Intelligence,Washington,DC,ACTIVE,24-Feb-15,24-Feb-16
-UGOV.GOV,Federal Agency,Director of National Intelligence,Fort George G Meade,MD,ACTIVE,21-Oct-14,30-Sep-15
-AIRNOW.GOV,Federal Agency,Environmental Protection Agency,Durham,NC,ACTIVE,18-Aug-14,1-Sep-15
-AQI.GOV,Federal Agency,Environmental Protection Agency,Durham,NC,ACTIVE,18-Aug-14,1-Sep-15
-CBI-EPA.GOV,Federal Agency,Environmental Protection Agency,Durham,NC,ACTIVE,13-Nov-14,27-Jan-16
-ENERGYSTAR.GOV,Federal Agency,Environmental Protection Agency,Washington,DC,ACTIVE,4-Sep-14,25-Oct-15
-EPA-ECHO.GOV,Federal Agency,Environmental Protection Agency,Washington,DC,ACTIVE,16-May-14,11-May-15
-EPA-OTIS.GOV,Federal Agency,Environmental Protection Agency,Washington,DC,ACTIVE,16-May-14,11-May-15
-EPA.GOV,Federal Agency,Environmental Protection Agency,Research Triangle Park,NC,ACTIVE,18-Aug-14,1-Sep-15
-FDMS.GOV,Federal Agency,Environmental Protection Agency,Washington,DC,ACTIVE,26-Aug-14,16-Sep-15
-FEDCENTER.GOV,Federal Agency,Environmental Protection Agency,Champaign,IL,ACTIVE,2-Sep-14,30-Sep-15
-FRTR.GOV,Federal Agency,Environmental Protection Agency,Omaha,NE,ACTIVE,19-Feb-15,30-Sep-15
-GREENGOV.GOV,Federal Agency,Environmental Protection Agency, Washington,DC,ACTIVE,12-Nov-14,15-Jan-16
-OFEE.GOV,Federal Agency,Environmental Protection Agency,Washington,DC,ACTIVE,14-Oct-14,19-Oct-15
-REGULATION.GOV,Federal Agency,Environmental Protection Agency,Washington,DC,ACTIVE,26-Aug-14,30-Sep-15
-REGULATIONS.GOV,Federal Agency,Environmental Protection Agency,Washington,DC,ACTIVE,26-Aug-14,30-Sep-15
-RELOCATEFEDS.GOV,Federal Agency,Environmental Protection Agency,Cincinnati,OH,ACTIVE,16-Jan-15,16-Jan-16
-SUSTAINABILITY.GOV,Federal Agency,Environmental Protection Agency,Washington,DC,ACTIVE,12-Nov-14,21-Jan-16
-URBANWATERS.GOV,Federal Agency,Environmental Protection Agency,Washington,DC,ACTIVE,2-Jul-14,20-Jun-15
-EEOC.GOV,Federal Agency,Equal Employment Opportunity Commission,Washington,DC,ACTIVE,7-Aug-14,30-Sep-15
-ASTRONGMIDDLECLASS.GOV,Federal Agency,Executive Office of the President,Washington,DC,ACTIVE,16-Jan-15,29-Jan-16
-BUDGET.GOV,Federal Agency,Executive Office of the President,Washington,DC,ACTIVE,24-Sep-14,30-Sep-15
-CHANGE.GOV,Federal Agency,Executive Office of the President,Arlington,VA,ACTIVE,24-Sep-14,5-Nov-15
-EARMARKS.GOV,Federal Agency,Executive Office of the President,Washington,DC,ACTIVE,2-Dec-14,30-Jan-16
-EGOV.GOV,Federal Agency,Executive Office of the President,Washington,DC,ACTIVE,24-Sep-14,30-Sep-15
-EOP.GOV,Federal Agency,Executive Office of the President,Washington,DC,ACTIVE,24-Sep-14,30-Sep-15
-ETHICS.GOV,Federal Agency,Executive Office of the President,Washington ,DC,ACTIVE,24-Sep-14,18-Oct-15
-EXRWH.GOV,Federal Agency,Executive Office of the President,Washington,DC,ACTIVE,3-Dec-14,7-Jan-16
-FISCALCOMMISSION.GOV,Federal Agency,Executive Office of the President,Washington,DC,ACTIVE,10-Apr-14,24-Apr-15
-HC.GOV,Federal Agency,Executive Office of the President,Washington,DC,ACTIVE,3-Oct-14,27-Sep-15
-ITDASHBOARD.GOV,Federal Agency,Executive Office of the President,Washington,DC,ACTIVE,15-May-14,19-May-15
-JOININGFORCES.GOV,Federal Agency,Executive Office of the President,Washington,DC,ACTIVE,10-Apr-14,5-Apr-15
-LETSMOVE.GOV,Federal Agency,Executive Office of the President,Washington,DC,ACTIVE,16-Jan-15,5-Feb-16
-MAX.GOV,Federal Agency,Executive Office of the President,NW,WA,ACTIVE,28-Oct-14,11-Dec-15
-NEPA.GOV,Federal Agency,Executive Office of the President,Washington,DC,ACTIVE,4-Sep-14,9-May-15
-NOTALONE.GOV,Federal Agency,Executive Office of the President,Washington,DC,ACTIVE,28-Apr-14,28-Apr-15
-NSTIC.GOV,Federal Agency,Executive Office of the President,Gaithersburg,MD,ACTIVE,21-Aug-14,25-Jul-15
-OMB.GOV,Federal Agency,Executive Office of the President,Washington,DC,ACTIVE,24-Sep-14,30-Sep-15
-OMBLOG.GOV,Federal Agency,Executive Office of the President,Washington,DC,ACTIVE,24-Apr-14,21-Apr-15
-ONDCP.GOV,Federal Agency,Executive Office of the President,Washington,DC,ACTIVE,3-Dec-14,9-Dec-15
-OSTP.GOV,Federal Agency,Executive Office of the President,Washington,DC,ACTIVE,24-Sep-14,30-Sep-15
-PAYMENTACCURACY.GOV,Federal Agency,Executive Office of the President,Washington,DC,ACTIVE,11-Feb-15,26-Mar-16
-PCI.GOV,Federal Agency,Executive Office of the President,Washington,DC,ACTIVE,3-Oct-14,27-Sep-15
-PRESIDIO.GOV,Federal Agency,Executive Office of the President,San Francisco,CA,ACTIVE,24-Sep-14,30-Sep-15
-PRESIDIOTRUST.GOV,Federal Agency,Executive Office of the President,San Francisco,CA,ACTIVE,24-Sep-14,30-Sep-15
-REACHHIGHER.GOV,Federal Agency,Executive Office of the President,Washington,DC,ACTIVE,28-Apr-14,28-Apr-15
-SAVE.GOV,Federal Agency,Executive Office of the President,Washington,DC,ACTIVE,29-Jun-14,26-Aug-15
-SAVEAWARD.GOV,Federal Agency,Executive Office of the President,Washington,DC,ACTIVE,29-Jun-14,26-Aug-15
-STRONGMIDDLECLASS.GOV,Federal Agency,Executive Office of the President,Washington,DC,ACTIVE,16-Jan-15,28-Jan-16
-USTR.GOV,Federal Agency,Executive Office of the President,Washington,DC,ACTIVE,24-Sep-14,30-Sep-15
-WH.GOV,Federal Agency,Executive Office of the President,Washington,DC,ACTIVE,29-Jul-14,4-Aug-15
-WHITEHOUSE.GOV,Federal Agency,Executive Office of the President,Washington,DC,ACTIVE,24-Sep-14,30-Sep-15
-WHITEHOUSEDRUGPOLICY.GOV,Federal Agency,Executive Office of the President,Washington,DC,ACTIVE,3-Oct-14,26-Aug-15
-EXIM.GOV,Federal Agency,Export/Import Bank of the U.S.,Washington,DC,ACTIVE,10-Jul-14,30-Sep-15
-EXIMCOOP.GOV,Federal Agency,Export/Import Bank of the U.S.,Washington,DC,ACTIVE,10-Jul-14,30-Sep-15
-FCA.GOV,Federal Agency,Farm Credit Administration,McLean,VA,ACTIVE,16-Jul-14,30-Sep-15
-FCSIC.GOV,Federal Agency,Farm Credit Administration,McLean,VA,ACTIVE,8-Jul-14,5-Oct-15
-BROADBAND.GOV,Federal Agency,Federal Communications Commission,Washington,DC,ACTIVE,11-Feb-15,28-Apr-16
-BROADBANDMAP.GOV,Federal Agency,Federal Communications Commission,Washington,DC,ACTIVE,4-Dec-14,6-Feb-16
-DTV.GOV,Federal Agency,Federal Communications Commission,Washington,DC,ACTIVE,10-Jul-14,23-Sep-15
-FCC.GOV,Federal Agency,Federal Communications Commission,Washington,DC,ACTIVE,10-Jul-14,8-Sep-15
-FCCUNIVERSITY.GOV,Federal Agency,Federal Communications Commission,Washington,DC,ACTIVE,10-Jul-14,8-Sep-15
-LIFELINE.GOV,Federal Agency,Federal Communications Commission,Washington,DC,ACTIVE,4-Dec-14,1-Feb-16
-NBM.GOV,Federal Agency,Federal Communications Commission,Washington,DC,ACTIVE,21-Oct-14,18-Nov-15
-OPENINTERNET.GOV,Federal Agency,Federal Communications Commission,Washington,DC,ACTIVE,10-Jul-14,18-Sep-15
-ECONOMICINCLUSION.GOV,Federal Agency,Federal Deposit Insurance Corporation,Arlington,VA,ACTIVE,10-Oct-14,1-Dec-15
-FDIC.GOV,Federal Agency,Federal Deposit Insurance Corporation,Arlington,VA,ACTIVE,16-Jun-14,10-Sep-15
-FDICBETS.GOV,Federal Agency,Federal Deposit Insurance Corporation,Arlington,VA,ACTIVE,20-Aug-14,29-Sep-15
-FDICCONNECT.GOV,Federal Agency,Federal Deposit Insurance Corporation,Arlington,VA,ACTIVE,16-Jun-14,10-Sep-15
-FDICIG.GOV,Federal Agency,Federal Deposit Insurance Corporation,Arlington,VA,ACTIVE,16-Jun-14,10-Sep-15
-FDICOIG.GOV,Federal Agency,Federal Deposit Insurance Corporation,Washington,DC,ACTIVE,16-Jun-14,10-Sep-15
-FDICSALES.GOV,Federal Agency,Federal Deposit Insurance Corporation,Arlington,VA,ACTIVE,14-May-14,15-Jul-15
-FDICSEGURO.GOV,Federal Agency,Federal Deposit Insurance Corporation,Arlington,VA,ACTIVE,20-Aug-14,21-Oct-15
-MYFDIC.GOV,Federal Agency,Federal Deposit Insurance Corporation,Arlington,VA,ACTIVE,16-Jun-14,12-Sep-15
-MYFDICINSURANCE.GOV,Federal Agency,Federal Deposit Insurance Corporation,Arlington,VA,ACTIVE,16-Jun-14,12-Sep-15
-FEC.GOV,Federal Agency,Federal Elections Commission,Washington,DC,ACTIVE,24-Sep-14,30-Sep-15
-FERC.GOV,Federal Agency,Federal Energy Regulatory Commission,Washington,DC,ACTIVE,2-Jul-14,30-Sep-15
-FERCALT.GOV,Federal Agency,Federal Energy Regulatory Commission,Washington,DC,ACTIVE,2-Jul-14,30-Sep-15
-FHFA.GOV,Federal Agency,Federal Housing Finance Agency,Washington,DC,ACTIVE,21-Apr-14,16-Jul-15
-FHFB.GOV,Federal Agency,Federal Housing Finance Agency,Washington,DC,ACTIVE,2-Jul-14,30-Sep-15
-HARP.GOV,Federal Agency,Federal Housing Finance Agency,Washington,DC,ACTIVE,25-Jun-14,23-Sep-15
-OFHEO.GOV,Federal Agency,Federal Housing Finance Agency,Washington,DC,ACTIVE,2-Jul-14,30-Sep-15
-FHFAOIG.GOV,Federal Agency,Federal Housing Finance Agency Office of Inspector General,Washington,DC,ACTIVE,9-Dec-14,9-Dec-15
-FLRA.GOV,Federal Agency,Federal Labor Relations Authority,Washington,DC,ACTIVE,2-Dec-14,24-Sep-15
-FMC.GOV,Federal Agency,Federal Maritime Commission,Washington,DC,ACTIVE,27-Aug-14,30-Sep-15
-FMCS.GOV,Federal Agency,Federal Mediation and Conciliation Service,Washington,DC,ACTIVE,29-Sep-14,30-Sep-15
-FBIIC.GOV,Federal Agency,Federal Reserve System,Washington,DC,ACTIVE,2-Jul-14,30-Sep-15
-FEDCENTENNIAL.GOV,Federal Agency,Federal Reserve System,Washington,DC,ACTIVE,21-May-14,19-Jul-15
-FEDERALRESERVE.GOV,Federal Agency,Federal Reserve System,Washington,DC,ACTIVE,2-Jul-14,30-Sep-15
-FEDERALRESERVE100.GOV,Federal Agency,Federal Reserve System,Washington ,DC,ACTIVE,8-Jan-15,10-Jan-16
-FEDERALRESERVE2013.GOV,Federal Agency,Federal Reserve System,Washington,DC,ACTIVE,8-Jan-15,10-Jan-16
-FEDERALRESERVECENTENNIAL.GOV,Federal Agency,Federal Reserve System,Washington ,DC,ACTIVE,8-Jan-15,10-Jan-16
-FEDERALRESERVECENTENNIALCELEBRATION.GOV,Federal Agency,Federal Reserve System,Washington,DC,ACTIVE,8-Jan-15,10-Jan-16
-FEDERALRESERVECONSUMERHELP.GOV,Federal Agency,Federal Reserve System,Washington,DC,ACTIVE,2-Jul-14,11-Sep-15
-FEDPARTNERSHIP.GOV,Federal Agency,Federal Reserve System,Washington,DC,ACTIVE,21-May-14,13-Jun-15
-FFIEC.GOV,Federal Agency,Federal Reserve System,Washington,DC,ACTIVE,2-Jul-14,30-Sep-15
-FRB.FED.US,Federal Agency,Federal Reserve System,Washington,DC,ACTIVE,2-Jul-14,30-Sep-15
-FRB.GOV,Federal Agency,Federal Reserve System,Washington,DC,ACTIVE,2-Jul-14,30-Aug-15
-FRS.GOV,Federal Agency,Federal Reserve System,Washington,DC,ACTIVE,2-Jul-14,30-Sep-15
-NEWMONEY.GOV,Federal Agency,Federal Reserve System,Washington,DC,ACTIVE,2-Jul-14,26-Aug-15
-EXPLORETSP.GOV,Federal Agency,Federal Retirement Thrift Investment Board,Washington,DC,ACTIVE,31-Jul-14,27-Aug-15
-FRTIB.GOV,Federal Agency,Federal Retirement Thrift Investment Board,Washington,DC,ACTIVE,31-Jul-14,30-Sep-15
-FRTIBTEST.GOV,Federal Agency,Federal Retirement Thrift Investment Board,Washigton,DC,ACTIVE,22-Jan-15,7-Feb-16
-TSP.GOV,Federal Agency,Federal Retirement Thrift Investment Board,Washington,DC,ACTIVE,31-Jul-14,30-Sep-15
-TSPTEST.GOV,Federal Agency,Federal Retirement Thrift Investment Board,Washington,DC,ACTIVE,22-Jan-15,18-Jan-16
-ADMONGO.GOV,Federal Agency,Federal Trade Commission,Washington,DC,ACTIVE,1-Apr-14,26-Jun-15
-ALERTAENLINEA.GOV,Federal Agency,Federal Trade Commission,Washington,DC,ACTIVE,10-Sep-14,21-Sep-15
-ANNUALCREDITREPORT.GOV,Federal Agency,Federal Trade Commission,Washington,DC,ACTIVE,1-Apr-14,26-Jun-15
-CONSUMER.GOV,Federal Agency,Federal Trade Commission,Washington,DC,ACTIVE,10-Sep-14,2-Sep-15
-CONSUMERSENTINEL.GOV,Federal Agency,Federal Trade Commission,Washington,DC,ACTIVE,27-Jan-15,19-Feb-16
-CONSUMERSENTINELNETWORK.GOV,Federal Agency,Federal Trade Commission,Washington,DC,ACTIVE,27-Jan-15,19-Feb-16
-CONSUMIDOR.GOV,Federal Agency,Federal Trade Commission,Washington,DC,ACTIVE,10-Sep-14,2-Dec-15
-DONOTCALL.GOV,Federal Agency,Federal Trade Commission,Washington,DC,ACTIVE,10-Sep-14,2-Sep-15
-DONTSERVETEENS.GOV,Federal Agency,Federal Trade Commission,Washington,DC,ACTIVE,27-Jan-15,12-Jan-16
-ECONSUMER.GOV,Federal Agency,Federal Trade Commission,Washington,DC,ACTIVE,10-Sep-14,2-Sep-15
-FREECREDITREPORT.GOV,Federal Agency,Federal Trade Commission,Washington,DC,ACTIVE,1-Apr-14,26-Jun-15
-FTC.GOV,Federal Agency,Federal Trade Commission,Washington,DC,ACTIVE,10-Sep-14,2-Sep-15
-FTCCOMPLAINTASSISTANT.GOV,Federal Agency,Federal Trade Commission,Washington,DC,ACTIVE,27-Jan-15,19-Feb-16
-FTCEFILE.GOV,Federal Agency,Federal Trade Commission,Washington,DC,ACTIVE,10-Sep-14,9-Sep-15
-HSR.GOV,Federal Agency,Federal Trade Commission,Washington,DC,ACTIVE,10-Sep-14,2-Sep-15
-IDENTITYTHEFT.GOV,Federal Agency,Federal Trade Commission,Washington,DC,ACTIVE,10-Sep-14,30-Aug-15
-IDTHEFT.GOV,Federal Agency,Federal Trade Commission,Washington,DC,ACTIVE,10-Sep-14,30-Aug-15
-NCPW.GOV,Federal Agency,Federal Trade Commission,Washington,DC,ACTIVE,10-Sep-14,30-Nov-15
-ONGUARDONLINE.GOV,Federal Agency,Federal Trade Commission,Washington,DC,ACTIVE,27-Jan-15,18-Feb-16
-ONLINEONGUARD.GOV,Federal Agency,Federal Trade Commission,Washington,DC,ACTIVE,27-Jan-15,18-Feb-16
-PROTECCIONDELCONSUMIDOR.GOV,Federal Agency,Federal Trade Commission,Washington,DC,ACTIVE,27-Jan-15,21-Jan-16
-SENTINEL.GOV,Federal Agency,Federal Trade Commission,Washington,DC,ACTIVE,10-Sep-14,2-Sep-15
-UCE.GOV,Federal Agency,Federal Trade Commission,Washington,DC,ACTIVE,10-Sep-14,2-Sep-15
-USICN.GOV,Federal Agency,Federal Trade Commission,Washington,DC,ACTIVE,10-Sep-14,2-Sep-15
-ACQUISITION.GOV,Federal Agency,General Services Administration,Arlington,VA,ACTIVE,10-Mar-15,15-May-16
-ADVANTAGE.GOV,Federal Agency,General Services Administration,Washington,DC,ACTIVE,9-Jul-14,30-Sep-15
-AFADVANTAGE.GOV,Federal Agency,General Services Administration,Washington,DC,ACTIVE,9-Jul-14,30-Sep-15
-AMERICANJOBCENTER.GOV,Federal Agency,General Services Administration,Washington,DC,ACTIVE,12-May-14,14-May-15
-APPS.GOV,Federal Agency,General Services Administration,Washington,DC,ACTIVE,4-Sep-14,4-Sep-15
-BUSINESSUSA.GOV,Federal Agency,General Services Administration,Washington,DC,ACTIVE,12-Jan-15,13-Jan-16
-BUYACCESSIBLE.GOV,Federal Agency,General Services Administration,Washington,DC,ACTIVE,24-Jul-14,28-Sep-15
-CAO.GOV,Federal Agency,General Services Administration,Washington,DC,ACTIVE,24-Jul-14,30-Sep-15
-CBCA.GOV,Federal Agency,General Services Administration,Washington,DC,ACTIVE,10-Jul-14,2-Sep-15
-CCR.GOV,Federal Agency,General Services Administration,Battle Creek,MI,ACTIVE,5-Sep-14,2-Sep-15
-CFDA.GOV,Federal Agency,General Services Administration,Washington,DC,ACTIVE,5-Sep-14,30-Sep-15
-CFO.GOV,Federal Agency,General Services Administration,Washington,DC,ACTIVE,10-Nov-14,22-Nov-15
-CHALLENGE.GOV,Federal Agency,General Services Administration,Washington,DC,ACTIVE,2-Mar-15,18-Mar-16
-CHALLENGES.GOV,Federal Agency,General Services Administration,Washington,DC,ACTIVE,2-Mar-15,18-Mar-16
-CIO.GOV,Federal Agency,General Services Administration,Washington,DC,ACTIVE,24-Jul-14,30-Sep-15
-COMPUTERS4LEARNING.GOV,Federal Agency,General Services Administration,Arlington,VA,ACTIVE,3-Feb-15,2-Apr-16
-COMPUTERSFORLEARNING.GOV,Federal Agency,General Services Administration,Arlington,VA,ACTIVE,3-Feb-15,2-Apr-16
-CONNECT.GOV,Federal Agency,General Services Administration,Washington,DC,ACTIVE,10-Nov-14,10-Nov-15
-CONSUMERACTION.GOV,Federal Agency,General Services Administration,Washington,DC,ACTIVE,4-Sep-14,30-Sep-15
-CONTRACTDIRECTORY.GOV,Federal Agency,General Services Administration,Arlington,VA,ACTIVE,24-Jul-14,30-Sep-15
-CPARS.GOV,Federal Agency,General Services Administration,Washington,DC,ACTIVE,6-Mar-15,6-Apr-16
-DATA.GOV,Federal Agency,General Services Administration,Washington,DC,ACTIVE,2-Apr-14,3-Apr-15
-DIGITALGOV.GOV,Federal Agency,General Services Administration,Washington,DC,ACTIVE,1-Dec-14,2-Dec-15
-DOTGOV.GOV,Federal Agency,General Services Administration,Fairfax,VA,ACTIVE,3-Jun-10,8-Sep-15
-EAC.GOV,Federal Agency,General Services Administration,Washington,DC,ACTIVE,8-Oct-14,30-Sep-15
-ECPIC.GOV,Federal Agency,General Services Administration,Washington,DC,ACTIVE,4-Sep-14,30-Sep-15
-EFACA.GOV,Federal Agency,General Services Administration,Washington,DC,ACTIVE,10-Mar-15,8-May-16
-EFORMS.GOV,Federal Agency,General Services Administration,Washington,DC,ACTIVE,4-Sep-14,30-Sep-15
-EISENHOWERMEMORIAL.GOV,Federal Agency,General Services Administration,Washington,DC,ACTIVE,30-May-14,22-Aug-15
-EPLS.GOV,Federal Agency,General Services Administration,Arlington,VA,ACTIVE,5-Sep-14,30-Sep-15
-ESPANOL.GOV,Federal Agency,General Services Administration,Washington,DC,ACTIVE,4-Sep-14,30-Sep-15
-ESRS.GOV,Federal Agency,General Services Administration,arlington,VA,ACTIVE,6-Mar-15,1-Apr-16
-FACA.GOV,Federal Agency,General Services Administration,Washington,DC,ACTIVE,24-Jul-14,30-Sep-15
-FACADATABASE.GOV,Federal Agency,General Services Administration,Washington,DC,ACTIVE,24-Jul-14,30-Sep-15
-FAI.GOV,Federal Agency,General Services Administration,Washington,DC,ACTIVE,24-Jul-14,30-Sep-15
-FAPIIS.GOV,Federal Agency,General Services Administration,Washington,DC,ACTIVE,6-Mar-15,7-Apr-16
-FAQ.GOV,Federal Agency,General Services Administration,Washington,DC,ACTIVE,4-Sep-14,30-Sep-15
-FBO.GOV,Federal Agency,General Services Administration,Arlington,VA,ACTIVE,5-Sep-14,20-Sep-15
-FED.US,Federal Agency,General Services Administration,Washington,DC,ACTIVE,3-Jun-10,31-Dec-99
-FEDBIZOPPS.GOV,Federal Agency,General Services Administration,Arlington,VA,ACTIVE,5-Sep-14,20-Sep-15
-FEDFORMS.GOV,Federal Agency,General Services Administration,Washington,DC,ACTIVE,4-Sep-14,30-Sep-15
-FEDIDCARD.GOV,Federal Agency,General Services Administration,Washington,DC,ACTIVE,21-Aug-14,31-Oct-15
-FEDINFO.GOV,Federal Agency,General Services Administration,Washington,DC,ACTIVE,4-Sep-14,17-Sep-15
-FEDRAMP.GOV,Federal Agency,General Services Administration,Washington,DC,ACTIVE,4-Sep-14,23-Sep-15
-FEDREALESTATE.GOV,Federal Agency,General Services Administration,San Francisco,CA,ACTIVE,20-Dec-13,16-Mar-15
-FEDROOMS.GOV,Federal Agency,General Services Administration,Arlington,VA,ACTIVE,17-Dec-14,20-Dec-15
-FIDO.GOV,Federal Agency,General Services Administration,Washington,DC,ACTIVE,24-Jul-14,30-Sep-15
-FIRSTGOV.GOV,Federal Agency,General Services Administration,Washington,DC,ACTIVE,4-Sep-14,30-Sep-15
-FMI.GOV,Federal Agency,General Services Administration,Washington,DC,ACTIVE,9-May-14,30-Jul-15
-FORMS.GOV,Federal Agency,General Services Administration,Washington,DC,ACTIVE,4-Sep-14,30-Sep-15
-FPDS.GOV,Federal Agency,General Services Administration,Arlington,VA,ACTIVE,5-Sep-14,30-Sep-15
-FPKI-LAB.GOV,Federal Agency,General Services Administration,Washington,DC,ACTIVE,4-Aug-14,2-Sep-15
-FPKI.GOV,Federal Agency,General Services Administration,Washington,DC,ACTIVE,9-Feb-15,11-Mar-16
-FRPP-PA.GOV,Federal Agency,General Services Administration,WASHINGTON,DC,ACTIVE,9-May-14,10-Jul-15
-FSD.GOV,Federal Agency,General Services Administration,Arlington,VA,ACTIVE,6-Mar-15,27-May-16
-FSRS.GOV,Federal Agency,General Services Administration,Crystal City,VA,ACTIVE,14-May-14,2-Jul-15
-GOBIERNO.GOV,Federal Agency,General Services Administration,Washington,DC,ACTIVE,1-Dec-14,21-Dec-15
-GOBIERNOUSA.GOV,Federal Agency,General Services Administration,Washington,DC,ACTIVE,31-Oct-14,6-Nov-15
-GOVSALES.GOV,Federal Agency,General Services Administration,Arlington,VA,ACTIVE,1-Jul-14,11-Sep-15
-GSA.GOV,Federal Agency,General Services Administration,Washington,DC,ACTIVE,30-Sep-14,30-Sep-15
-GSAADVANTAGE.GOV,Federal Agency,General Services Administration,Washington,DC,ACTIVE,9-Jul-14,30-Sep-15
-GSAAUCTIONS.GOV,Federal Agency,General Services Administration,Washington,DC,ACTIVE,1-Jul-14,30-Sep-15
-GSADVANTAGE.GOV,Federal Agency,General Services Administration,Washington,DC,ACTIVE,9-Jul-14,30-Sep-15
-GSAIG.GOV,Federal Agency,General Services Administration,Washington,DC,ACTIVE,14-Apr-14,5-Jun-15
-GSAXCESS.GOV,Federal Agency,General Services Administration,Arlington,VA,ACTIVE,1-Jul-14,30-Sep-15
-HOWTO.GOV,Federal Agency,General Services Administration,Washington,DC,ACTIVE,1-Dec-14,14-Dec-15
-IDMANAGEMENT.GOV,Federal Agency,General Services Administration,Washington,DC,ACTIVE,10-Mar-15,9-Mar-16
-INFO.GOV,Federal Agency,General Services Administration,Washington,DC,ACTIVE,4-Sep-14,30-Sep-15
-JOBCENTER.GOV,Federal Agency,General Services Administration,Washington,DC,ACTIVE,6-Mar-15,12-Mar-16
-KIDS.GOV,Federal Agency,General Services Administration,Washington,DC,ACTIVE,4-Sep-14,30-Sep-15
-LEARNPERFORMANCE.GOV,Federal Agency,General Services Administration,Washington,DC,ACTIVE,6-Jan-15,6-Jan-16
-MYUSA.GOV,Federal Agency,General Services Administration,Washington,DC,ACTIVE,4-Sep-14,25-Sep-15
-NBRC.GOV,Federal Agency,General Services Administration,Bangor,ME,ACTIVE,13-Jun-14,13-Jul-15
-NETWORX.GOV,Federal Agency,General Services Administration,Fairfax,VA,ACTIVE,18-Feb-15,19-Mar-16
-NIC.GOV,Federal Agency,General Services Administration,Fairfax,VA,ACTIVE,3-Jun-10,8-Sep-15
-NONPROFIT.GOV,Federal Agency,General Services Administration,Washington,DC,ACTIVE,4-Sep-14,30-Sep-15
-PARTNER4SOLUTIONS.GOV,Federal Agency,General Services Administration,Washington,DC,ACTIVE,1-Dec-14,7-Dec-15
-PCLOB.GOV,Federal Agency,General Services Administration,Washington,DC,ACTIVE,12-Nov-14,14-Jan-16
-PERFORMANCE.GOV,Federal Agency,General Services Administration,Washington,DC,ACTIVE,1-Mar-15,1-Mar-16
-PIC.GOV,Federal Agency,General Services Administration,Washington,DC,ACTIVE,10-Mar-15,3-May-16
-PPIRS.GOV,Federal Agency,General Services Administration,Washington,DC,ACTIVE,5-Sep-14,14-Sep-15
-PTT.GOV,Federal Agency,General Services Administration,Washington D.C.,DC,ACTIVE,19-Aug-14,6-Oct-15
-REALESTATESALES.GOV,Federal Agency,General Services Administration,Washington,DC,ACTIVE,30-Apr-14,29-Jul-15
-REALPROPERTYPROFILE.GOV,Federal Agency,General Services Administration,Washington,DC,ACTIVE,24-Jul-14,30-Sep-15
-REGINFO.GOV,Federal Agency,General Services Administration,Washington,DC,ACTIVE,24-Jul-14,30-Sep-15
-ROCIS.GOV,Federal Agency,General Services Administration,Washington,DC,ACTIVE,24-Jul-14,30-Sep-15
-SAM.GOV,Federal Agency,General Services Administration,Arlington,VA,ACTIVE,5-Sep-14,30-Sep-15
-SANDBOX.GOV,Federal Agency,General Services Administration,Washinton,DC,ACTIVE,12-May-14,22-May-15
-SECTION508.GOV,Federal Agency,General Services Administration,Washington,DC,ACTIVE,24-Jul-14,30-Sep-15
-SENIORS.GOV,Federal Agency,General Services Administration,Washington,DC,ACTIVE,4-Sep-14,30-Sep-15
-SFTOOL.GOV,Federal Agency,General Services Administration,Chicago,IL,ACTIVE,10-Mar-15,5-Apr-16
-STRATEGICSOURCING.GOV,Federal Agency,General Services Administration,Arlington,VA,ACTIVE,3-Mar-15,13-Apr-16
-SUPPORTTHEVOTER.GOV,Federal Agency,General Services Administration,WASHINGTON,DC,ACTIVE,28-Aug-14,13-May-15
-TRANSPARENCY.GOV,Federal Agency,General Services Administration,Washington,DC,ACTIVE,7-Jan-14,26-Jan-15
-UNITEDSTATES.GOV,Federal Agency,General Services Administration,Washington,DC,ACTIVE,30-Jan-15,21-Feb-16
-US.GOV,Federal Agency,General Services Administration,Washington,DC,ACTIVE,4-Sep-14,30-Sep-15
-USA.GOV,Federal Agency,General Services Administration,Washington,DC,ACTIVE,4-Sep-14,30-Sep-15
-USAGOV.GOV,Federal Agency,General Services Administration,Washington,DC,ACTIVE,1-Dec-14,21-Dec-15
-USAPERFORMANCE.GOV,Federal Agency,General Services Administration,Washington,DC,ACTIVE,1-Mar-15,1-Mar-16
-USCIRF.GOV,Federal Agency,General Services Administration,Washington,DC,ACTIVE,7-Aug-14,30-Sep-15
-USGOVERNMENT.GOV,Federal Agency,General Services Administration,Washington,DC,ACTIVE,4-Sep-14,30-Sep-15
-USIP.GOV,Federal Agency,General Services Administration,Washington,DC,ACTIVE,8-Aug-14,19-Oct-15
-VEF.GOV,Federal Agency,General Services Administration,Arlington,VA,ACTIVE,3-Sep-14,3-Sep-15
-VITM.GOV,Federal Agency,General Services Administration,Arlington,VA,ACTIVE,9-Jul-14,30-Sep-15
-BROWSETOPICS.GOV,Federal Agency,Government Printing Office,Washington,DC,ACTIVE,1-Jul-14,3-May-15
-CONGRESSIONALDIRECTORY.GOV,Federal Agency,Government Printing Office,Washington,DC,ACTIVE,3-Nov-14,1-Nov-15
-CONGRESSIONALRECORD.GOV,Federal Agency,Government Printing Office,Washington,DC,ACTIVE,3-Nov-14,18-Oct-15
-ECFR.GOV,Federal Agency,Government Printing Office,Washington,DC,ACTIVE,31-Oct-14,10-Jan-16
-FDLP.GOV,Federal Agency,Government Printing Office,Washington,DC,ACTIVE,1-Jul-14,22-May-15
-FDSYS.GOV,Federal Agency,Government Printing Office,Washington,DC,ACTIVE,12-Mar-14,13-Feb-15
-FEDERALREGISTER.GOV,Federal Agency,Government Printing Office,Washington,DC,ACTIVE,18-Mar-14,19-Mar-15
-FEDREG.GOV,Federal Agency,Government Printing Office,Washington,DC,ACTIVE,17-Sep-14,17-Sep-15
-FMSHRC.GOV,Federal Agency,Government Printing Office,Washington,DC,ACTIVE,17-Sep-14,30-Sep-15
-GOVINFO.GOV,Federal Agency,Government Printing Office,Washington,DC,ACTIVE,23-Jun-14,23-Jun-15
-GPO.GOV,Federal Agency,Government Printing Office,Washington,DC,ACTIVE,17-Sep-14,3-Sep-15
-GPOACCESS.GOV,Federal Agency,Government Printing Office,Washington,DC,ACTIVE,8-Jul-13,3-Sep-14
-HOUSECALENDAR.GOV,Federal Agency,Government Printing Office,Washington,DC,ACTIVE,23-Jan-15,13-Jan-16
-OFR.GOV,Federal Agency,Government Printing Office,Washington,DC,ACTIVE,30-Jun-14,16-Jun-15
-OPENWORLD.GOV,Federal Agency,Government Printing Office,Washington,DC,ACTIVE,17-Sep-14,1-Sep-15
-PRESIDENTIALDOCUMENTS.GOV,Federal Agency,Government Printing Office,Washington,DC,ACTIVE,23-Jan-15,14-Jan-16
-SENATECALENDAR.GOV,Federal Agency,Government Printing Office,Washington,DC,ACTIVE,30-Jun-14,28-Jun-15
-STOPFAKES.GOV,Federal Agency,Government Printing Office,Washington,DC,ACTIVE,31-Oct-14,30-Sep-15
-USCAPITOLPOLICE.GOV,Federal Agency,Government Printing Office,Washington,DC,ACTIVE,17-Sep-14,3-Sep-15
-USCC.GOV,Federal Agency,Government Printing Office,Washington,DC,ACTIVE,17-Sep-14,3-Sep-15
-USCCR.GOV,Federal Agency,Government Printing Office,Washington,DC,ACTIVE,17-Sep-14,3-Sep-15
-USCODE.GOV,Federal Agency,Government Printing Office,Washington,DC,ACTIVE,23-Jan-15,11-Jan-16
-USGOVERNMENTMANUAL.GOV,Federal Agency,Government Printing Office,College Park,MD,ACTIVE,18-Mar-14,2-Apr-15
-WELCOMETOUSA.GOV,Federal Agency,Government Printing Office,Washington,DC,ACTIVE,31-Oct-14,25-Jan-16
-TRUMAN.GOV,Federal Agency,Harry S. Truman Scholarship Foundation,Washington,DC,ACTIVE,31-Jul-14,30-Sep-15
-IMLS.GOV,Federal Agency,Institute of Museum and Library Services,Washington,DC,ACTIVE,3-Jul-14,29-Sep-15
-IAF.GOV,Federal Agency,Inter-American Foundation,Washington,DC,ACTIVE,21-Jul-14,27-Aug-15
-BBG.GOV,Federal Agency,International Broadcasting Bureau,Washington,DC,ACTIVE,24-Jul-14,30-Sep-15
-IBB.GOV,Federal Agency,International Broadcasting Bureau,Washington,DC,ACTIVE,24-Jul-14,30-Sep-15
-VOA.GOV,Federal Agency,International Broadcasting Bureau,Washington,DC,ACTIVE,24-Jul-14,30-Sep-15
-JAMESMADISON.GOV,Federal Agency,James Madison Memorial Fellowship Foundation,Alexandria,VA,ACTIVE,17-Dec-14,14-Feb-16
-LSC.GOV,Federal Agency,Legal Services Corporation,Washington,DC,ACTIVE,2-Jul-14,30-Sep-15
-AFRICANAMERICANHISTORYMONTH.GOV,Federal Agency,Library of Congress,Washington,DC,ACTIVE,10-Dec-14,8-Jan-16
-AMERICANMEMORY.GOV,Federal Agency,Library of Congress,Washington,DC,ACTIVE,14-Apr-14,12-Jul-15
-AMERICASLIBRARY.GOV,Federal Agency,Library of Congress,Washington,DC,ACTIVE,19-Jun-14,1-Sep-15
-AMERICASSTORY.GOV,Federal Agency,Library of Congress,Washington,DC,ACTIVE,19-Jun-14,1-Sep-15
-AMERICASTORY.GOV,Federal Agency,Library of Congress,Washington,DC,ACTIVE,19-Jun-14,1-Sep-15
-ASIANPACIFICHERITAGE.GOV,Federal Agency,Library of Congress,Washington,DC,ACTIVE,9-Jan-14,3-Apr-15
-CAPITOLHILL.GOV,Federal Agency,Library of Congress,Washington,DC,ACTIVE,14-Apr-14,12-Jul-15
-COMMISSION.GOV,Federal Agency,Library of Congress,Washington,DC,ACTIVE,19-Jun-14,1-Sep-15
-CONGRESS.GOV,Federal Agency,Library of Congress,Washington,DC,ACTIVE,19-Jun-14,1-Sep-15
-COPYRIGHT.GOV,Federal Agency,Library of Congress,Washington,DC,ACTIVE,19-Jun-14,1-Sep-15
-CRS.GOV,Federal Agency,Library of Congress,Washington,DC,ACTIVE,29-Jul-14,30-Sep-15
-DIGITALPRESERVATION.GOV,Federal Agency,Library of Congress,Washington,DC,ACTIVE,19-Jun-14,1-Sep-15
-DIGITALSTEWARDSHIP.GOV,Federal Agency,Library of Congress,Washington,DC,ACTIVE,29-May-14,19-Aug-15
-DIGITIZATIONGUIDELINES.GOV,Federal Agency,Library of Congress,Washington,DC,ACTIVE,28-Oct-14,18-Dec-15
-HILL.GOV,Federal Agency,Library of Congress,Washington,DC,ACTIVE,14-Apr-14,12-Jul-15
-HISPANICHERITAGEMONTH.GOV,Federal Agency,Library of Congress,Washington,DC,ACTIVE,26-Jan-15,6-Feb-16
-JEWISHHERITAGE.GOV,Federal Agency,Library of Congress,Washington,DC,ACTIVE,5-Mar-14,1-May-15
-JEWISHHERITAGEMONTH.GOV,Federal Agency,Library of Congress,Washington,DC,ACTIVE,5-Mar-14,1-May-15
-LAW.GOV,Federal Agency,Library of Congress,Washington,DC,ACTIVE,9-Jan-14,1-Apr-15
-LCTL.GOV,Federal Agency,Library of Congress,Washington,DC,ACTIVE,16-Oct-14,30-Nov-15
-LEGISLATIVE.GOV,Federal Agency,Library of Congress,Washington,DC,ACTIVE,14-Apr-14,12-Jul-15
-LEGISLATIVEBRANCH.GOV,Federal Agency,Library of Congress,Washington,DC,ACTIVE,14-Apr-14,12-Jul-15
-LIBRARY-OF-CONGRESS.GOV,Federal Agency,Library of Congress,Washington,DC,ACTIVE,14-Apr-14,12-Jul-15
-LIBRARYOFCONGRESS.GOV,Federal Agency,Library of Congress,Washington,DC,ACTIVE,14-Apr-14,12-Jul-15
-LIS.GOV,Federal Agency,Library of Congress,Washington,DC,ACTIVE,5-Mar-14,4-May-15
-LITERACY.GOV,Federal Agency,Library of Congress,Washington,DC,ACTIVE,14-Apr-14,12-Jul-15
-LOC.GOV,Federal Agency,Library of Congress,Washington,DC,ACTIVE,19-Jun-14,1-Sep-15
-LOCIMAGES.GOV,Federal Agency,Library of Congress,Washington,DC,ACTIVE,14-Apr-14,12-Jul-15
-LOCSTORE.GOV,Federal Agency,Library of Congress,Washington,DC,ACTIVE,14-Apr-14,12-Jul-15
-LOCTPS.GOV,Federal Agency,Library of Congress,Washington,DC,ACTIVE,26-Jan-15,12-Feb-16
-MYLOC.GOV,Federal Agency,Library of Congress,Washington,DC,ACTIVE,26-Jan-15,12-Feb-16
-NATIVEAMERICANHERITAGEMONTH.GOV,Federal Agency,Library of Congress,Washington,DC,ACTIVE,26-Jan-15,6-Feb-16
-NDSA.GOV,Federal Agency,Library of Congress,Washington,DC,ACTIVE,29-May-14,19-Aug-15
-PRIMARYSOURCES.GOV,Federal Agency,Library of Congress,Washington,DC,ACTIVE,18-Mar-14,15-Jun-15
-READ.GOV,Federal Agency,Library of Congress,Washington,DC,ACTIVE,14-Oct-14,19-Nov-15
-SECTION108.GOV,Federal Agency,Library of Congress,Washington,DC,ACTIVE,28-Oct-14,18-Dec-15
-TEACHINGPRIMARYSOURCES.GOV,Federal Agency,Library of Congress,Washington,DC,ACTIVE,26-Jan-15,12-Feb-16
-TEACHINGWITHPRIMARYSOURCES.GOV,Federal Agency,Library of Congress,Washington,DC,ACTIVE,26-Jan-15,12-Feb-16
-THOMAS.GOV,Federal Agency,Library of Congress,Washington,DC,ACTIVE,14-Apr-14,12-Jul-15
-TPS.GOV,Federal Agency,Library of Congress,Washington,DC,ACTIVE,26-Jan-15,12-Feb-16
-UNITEDSTATESCONGRESS.GOV,Federal Agency,Library of Congress,Washington,DC,ACTIVE,14-Apr-14,12-Jul-15
-USCONGRESS.GOV,Federal Agency,Library of Congress,Washington,DC,ACTIVE,14-Apr-14,12-Jul-15
-WDL.GOV,Federal Agency,Library of Congress,Washington,DC,ACTIVE,4-Nov-14,5-Jan-16
-WOMENSHISTORYMONTH.GOV,Federal Agency,Library of Congress,Washington,DC,ACTIVE,10-Dec-14,8-Jan-16
-WORLDDIGITALLIBRARY.GOV,Federal Agency,Library of Congress,Washington,DC,ACTIVE,4-Nov-14,5-Jan-16
-MMC.GOV,Federal Agency,Marine Mammal Commission,Bethesda,MD,ACTIVE,25-Jul-14,30-Sep-15
-MACPAC.GOV,Federal Agency,Medicaid and CHIP Payment and Access Commission,Washington,DC,ACTIVE,31-Jul-14,30-Aug-15
-MEDPAC.GOV,Federal Agency,Medical Payment Advisory Commission,Washington,DC,ACTIVE,1-Oct-14,30-Sep-15
-MSPB.GOV,Federal Agency,Merit Systems Protection Board,Washington,DC,ACTIVE,19-Aug-14,30-Sep-15
-MCC.GOV,Federal Agency,Millennium Challenge Corporation,Washington,DC,ACTIVE,19-Aug-14,30-Sep-15
-ECR.GOV,Federal Agency,Morris K. Udall Foundation,Tucson,AZ,ACTIVE,2-Jul-14,30-Sep-15
-UDALL.GOV,Federal Agency,Morris K. Udall Foundation,Tucson,AZ,ACTIVE,2-Jul-14,30-Sep-15
-GLOBE.GOV,Federal Agency,National Aeronautics and Space Administration,Greenbelt,MD,ACTIVE,7-Aug-14,3-Sep-15
-NASA.GOV,Federal Agency,National Aeronautics and Space Administration,MSFC,AL,ACTIVE,5-Jun-14,30-Aug-15
-NSWP.GOV,Federal Agency,National Aeronautics and Space Administration,MSFC,AL,ACTIVE,5-Jun-14,5-Jul-15
-SCIJINKS.GOV,Federal Agency,National Aeronautics and Space Administration,MSFC,AL,ACTIVE,11-Mar-15,25-Apr-16
-USGEO.GOV,Federal Agency,National Aeronautics and Space Administration,MSFC,AL,ACTIVE,21-Nov-14,9-Dec-15
-9-11COMMISSION.GOV,Federal Agency,National Archives and Records Administration,College Park,MD,ACTIVE,8-Jul-14,30-Sep-15
-911COMMISSION.GOV,Federal Agency,National Archives and Records Administration,College Park,MD,ACTIVE,8-Jul-14,30-Sep-15
-ARCHIVES.GOV,Federal Agency,National Archives and Records Administration,College Park,MD,ACTIVE,8-Jul-14,30-Sep-15
-CLINTONLIBRARY.GOV,Federal Agency,National Archives and Records Administration,Little Rock,AR,ACTIVE,8-Jul-14,30-Sep-15
-EMERGENCY-FEDERAL-REGISTER.GOV,Federal Agency,National Archives and Records Administration,College Park,MD,ACTIVE,12-Sep-13,29-Oct-14
-FCIC.GOV,Federal Agency,National Archives and Records Administration,College Park,MD,ACTIVE,13-Mar-14,4-May-15
-FORDLIBRARYMUSEUM.GOV,Federal Agency,National Archives and Records Administration,College Park,MD,ACTIVE,8-Jul-14,30-Sep-15
-FRC.GOV,Federal Agency,National Archives and Records Administration,College Park,MD,ACTIVE,20-Jan-15,12-Dec-15
-GEORGEWBUSHLIBRARY.GOV,Federal Agency,National Archives and Records Administration,College Park,MD,ACTIVE,23-Dec-14,15-Jan-16
-HISTORY.GOV,Federal Agency,National Archives and Records Administration,College Park,MD,ACTIVE,13-Mar-14,2-Jun-15
-JIMMYCARTERLIBRARY.GOV,Federal Agency,National Archives and Records Administration,College,MD,ACTIVE,8-Jul-14,30-Sep-15
-NARA-AT-WORK.GOV,Federal Agency,National Archives and Records Administration,College Park,MD,ACTIVE,8-Jul-14,30-Sep-15
-NARA.GOV,Federal Agency,National Archives and Records Administration,College Park,MD,ACTIVE,8-Jul-14,30-Sep-15
-NIXONLIBRARY.GOV,Federal Agency,National Archives and Records Administration,College Park,MD,ACTIVE,30-Apr-14,25-Jun-15
-OGIS.GOV,Federal Agency,National Archives and Records Administration,College Park,MD,ACTIVE,23-Dec-14,19-Nov-15
-OURDOCUMENTS.GOV,Federal Agency,National Archives and Records Administration,College Park,MD,ACTIVE,8-Jul-14,30-Sep-15
-REAGANLIBRARY.GOV,Federal Agency,National Archives and Records Administration,College Park,MD,ACTIVE,20-Jan-15,8-Jan-16
-RECORDSMANAGEMENT.GOV,Federal Agency,National Archives and Records Administration,College Park,MD,ACTIVE,30-Apr-14,23-Jul-15
-WARTIMECONTRACTING.GOV,Federal Agency,National Archives and Records Administration,College Park,MD,ACTIVE,8-Jul-14,25-Sep-15
-WEBHARVEST.GOV,Federal Agency,National Archives and Records Administration,College Park,MD,ACTIVE,20-Jan-15,12-Jan-16
-NCPC.GOV,Federal Agency,National Capital Planning Commission,Washington,DC,ACTIVE,19-Sep-14,30-Sep-15
-NCD.GOV,Federal Agency,National Council on Disability,Washington,DC,ACTIVE,22-Oct-14,30-Sep-15
-MYCREDITUNION.GOV,Federal Agency,National Credit Union Administration,Alexandria,VA,ACTIVE,24-Jan-14,8-Mar-15
-NCUA.GOV,Federal Agency,National Credit Union Administration,Alexandria,VA,ACTIVE,26-Sep-14,30-Sep-15
-ARTS.GOV,Federal Agency,National Endowment for the Arts,Washington,DC,ACTIVE,28-Jan-15,27-Aug-15
-NEA.GOV,Federal Agency,National Endowment for the Arts,Washington,DC,ACTIVE,28-Jan-15,27-Aug-15
-HUMANITIES.GOV,Federal Agency,National Endowment for the Humanities,Washington,DC,ACTIVE,16-Jun-14,30-Aug-15
-NEH.GOV,Federal Agency,National Endowment for the Humanities,Washington,DC,ACTIVE,16-Jun-14,30-Aug-15
-PCAH.GOV,Federal Agency,National Endowment for the Humanities,Washington,DC,ACTIVE,16-Jun-14,30-Aug-15
-WETHEPEOPLE.GOV,Federal Agency,National Endowment for the Humanities,Washington,DC,ACTIVE,16-Jun-14,30-Aug-15
-NGA.GOV,Federal Agency,National Gallery of Art,Washington,DC,ACTIVE,9-Jul-14,30-Sep-15
-NIGC.GOV,Federal Agency,National Indian Gaming Commission,Washington,DC,ACTIVE,27-Aug-14,30-Sep-15
-NLRB.GOV,Federal Agency,National Labor Relations Board,Washington,DC,ACTIVE,7-Aug-14,27-Aug-15
-NMB.GOV,Federal Agency,National Mediation Board,Washington,DC,ACTIVE,14-Jul-14,30-Sep-15
-NANO.GOV,Federal Agency,National Nanotechnology Coordination Office,Arlington,VA,ACTIVE,30-Sep-14,30-Sep-15
-ARCTIC.GOV,Federal Agency,National Science Foundation,Arlington,VA,ACTIVE,20-Aug-14,18-Nov-15
-ARCTICGAS.GOV,Federal Agency,National Science Foundation,Washington,DC,ACTIVE,10-Feb-15,9-May-16
-NSF.GOV,Federal Agency,National Science Foundation,Arlington,VA,ACTIVE,5-Aug-14,23-Sep-15
-RESEARCH.GOV,Federal Agency,National Science Foundation,Arlington,VA,ACTIVE,13-Aug-14,12-Oct-15
-SAC.GOV,Federal Agency,National Science Foundation,Arlington,VA,ACTIVE,13-Aug-14,30-Sep-15
-SBIR.GOV,Federal Agency,National Science Foundation,Arlington,VA,ACTIVE,13-Aug-14,30-Oct-15
-SCIENCE360.GOV,Federal Agency,National Science Foundation,Arlington,VA,ACTIVE,5-Aug-14,4-Sep-15
-USAP.GOV,Federal Agency,National Science Foundation,Arlington,VA,ACTIVE,11-Sep-14,30-Sep-15
-LPS.GOV,Federal Agency,National Security Agency,College Park,MD,ACTIVE,24-Feb-15,11-Feb-16
-NTSB.GOV,Federal Agency,National Transportation Safety Board,Washington,DC,ACTIVE,24-Sep-14,30-Sep-15
-ITRD.GOV,Federal Agency,Networking Information Technology Research and Development (NITRD),Arlington,VA,ACTIVE,13-Aug-14,30-Sep-15
-NITRD.GOV,Federal Agency,Networking Information Technology Research and Development (NITRD),Arlington,VA,ACTIVE,13-Aug-14,30-Sep-15
-HERITAGEABROAD.GOV,Federal Agency,Non-Federal Agency,Washington,DC,ACTIVE,4-Jun-13,1-Sep-14
-IAB.GOV,Federal Agency,Non-Federal Agency,Quantico,VA,ACTIVE,6-Aug-14,30-Sep-15
-JUSFC.GOV,Federal Agency,Non-Federal Agency,Washington,DC,ACTIVE,10-Sep-14,30-Sep-15
-NWTRB.GOV,Federal Agency,Non-Federal Agency,Arlington,VA,ACTIVE,29-May-14,26-Aug-15
-PPPL.GOV,Federal Agency,Non-Federal Agency,Princeton,NJ,ACTIVE,21-Jul-14,30-Sep-15
-SERVEINDIANA.GOV,Federal Agency,Non-Federal Agency,Indianapolis,IN,ACTIVE,13-May-14,2-Aug-15
-SJI.GOV,Federal Agency,Non-Federal Agency,Reston,VA,ACTIVE,15-Jan-15,19-Mar-16
-WMATC.GOV,Federal Agency,Non-Federal Agency,Silver Spring,MD,ACTIVE,3-Nov-14,26-Jan-16
-NRC-GATEWAY.GOV,Federal Agency,Nuclear Regulatory Commission,Rockville,MD,ACTIVE,2-Jul-14,17-Jul-15
-NRC.GOV,Federal Agency,Nuclear Regulatory Commission,Rockville,MD,ACTIVE,2-Jul-14,30-Sep-15
-OSHRC.GOV,Federal Agency,Occupational Safety & Health Review Commission,Washington,DC,ACTIVE,11-Dec-14,30-Jan-16
-INTEGRITY.GOV,Federal Agency,Office of Government Ethics,Washington,DC,ACTIVE,9-May-14,9-May-15
-APPLICATIONMANAGER.GOV,Federal Agency,Office of Personnel Management,Macon,GA,ACTIVE,2-Jun-14,30-Jun-15
-CHCOC.GOV,Federal Agency,Office of Personnel Management,Washington,DC,ACTIVE,2-Jul-14,30-Sep-15
-E-QIP.GOV,Federal Agency,Office of Personnel Management,Washington,DC,ACTIVE,2-Jul-14,30-Sep-15
-EMPLOYEEEXPRESS.GOV,Federal Agency,Office of Personnel Management,Macon,GA,ACTIVE,12-Nov-14,13-Oct-15
-FEB.GOV,Federal Agency,Office of Personnel Management,Washington,DC,ACTIVE,12-Nov-14,13-Oct-15
-FEDERALJOBS.GOV,Federal Agency,Office of Personnel Management,Macon,GA,ACTIVE,12-Nov-14,13-Oct-15
-FEDJOBS.GOV,Federal Agency,Office of Personnel Management,Macon,GA,ACTIVE,12-Nov-14,13-Oct-15
-FEDSHIREVETS.GOV,Federal Agency,Office of Personnel Management,Washington,DC,ACTIVE,25-Jul-14,15-Oct-15
-FEGLI.GOV,Federal Agency,Office of Personnel Management,Washington,DC,ACTIVE,2-Jul-14,30-Sep-15
-FSAFEDS.GOV,Federal Agency,Office of Personnel Management,Washington,DC,ACTIVE,2-Jul-14,30-Sep-15
-GOLEARN.GOV,Federal Agency,Office of Personnel Management,Washington,DC,ACTIVE,2-Jul-14,30-Sep-15
-GOVERNMENTJOBS.GOV,Federal Agency,Office of Personnel Management,Macon,GA,ACTIVE,12-Nov-14,13-Oct-15
-HRU.GOV,Federal Agency,Office of Personnel Management,Washington,DC,ACTIVE,13-Feb-15,4-Feb-16
-LMRCOUNCIL.GOV,Federal Agency,Office of Personnel Management,Washington,DC,ACTIVE,28-Jan-15,25-Feb-16
-OPM.GOV,Federal Agency,Office of Personnel Management,Macon,GA,ACTIVE,12-Nov-14,13-Oct-15
-PAC.GOV,Federal Agency,Office of Personnel Management,Washington,DC,ACTIVE,12-Jan-15,3-Apr-16
-PMF.GOV,Federal Agency,Office of Personnel Management,Washington,DC,ACTIVE,2-Jul-14,30-Sep-15
-TELEWORK.GOV,Federal Agency,Office of Personnel Management,Washington,DC,ACTIVE,2-Jul-14,30-Sep-15
-UNLOCKTALENT.GOV,Federal Agency,Office of Personnel Management,Washington,DC,ACTIVE,2-Jul-14,2-Jul-15
-USAJOBS.GOV,Federal Agency,Office of Personnel Management,Washington,DC,ACTIVE,22-Aug-14,30-Sep-15
-USALEARNING.GOV,Federal Agency,Office of Personnel Management,Washington,DC,ACTIVE,12-Jan-15,9-Mar-16
-USASTAFFING.GOV,Federal Agency,Office of Personnel Management,Macon,GA,ACTIVE,2-Jun-14,30-Jun-15
-OPIC.GOV,Federal Agency,Overseas Private Investment Corporation,Washington,DC,ACTIVE,28-Aug-14,30-Sep-15
-PBGC.GOV,Federal Agency,Pension Benefit Guaranty Corporation,Washington,DC,ACTIVE,7-Jul-14,30-Sep-15
-PRC.GOV,Federal Agency,Postal Rate Commission,Washington,DC,ACTIVE,8-Jul-14,30-Sep-15
-RRB.GOV,Federal Agency,Railroad Retirement Board,Chicago,IL,ACTIVE,16-Jul-14,30-Sep-15
-EDUCATIONJOBSFUND.GOV,Federal Agency,Recovery Accountability and Transparency Board,Washington,DC,ACTIVE,23-Jul-14,12-Nov-13
-FEDERALACCOUNTABILITY.GOV,Federal Agency,Recovery Accountability and Transparency Board,Washington,DC,ACTIVE,23-Jul-14,1-Jun-14
-FEDERALREPORTING.GOV,Federal Agency,Recovery Accountability and Transparency Board,Washington,DC,ACTIVE,4-Mar-15,19-Mar-16
-FEDERALTRANSPARENCY.GOV,Federal Agency,Recovery Accountability and Transparency Board,Washington ,DC,ACTIVE,7-Aug-13,12-Nov-12
-RATB.GOV,Federal Agency,Recovery Accountability and Transparency Board,WASHINGTON,DC,ACTIVE,4-Mar-15,21-Apr-16
-RECOVERY.GOV,Federal Agency,Recovery Accountability and Transparency Board,Washington,DC,ACTIVE,6-Nov-14,15-Jan-16
-404.GOV,Federal Agency,Securities and Exchange Commission,Alexandria,VA,ACTIVE,4-Sep-14,19-Nov-15
-INVESTOR.GOV,Federal Agency,Securities and Exchange Commission,Alexandria,VA,ACTIVE,28-Jul-14,12-Sep-15
-SEC.GOV,Federal Agency,Securities and Exchange Commission,Alexandria,VA,ACTIVE,28-Jul-14,30-Sep-15
-SSS.GOV,Federal Agency,Selective Service System,Arlington,VA,ACTIVE,7-Oct-14,30-Sep-15
-BUSINESS.GOV,Federal Agency,Small Business Administration,Washington,DC,ACTIVE,10-Jul-14,30-Sep-15
-DISASTERCONTRACTINGASSISTANCE.GOV,Federal Agency,Small Business Administration,Washington,DC,SERVER-HOLD,17-Jul-12,17-Jun-13
-HSA.GOV,Federal Agency,Small Business Administration,Washington,DC,ACTIVE,10-Jul-14,5-Sep-15
-NWBC.GOV,Federal Agency,Small Business Administration,Washington,DC,ACTIVE,10-Jul-14,30-Sep-15
-ONLINEWBC.GOV,Federal Agency,Small Business Administration,Washington,DC,ACTIVE,10-Jul-14,30-Sep-15
-SBA.GOV,Federal Agency,Small Business Administration,Washington,DC,ACTIVE,10-Jul-14,30-Sep-15
-SMALLBUSINESS.GOV,Federal Agency,Small Business Administration,Washington,DC,ACTIVE,30-Oct-13,8-Dec-14
-WOMENBIZ.GOV,Federal Agency,Small Business Administration,Washington,DC,ACTIVE,10-Jul-14,30-Sep-15
-ITIS.GOV,Federal Agency,Smithsonian Institution,Washington,DC,ACTIVE,5-Feb-15,7-Mar-16
-SEGUROSOCIAL.GOV,Federal Agency,Social Security Administration,Baltimore,MD,ACTIVE,23-Jul-14,3-Sep-15
-SOCIALSECURITY.GOV,Federal Agency,Social Security Administration,Baltimore,MD,ACTIVE,23-Jul-14,3-Sep-15
-SSA.GOV,Federal Agency,Social Security Administration,Baltimore,MD,ACTIVE,23-Jul-14,3-Sep-15
-SOCIALSECURITYADVISORYBOARD.GOV,Federal Agency,Social Security Advisory Board,Washington,DC,SERVER-HOLD,30-May-12,26-Aug-13
-SSAB.GOV,Federal Agency,Social Security Advisory Board,WASHINGTON,DC,ACTIVE,26-Aug-14,26-Aug-15
-STENNIS.GOV,Federal Agency,Stennis Center for Public Service,Starkville,MS,ACTIVE,7-Jul-14,30-Sep-15
-TVA.GOV,Federal Agency,Tennessee Valley Authority,Knoxville,TN,ACTIVE,5-Sep-14,30-Sep-15
-TVAOIG.GOV,Federal Agency,Tennessee Valley Authority,Knoxville,TN,ACTIVE,29-Sep-14,29-Sep-15
-TSC.GOV,Federal Agency,Terrorist Screening Center,Washington,DC,ACTIVE,9-Jul-14,19-Sep-15
-PTF.GOV,Federal Agency,The Intelligence Community,Washington,DC,ACTIVE,6-Nov-14,28-Nov-15
-BANKRUPTCY.GOV,Federal Agency,The Judicial Branch (Courts),Washington,DC,ACTIVE,15-Oct-14,9-Jan-16
-CAVC.GOV,Federal Agency,The Judicial Branch (Courts),Washington,DC,ACTIVE,14-Mar-14,20-May-15
-DCSC.GOV,Federal Agency,The Judicial Branch (Courts),Washington,DC,ACTIVE,21-Aug-14,30-Sep-15
-FEDCIR.GOV,Federal Agency,The Judicial Branch (Courts),Washington,DC,ACTIVE,26-Oct-10,30-Sep-11
-FEDERALCOURTS.GOV,Federal Agency,The Judicial Branch (Courts),Washington,DC,ACTIVE,15-Oct-14,9-Jan-16
-FEDERALPROBATION.GOV,Federal Agency,The Judicial Branch (Courts),Washington,DC,ACTIVE,15-Oct-14,9-Jan-16
-FEDERALRULES.GOV,Federal Agency,The Judicial Branch (Courts),Washington,DC,ACTIVE,15-Oct-14,9-Jan-16
-FJC.GOV,Federal Agency,The Judicial Branch (Courts),Washington,DC,ACTIVE,15-Sep-14,30-Sep-15
-JUDICIALCONFERENCE.GOV,Federal Agency,The Judicial Branch (Courts),Washington,DC,ACTIVE,15-Oct-14,9-Jan-16
-NMCOURT.FED.US,Federal Agency,The Judicial Branch (Courts),Albuquerque,NM,ACTIVE,15-Sep-14,30-Sep-15
-PACER.GOV,Federal Agency,The Judicial Branch (Courts),Washington,DC,ACTIVE,15-Oct-14,9-Jan-16
-SC-US.GOV,Federal Agency,The Judicial Branch (Courts),Washington,DC,ACTIVE,8-Jul-14,30-Sep-15
-SCINET-TEST.GOV,Federal Agency,The Judicial Branch (Courts),Washington,DC,ACTIVE,8-Jul-14,30-Sep-15
-SCINET.GOV,Federal Agency,The Judicial Branch (Courts),Washington,DC,ACTIVE,28-Apr-14,28-Apr-15
-SCUS.GOV,Federal Agency,The Judicial Branch (Courts),WASHINGTON,DC,ACTIVE,8-Jul-14,30-Sep-15
-SUPREME-COURT.GOV,Federal Agency,The Judicial Branch (Courts),Washington,DC,ACTIVE,8-Jul-14,30-Sep-15
-SUPREMECOURT.GOV,Federal Agency,The Judicial Branch (Courts),Washington,DC,ACTIVE,8-Jul-14,30-Sep-15
-SUPREMECOURTUS.GOV,Federal Agency,The Judicial Branch (Courts),Washington,DC,ACTIVE,8-Jul-14,30-Sep-15
-USBANKRUPTCY.GOV,Federal Agency,The Judicial Branch (Courts),Washington,DC,ACTIVE,15-Oct-14,9-Jan-16
-USC.GOV,Federal Agency,The Judicial Branch (Courts),Washington,DC,ACTIVE,23-Jul-14,30-Sep-15
-USCAVC.GOV,Federal Agency,The Judicial Branch (Courts),Washington,DC,ACTIVE,20-Dec-11,4-Feb-13
-USCOURTS.GOV,Federal Agency,The Judicial Branch (Courts),Washington,DC,ACTIVE,18-Aug-14,10-Nov-15
-USCVA.GOV,Federal Agency,The Judicial Branch (Courts),Washington,DC,ACTIVE,27-Aug-12,30-Sep-13
-USPROBATION.GOV,Federal Agency,The Judicial Branch (Courts),Washington,DC,ACTIVE,15-Oct-14,9-Jan-16
-USSC.GOV,Federal Agency,The Judicial Branch (Courts),Washington,DC,ACTIVE,12-Aug-14,30-Sep-15
-USTAXCOURT.GOV,Federal Agency,The Judicial Branch (Courts),Washington,DC,ACTIVE,19-Aug-14,30-Sep-15
-VETAPP.GOV,Federal Agency,The Judicial Branch (Courts),Washington,DC,ACTIVE,30-Oct-13,30-Sep-14
-AOC.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC,ACTIVE,8-Sep-14,30-Sep-15
-CAPITAL.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC,ACTIVE,13-Nov-14,12-Nov-15
-CAPITOL.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC,ACTIVE,13-Nov-14,12-Nov-15
-CAPITOLFLAGS.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC,ACTIVE,8-Sep-14,30-Sep-15
-CBO.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC,ACTIVE,23-Jun-14,10-Sep-15
-CBONEWS.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC,ACTIVE,23-Jun-14,10-Sep-15
-CECC.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC,ACTIVE,28-Aug-14,31-Aug-15
-CHINA-COMMISSION.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC,ACTIVE,19-May-14,14-Jun-15
-CHINACOMMISSION.GOV,Federal Agency,The Legislative Branch (Congress),Washington,MD,ACTIVE,19-May-14,14-Jun-15
-CITIZENCOSPONSORS.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC,ACTIVE,6-Mar-15,31-May-16
-CITIZENS.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC,ACTIVE,6-Mar-15,31-May-16
-COSPONSOR.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC,ACTIVE,6-Mar-15,31-May-16
-CSCE.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC,ACTIVE,25-Aug-14,30-Sep-15
-DEMOCRATICLEADER.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC,ACTIVE,6-Nov-14,1-Feb-16
-DEMOCRATICWHIP.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC,ACTIVE,2-Sep-14,17-Sep-15
-DEMOCRATS.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC,ACTIVE,2-Sep-14,30-Sep-15
-DEMS.GOV,Federal Agency,The Legislative Branch (Congress),Washington DC,DC,ACTIVE,2-Sep-14,30-Sep-15
-ESECLAB.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC,ACTIVE,7-Nov-14,2-Sep-15
-FASAB.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC,ACTIVE,20-Aug-14,27-Aug-15
-GAO.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC,ACTIVE,22-Oct-14,30-Sep-15
-GAONET.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC,ACTIVE,22-Oct-14,30-Sep-15
-GOP.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC,ACTIVE,7-Jul-14,30-Sep-15
-GOPCONFERENCE.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC,ACTIVE,27-Jan-15,27-Apr-14
-GOPLEADER.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC,ACTIVE,23-Apr-14,23-May-14
-HOUSE.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC,ACTIVE,2-Jul-14,30-Sep-15
-HOUSECOMMUNICATIONS.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC,ACTIVE,6-Nov-14,31-Jan-16
-HOUSEDEMOCRATS.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC,ACTIVE,2-Sep-14,30-Sep-15
-HOUSEDEMS.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC,ACTIVE,2-Sep-14,30-Sep-15
-HOUSELIVE.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC,ACTIVE,6-Nov-14,9-Dec-15
-HOUSENEWSLETTERS.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC,ACTIVE,6-Nov-14,31-Jan-16
-JCT.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC,ACTIVE,2-May-14,4-May-15
-LISTENSTOYOU.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC,ACTIVE,18-Mar-14,13-Jun-15
-MAJORITYLEADER.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC,ACTIVE,2-Sep-14,30-Sep-15
-MAJORITYWHIP.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC,ACTIVE,28-Jul-14,30-Sep-15
-PDBCECC.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC,ACTIVE,19-May-14,16-May-15
-PPDCECC.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC,ACTIVE,19-May-14,16-May-15
-REPUBLICANS.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC,ACTIVE,20-Nov-14,21-Oct-15
-SENATE.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC,ACTIVE,28-Jul-14,30-Sep-15
-SENATERESTAURANTS.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC,ACTIVE,8-Sep-14,30-Sep-15
-SPEAKER.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC,ACTIVE,13-Aug-14,10-Sep-15
-TAXREFORM.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC,ACTIVE,6-Nov-14,5-Feb-16
-USBG.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC,ACTIVE,8-Sep-14,30-Sep-15
-USCAPITAL.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC,ACTIVE,13-Nov-14,12-Nov-15
-USCAPITOL.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC,ACTIVE,13-Nov-14,12-Nov-15
-USCAPITOLVISITORCENTER.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC,ACTIVE,13-Nov-14,30-Sep-14
-USCVC.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC,ACTIVE,13-Nov-14,30-Sep-14
-VISITTHECAPITAL.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC,ACTIVE,13-Nov-14,12-Nov-15
-VISITTHECAPITOL.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC,ACTIVE,13-Nov-14,6-Nov-15
-WORLDWAR1CENTENNIAL.GOV,Federal Agency,The United States World War One Centennial Commission,Washington,DC,ACTIVE,9-Feb-15,9-Feb-16
-ACCESS-BOARD-MEMBERS.GOV,Federal Agency,U. S. Access Board,Washington,DC,SERVER-HOLD,16-Aug-12,30-Aug-13
-ACCESS-BOARD.GOV,Federal Agency,U. S. Access Board,Washington,DC,ACTIVE,21-Jul-14,30-Aug-15
-USHMM.GOV,Federal Agency,U. S. Holocaust Memorial Museum,Washington,DC,ACTIVE,13-Aug-14,30-Sep-15
-USITC.GOV,Federal Agency,U. S. International Trade Commission,Washington,DC,ACTIVE,18-Jul-14,30-Sep-15
-OSC.GOV,Federal Agency,U. S. Office of Special Counsel,Washington,DC,ACTIVE,10-Sep-14,30-Aug-15
-OSCNET.GOV,Federal Agency,U. S. Office of Special Counsel,Washington,DC,ACTIVE,21-Nov-14,15-Dec-15
-PEACECORE.GOV,Federal Agency,U. S. Peace Corps,Washington,DC,ACTIVE,23-Sep-14,30-Sep-15
-PEACECORP.GOV,Federal Agency,U. S. Peace Corps,Washington,DC,ACTIVE,23-Sep-14,30-Sep-15
-PEACECORPS.GOV,Federal Agency,U. S. Peace Corps,Washington,DC,ACTIVE,23-Sep-14,30-Sep-15
-MAIL.GOV,Federal Agency,U. S. Postal Service,Raleigh,NC,ACTIVE,3-Oct-14,30-Sep-15
-POSTOFFICE.GOV,Federal Agency,U. S. Postal Service,Raleigh,NC,ACTIVE,25-Nov-14,22-Feb-16
-PURCHASING.GOV,Federal Agency,U. S. Postal Service,Raleigh,NC,ACTIVE,3-Oct-14,30-Sep-15
-USPIS.GOV,Federal Agency,U. S. Postal Service,Arlington,VA,ACTIVE,3-Oct-14,30-Sep-15
-USPS.GOV,Federal Agency,U. S. Postal Service,Raleigh,NC,ACTIVE,3-Oct-14,30-Sep-15
-CHILDRENINADVERSITY.GOV,Federal Agency,U.S. Agency for International Development,Washington,DC,ACTIVE,9-May-14,9-May-15
-DFAFACTS.GOV,Federal Agency,U.S. Agency for International Development,Washington,DC,ACTIVE,9-Apr-14,24-May-15
-FEEDTHEFUTURE.GOV,Federal Agency,U.S. Agency for International Development,Washington,DC,ACTIVE,16-Apr-14,5-May-15
-FIGHTINGMALARIA.GOV,Federal Agency,U.S. Agency for International Development,Washington,DC,ACTIVE,10-Sep-13,16-Sep-14
-JMC.GOV,Federal Agency,U.S. Agency for International Development,Washington,DC,ACTIVE,23-Jul-14,11-Apr-15
-NEGLECTEDDISEASES.GOV,Federal Agency,U.S. Agency for International Development,Washington,DC,ACTIVE,14-Apr-14,16-Apr-15
-OFDA.GOV,Federal Agency,U.S. Agency for International Development,Washington,DC,ACTIVE,17-Dec-14,20-Dec-15
-OTI.GOV,Federal Agency,U.S. Agency for International Development,Washington,DC,ACTIVE,21-Jul-14,28-Apr-15
-PMI.GOV,Federal Agency,U.S. Agency for International Development,Washington,DC,ACTIVE,15-Dec-14,3-Jan-16
-USAID.GOV,Federal Agency,U.S. Agency for International Development,Washington,DC,ACTIVE,22-Aug-14,22-Sep-15
-USAIDALLNET.GOV,Federal Agency,U.S. Agency for International Development,Arlington,VA,ACTIVE,22-Sep-14,20-Dec-15
-VOLUNTEERSFORPROSPERITY.GOV,Federal Agency,U.S. Agency for International Development,Washington,DC,SERVER-HOLD,23-Aug-12,15-Sep-13
-USCP.GOV,Federal Agency,U.S. Capitol Police,Washington,DC,ACTIVE,12-Feb-14,21-Apr-15
-CHEMSAFETY.GOV,Federal Agency,U.S. Chemical Safety and Hazard Investigation Board,Washington,DC,ACTIVE,21-Jan-15,21-Jan-16
-CSB.GOV,Federal Agency,U.S. Chemical Safety and Hazard Investigation Board,Washington,DC,ACTIVE,3-Jul-14,30-Sep-15
-SAFETYVIDEOS.GOV,Federal Agency,U.S. Chemical Safety and Hazard Investigation Board,Washington,DC,ACTIVE,16-Jun-14,13-Sep-15
-CFA.GOV,Federal Agency,U.S. Commission of Fine Arts,Washington,DC,ACTIVE,31-Oct-14,1-Sep-15
-PEACECORPSOIG.GOV,Federal Agency,"U.S. Postal Service, Office of Inspector General",Washington,DC,ACTIVE,5-Dec-14,5-Dec-15
-USPSOIG.GOV,Federal Agency,"U.S. Postal Service, Office of Inspector General",Arlington,VA,ACTIVE,31-Jul-14,30-Sep-15
-TDA.GOV,Federal Agency,U.S. Trade and Development Agency,Arlington,VA,SERVER-HOLD,19-Jul-11,10-Sep-12
-USTDA.GOV,Federal Agency,U.S. Trade and Development Agency,Arlington,VA,ACTIVE,28-Aug-14,31-Aug-15
-CARBONCYCLESCIENCE.GOV,Federal Agency,United Stated Global Change Research Program,Washington,DC,ACTIVE,29-Aug-13,30-Aug-14
-GLOBALCHANGE.GOV,Federal Agency,United Stated Global Change Research Program,Washington,DC,ACTIVE,21-Aug-14,31-Aug-15
-IPCC-WG2.GOV,Federal Agency,United Stated Global Change Research Program,Stanford,CA,ACTIVE,27-Oct-14,3-Nov-15
-USGCRP.GOV,Federal Agency,United Stated Global Change Research Program,Washington,DC,ACTIVE,21-Aug-14,30-Aug-15
-OGE.GOV,Federal Agency,United States Office of Government Ethics,Washington,DC,ACTIVE,3-Mar-15,10-Sep-15
-USOGE.GOV,Federal Agency,United States Office of Government Ethics,Washington,DC,ACTIVE,3-Mar-15,3-Sep-15
-ICH.GOV,Federal Agency,US Interagency Council on Homelessness,washington,DC,ACTIVE,17-Jul-14,27-Aug-15
-USICH.GOV,Federal Agency,US Interagency Council on Homelessness,Washington,DC,ACTIVE,8-Oct-14,5-Jan-16
-PHC-NSN.GOV,Native Sovereign Nation,Department of the Interior,Princeton,ME,ACTIVE,29-Apr-14,29-Apr-15
-29PALMSBOMI-NSN.GOV,Native Sovereign Nation,Indian Affairs,Coachella,CA,ACTIVE,12-Mar-14,2-Apr-15
-ABSENTEESHAWNEETRIBE-NSN.GOV,Native Sovereign Nation,Indian Affairs,Shawnee,OK,ACTIVE,31-Aug-14,30-Aug-15
-AGUACALIENTE-NSN.GOV,Native Sovereign Nation,Indian Affairs,Palm Springs,CA,ACTIVE,9-Jul-14,17-Aug-15
-BADRIVER-NSN.GOV,Native Sovereign Nation,Indian Affairs,Odanah,WI,ACTIVE,30-May-14,26-May-15
-BARONA-NSN.GOV,Native Sovereign Nation,Indian Affairs,Lakeside,CA,ACTIVE,28-Apr-14,27-Jun-15
-BEARRIVER-NSN.GOV,Native Sovereign Nation,Indian Affairs,Loleta,CA,ACTIVE,28-Oct-14,28-Oct-15
-BIGVALLEYRANCHERIA-NSN.GOV,Native Sovereign Nation,Indian Affairs,Lakeport,CA,SERVER-HOLD,4-Jan-12,8-Jun-12
-BIHASITKA-NSN.GOV,Native Sovereign Nation,Indian Affairs,Sitka,AK,ACTIVE,13-Aug-14,3-Oct-15
-BLUELAKERANCHERIA-NSN.GOV,Native Sovereign Nation,Indian Affairs,Blue Lake,CA,ACTIVE,26-Aug-14,26-Aug-15
-BOISFORTE-NSN.GOV,Native Sovereign Nation,Indian Affairs,Nett Lake,MN,ACTIVE,9-Feb-15,9-Feb-16
-BRB-NSN.GOV,Native Sovereign Nation,Indian Affairs,LOLETA,CA,ACTIVE,26-Aug-14,5-May-15
-BURNSPAIUTE-NSN.GOV,Native Sovereign Nation,Indian Affairs,Burns,OR,ACTIVE,27-Aug-14,20-Sep-15
-CABAZONINDIANS-NSN.GOV,Native Sovereign Nation,Indian Affairs,Indio,CA,ACTIVE,2-Oct-14,30-Sep-15
-CADDONATION-NSN.GOV,Native Sovereign Nation,Indian Affairs,Binger,OK,ACTIVE,19-Sep-13,30-Sep-14
-CALIFORNIAVALLEYMIWOKTRIBE-NSN.GOV,Native Sovereign Nation,Indian Affairs,Stockton,CA,ACTIVE,22-Jun-14,8-Sep-15
-CAMPO-NSN.GOV,Native Sovereign Nation,Indian Affairs,Campo,CA,ACTIVE,13-Aug-14,1-Aug-15
-CAYUGANATION-NSN.GOV,Native Sovereign Nation,Indian Affairs,Seneca Falls ,NY,ACTIVE,14-Aug-14,9-Jun-15
-CDATRIBE-NSN.GOV,Native Sovereign Nation,Indian Affairs,Plummer,ID,ACTIVE,26-Aug-14,22-Sep-15
-CHEROKEE-NSN.GOV,Native Sovereign Nation,Indian Affairs,Tahlequah,OK,ACTIVE,7-Oct-14,30-Oct-15
-CHEYENNERIVERSIOUXTRIBE-NSN.GOV,Native Sovereign Nation,Indian Affairs,Eagle Butte,SD,SERVER-HOLD,22-Aug-11,2-Oct-12
-CHICKASAW-GOVERNMENT-NSN.GOV,Native Sovereign Nation,Indian Affairs,Ada,OK,ACTIVE,19-Sep-14,24-Sep-15
-CHICKASAW-NSN.GOV,Native Sovereign Nation,Indian Affairs,Ada,OK,ACTIVE,19-Sep-14,24-Sep-15
-CHICKASAWARTISANS-NSN.GOV,Native Sovereign Nation,Indian Affairs,Ada,OK,ACTIVE,19-Sep-14,24-Sep-15
-CHICKASAWGOVERNMENT-NSN.GOV,Native Sovereign Nation,Indian Affairs,Ada,OK,ACTIVE,19-Sep-14,24-Sep-15
-CHICKASAWJUDICIAL-NSN.GOV,Native Sovereign Nation,Indian Affairs,Ada,OK,ACTIVE,19-Sep-14,24-Sep-15
-CHICKASAWLEGISLATURE-NSN.GOV,Native Sovereign Nation,Indian Affairs,Ada,OK,ACTIVE,19-Sep-14,24-Sep-15
-CHICKASAWNATION-NSN.GOV,Native Sovereign Nation,Indian Affairs,Ada,OK,ACTIVE,19-Sep-14,24-Sep-15
-CHICKASAWTRIBE-NSN.GOV,Native Sovereign Nation,Indian Affairs,Ada,OK,ACTIVE,19-Sep-14,24-Sep-15
-CHILKOOT-NSN.GOV,Native Sovereign Nation,Indian Affairs,Haines,AK,ACTIVE,29-Apr-14,12-Jul-15
-CHITIMACHA.GOV,Native Sovereign Nation,Indian Affairs,Charenton,LA,ACTIVE,8-Sep-14,30-Sep-15
-CHUKCHANSI-NSN.GOV,Native Sovereign Nation,Indian Affairs,Fresno,CA,ACTIVE,1-Sep-14,1-Apr-15
-CIT-NSN.GOV,Native Sovereign Nation,Indian Affairs,Havasu Lake,CA,ACTIVE,5-Mar-15,5-Mar-16
-COLUSA-NSN.GOV,Native Sovereign Nation,Indian Affairs,Colusa,CA,ACTIVE,23-Jan-15,23-Mar-16
-COYOTEVALLEY-NSN.GOV,Native Sovereign Nation,Indian Affairs,Redwood valley,CA,ACTIVE,8-Jan-14,8-Jan-15
-CRHC-NSN.GOV,Native Sovereign Nation,Indian Affairs,Chico,CA,ACTIVE,23-Jun-14,22-Jul-15
-CRIT-NSN.GOV,Native Sovereign Nation,Indian Affairs,Parker,AZ,ACTIVE,8-Dec-14,8-Dec-15
-CROW-NSN.GOV,Native Sovereign Nation,Indian Affairs,Crow Agency,MT,ACTIVE,26-Aug-14,17-Jun-15
-CRST-NSN.GOV,Native Sovereign Nation,Indian Affairs,EAGLE BUTTE,SD,ACTIVE,28-Aug-14,16-Aug-15
-CST-NSN.GOV,Native Sovereign Nation,Indian Affairs,Tollhouse,CA,SERVER-HOLD,26-Apr-10,26-Mar-11
-EKLUTNA-NSN.GOV,Native Sovereign Nation,Indian Affairs,Chugiak,AK,ACTIVE,27-Aug-14,30-Sep-15
-ELYSHOSHONETRIBE-NSN.GOV,Native Sovereign Nation,Indian Affairs,Ely,NV,ACTIVE,9-Mar-15,20-Aug-15
-ESTOO-NSN.GOV,Native Sovereign Nation,Indian Affairs,Wyandotte,OK,ACTIVE,8-Oct-14,29-Sep-15
-EWIIAAPAAYP-NSN.GOV,Native Sovereign Nation,Indian Affairs,Alpine,CA,ACTIVE,20-Aug-14,10-Jan-15
-EYAK-NSN.GOV,Native Sovereign Nation,Indian Affairs,Cordova,AK,ACTIVE,19-Jan-15,7-Apr-16
-FCP-NSN.GOV,Native Sovereign Nation,Indian Affairs,Crandon,WI,ACTIVE,14-Aug-14,14-Aug-15
-FCPOTAWATOMI-NSN.GOV,Native Sovereign Nation,Indian Affairs,Crandon,WI,ACTIVE,23-Jun-14,16-Jul-15
-FORTSILLAPACHE-NSN.GOV,Native Sovereign Nation,Indian Affairs,Apache,OK,ACTIVE,23-Jul-14,11-Aug-15
-FTBELKNAP-NSN.GOV,Native Sovereign Nation,Indian Affairs,Harlem,MT,SERVER-HOLD,14-Jan-11,24-Jan-12
-GILARIVER-NSN.GOV,Native Sovereign Nation,Indian Affairs,Sacaton,AZ,ACTIVE,13-Feb-15,19-Mar-16
-GILARIVERINDIANCOMMUNITY-NSN.GOV,Native Sovereign Nation,Indian Affairs,Sacaton,AZ,SERVER-HOLD,13-Feb-15,28-Feb-16
-GLT-NSN.GOV,Native Sovereign Nation,Indian Affairs,Dorr,MI,ACTIVE,22-Jul-14,22-Jul-15
-GUNLAKETRIBE-NSN.GOV,Native Sovereign Nation,Indian Affairs,Dorr,MI,ACTIVE,22-Jul-14,22-Jul-15
-HANNAHVILLEPOTAWATOMI-NSN.GOV,Native Sovereign Nation,Indian Affairs,Wilson,MI,ACTIVE,2-Jun-14,30-Aug-15
-HAVASUPAI-NSN.GOV,Native Sovereign Nation,Indian Affairs,Supai,AZ,ACTIVE,17-Feb-15,15-May-16
-HOOPA-NSN.GOV,Native Sovereign Nation,Indian Affairs,Hoopa,CA,ACTIVE,6-Aug-14,29-Sep-15
-HOPI-NSN.GOV,Native Sovereign Nation,Indian Affairs,Kykotsmovi,AZ,ACTIVE,6-Oct-14,4-Sep-15
-HUALAPAI-NSN.GOV,Native Sovereign Nation,Indian Affairs,Peach Springs,AZ,ACTIVE,13-Aug-14,8-Aug-15
-IIPAYNATION-NSN.GOV,Native Sovereign Nation,Indian Affairs,santa ysabel,CA,ACTIVE,9-Jun-14,9-Jun-15
-ISLETAPUEBLO-NSN.GOV,Native Sovereign Nation,Indian Affairs,Isleta,NM,ACTIVE,21-Jan-15,28-Sep-15
-JACKSONRANCHERIA-NSN.GOV,Native Sovereign Nation,Indian Affairs,Jackson,CA,ACTIVE,4-Mar-15,1-Feb-16
-KAIBABPAIUTE-NSN.GOV,Native Sovereign Nation,Indian Affairs,Fredonia,AZ,ACTIVE,9-Feb-15,7-Feb-16
-KAWAIKA-NSN.GOV,Native Sovereign Nation,Indian Affairs,Laguna,NM,ACTIVE,2-Jun-14,31-Jul-15
-KAYENTATOWNSHIP-NSN.GOV,Native Sovereign Nation,Indian Affairs,Kayenta,AZ,ACTIVE,26-Feb-15,24-Feb-16
-KBIC-NSN.GOV,Native Sovereign Nation,Indian Affairs,Baraga,MI,ACTIVE,10-Sep-14,10-Sep-15
-KENAITZE-NSN.GOV,Native Sovereign Nation,Indian Affairs,Kenai,AK,ACTIVE,10-Feb-14,10-Feb-15
-KEWEENAWBAY-NSN.GOV,Native Sovereign Nation,Indian Affairs,Baraga,MI,ACTIVE,10-Sep-14,10-Sep-15
-KTIK-NSN.GOV,Native Sovereign Nation,Indian Affairs,Horton,KS,ACTIVE,13-Aug-14,10-Aug-15
-LAGUNA-NSN.GOV,Native Sovereign Nation,Indian Affairs,Laguna,NM,ACTIVE,2-Jun-14,31-Jul-15
-LAGUNAPUEBLO-NSN.GOV,Native Sovereign Nation,Indian Affairs,Laguna,NM,ACTIVE,23-Apr-14,30-Apr-15
-LAJOLLA-NSN.GOV,Native Sovereign Nation,Indian Affairs,Pauma Valley,CA,ACTIVE,29-Jan-14,24-Mar-15
-LCO-NSN.GOV,Native Sovereign Nation,Indian Affairs,Hayward,WI,ACTIVE,4-Aug-14,30-Sep-15
-LTBBODAWA-NSN.GOV,Native Sovereign Nation,Indian Affairs,Harbor Springs,MI,ACTIVE,5-Jun-14,2-Sep-15
-LUMMI-NSN.GOV,Native Sovereign Nation,Indian Affairs,Bellingham,WA,ACTIVE,24-Sep-14,30-Sep-15
-MASHANTUCKET-NSN.GOV,Native Sovereign Nation,Indian Affairs,Mashantucket,CT,ACTIVE,25-Aug-14,8-Sep-15
-MASHANTUCKETPEQUOT-NSN.GOV,Native Sovereign Nation,Indian Affairs,Mashantucket,CT,ACTIVE,25-Aug-14,8-Sep-15
-MASHANTUCKETWESTERNPEQUOT-NSN.GOV,Native Sovereign Nation,Indian Affairs,Mashantucket,CT,ACTIVE,25-Aug-14,8-Sep-15
-MCN-NSN.GOV,Native Sovereign Nation,Indian Affairs,Okmulgee,OK,ACTIVE,21-Jan-15,19-Mar-16
-MECHOOPDA-NSN.GOV,Native Sovereign Nation,Indian Affairs,Chico,CA,ACTIVE,9-Sep-14,25-Oct-15
-MENOMINEE-NSN.GOV,Native Sovereign Nation,Indian Affairs,Keshena,WI,ACTIVE,9-Jun-14,8-Jul-15
-MESAGRANDEBAND-NSN.GOV,Native Sovereign Nation,Indian Affairs,SantaYsabel,CA,ACTIVE,6-Nov-13,6-Nov-14
-MESKWAKI-NSN.GOV,Native Sovereign Nation,Indian Affairs,Tama,IA,ACTIVE,30-May-14,4-Jun-15
-MICCOSUKEE-NSN.GOV,Native Sovereign Nation,Indian Affairs,Miami,FL,ACTIVE,19-Dec-14,14-Dec-15
-MICMAC-NSN.GOV,Native Sovereign Nation,Indian Affairs,Presque Isle,ME,ACTIVE,9-Sep-14,30-Sep-15
-MIDDLETOWNRANCHERIA-NSN.GOV,Native Sovereign Nation,Indian Affairs,Middletown,CA,ACTIVE,3-Feb-15,5-Dec-15
-MILLELACSBAND-NSN.GOV,Native Sovereign Nation,Indian Affairs,Onamia,MN,ACTIVE,21-Mar-14,21-Mar-15
-MOAPABANDOFPAIUTES-NSN.GOV,Native Sovereign Nation,Indian Affairs,Moapa,NV,ACTIVE,7-Jan-15,6-Feb-16
-MOHICAN-NSN.GOV,Native Sovereign Nation,Indian Affairs,Bowler,WI,ACTIVE,9-Sep-14,30-Sep-15
-MORONGO-NSN.GOV,Native Sovereign Nation,Indian Affairs,Banning,CA,ACTIVE,9-Oct-13,27-Oct-14
-MPGE-NSN.GOV,Native Sovereign Nation,Indian Affairs,Mashantucket,CT,ACTIVE,25-Aug-14,8-Sep-15
-MPTN-NSN.GOV,Native Sovereign Nation,Indian Affairs,Mashantucket,CT,ACTIVE,25-Aug-14,8-Sep-15
-MUSCOGEENATION-NSN.GOV,Native Sovereign Nation,Indian Affairs,Okmulgee,OK,ACTIVE,22-Aug-14,30-Sep-14
-NCIHA-NSN.GOV,Native Sovereign Nation,Indian Affairs,Ukiah,CA,ACTIVE,14-Aug-14,9-Nov-15
-NFR-NSN.GOV,Native Sovereign Nation,Indian Affairs,North Fork,CA,ACTIVE,22-May-14,6-Aug-15
-NINILCHIKTRIBE-NSN.GOV,Native Sovereign Nation,Indian Affairs,Ninilchik,AK,ACTIVE,21-Jul-14,17-Sep-15
-NISQUALLY-NSN.GOV,Native Sovereign Nation,Indian Affairs,Olympia,WA,ACTIVE,2-Sep-14,30-Sep-15
-NOOKSACK-NSN.GOV,Native Sovereign Nation,Indian Affairs,Deming,WA,ACTIVE,9-Apr-14,26-Jun-15
-NORTHFORKRANCHERIA-NSN.GOV,Native Sovereign Nation,Indian Affairs,North Fork ,CA,ACTIVE,22-May-14,11-Jul-15
-NVB-NSN.GOV,Native Sovereign Nation,Indian Affairs,Barrow,AK,ACTIVE,21-Aug-14,20-Oct-15
-NWBSHOSHONE-NSN.GOV,Native Sovereign Nation,Indian Affairs,Brigham City,UT,SERVER-HOLD,11-Jan-10,21-Feb-11
-OHKAYOWINGEH-NSN.GOV,Native Sovereign Nation,Indian Affairs,San Juan Pueblo,NM,ACTIVE,19-Aug-14,8-Jun-15
-OMAHA-NSN.GOV,Native Sovereign Nation,Indian Affairs,Macy,NE,ACTIVE,19-Aug-14,22-Sep-15
-ONEIDA-NSN.GOV,Native Sovereign Nation,Indian Affairs,Oneida,WI,ACTIVE,26-Aug-14,21-Sep-15
-ONEIDAINDIANNATION-NSN.GOV,Native Sovereign Nation,Indian Affairs,Oneida,NY,SERVER-HOLD,26-Nov-12,3-Feb-14
-ONEIDANATION-NSN.GOV,Native Sovereign Nation,Indian Affairs,Oneida,NY,SERVER-HOLD,26-Nov-12,3-Feb-14
-OSAGECONGRESS-NSN.GOV,Native Sovereign Nation,Indian Affairs,Pawhuska,OK,ACTIVE,17-Dec-14,16-Mar-16
-OSAGENATION-NSN.GOV,Native Sovereign Nation,Indian Affairs,Pawhuska,OK,ACTIVE,2-Jun-14,30-Jul-15
-PASCUAYAQUI-NSN.GOV,Native Sovereign Nation,Indian Affairs,Tucson,AZ,ACTIVE,15-Aug-14,16-Sep-15
-PASKENTA-NSN.GOV,Native Sovereign Nation,Indian Affairs,Corning,CA,ACTIVE,5-Jun-14,5-Jun-15
-PAUMA-NSN.GOV,Native Sovereign Nation,Indian Affairs,Pauma Valley,CA,ACTIVE,23-Jan-15,22-Feb-16
-PCI-NSN.GOV,Native Sovereign Nation,Indian Affairs,Atmore,AL,ACTIVE,12-Aug-14,29-Oct-14
-PECHANGA-NSN.GOV,Native Sovereign Nation,Indian Affairs,Temecula,CA,ACTIVE,11-Aug-14,30-Sep-15
-PEQUOT-NSN.GOV,Native Sovereign Nation,Indian Affairs,Mashantucket,CT,ACTIVE,25-Aug-14,8-Sep-15
-PICAYUNERANCHERIA-NSN.GOV,Native Sovereign Nation,Indian Affairs,Coarsegold,CA,ACTIVE,12-Aug-14,21-Aug-15
-POARCHCREEKINDIANS-NSN.GOV,Native Sovereign Nation,Indian Affairs,ATMORE,AL,ACTIVE,12-Aug-14,14-Sep-14
-POKAGONBAND-NSN.GOV,Native Sovereign Nation,Indian Affairs,DOWAGIAC,MI,ACTIVE,10-Feb-15,6-Apr-16
-POL-NSN.GOV,Native Sovereign Nation,Indian Affairs,Laguna,NM,ACTIVE,2-Jun-14,31-Jul-15
-QVIR-NSN.GOV,Native Sovereign Nation,Indian Affairs,Fort jones,CA,ACTIVE,25-Nov-14,25-Nov-15
-RAMONA-NSN.GOV,Native Sovereign Nation,Indian Affairs,Anza,CA,ACTIVE,15-Jul-14,13-Jul-15
-REDCLIFF-NSN.GOV,Native Sovereign Nation,Indian Affairs,Bayfield,WI,ACTIVE,6-Mar-15,30-Sep-15
-ROSEBUDSIOUXTRIBE-NSN.GOV,Native Sovereign Nation,Indian Affairs,Rosebud,SD,ACTIVE,3-Sep-14,10-Oct-15
-RST-NSN.GOV,Native Sovereign Nation,Indian Affairs,Rosebud,SD,ACTIVE,20-Feb-15,3-Apr-16
-RSTWATER-NSN.GOV,Native Sovereign Nation,Indian Affairs,Rosebud,SD,ACTIVE,13-Jun-14,12-Aug-15
-SACANDFOXNATION-NSN.GOV,Native Sovereign Nation,Indian Affairs,Stroud,OK,ACTIVE,29-Dec-14,29-Dec-15
-SANMANUEL-NSN.GOV,Native Sovereign Nation,Indian Affairs,Highland,CA,ACTIVE,28-Aug-14,23-Sep-15
-SANTAANA-NSN.GOV,Native Sovereign Nation,Indian Affairs,Santa Ana,NM,ACTIVE,14-Jan-15,5-Mar-16
-SANTAROSACAHUILLA-NSN.GOV,Native Sovereign Nation,Indian Affairs,Anza,CA,ACTIVE,29-May-14,18-Aug-15
-SAUK-SUIATTLE-NSN.GOV,Native Sovereign Nation,Indian Affairs,Darrington,WA,SERVER-HOLD,11-Sep-12,22-Jun-13
-SCAT-NSN.GOV,Native Sovereign Nation,Indian Affairs,Peridot,AZ,ACTIVE,18-Aug-14,16-Sep-15
-SCC-NSN.GOV,Native Sovereign Nation,Indian Affairs,Crandon,WI,ACTIVE,17-Feb-15,14-May-16
-SEMINOLENATION-NSN.GOV,Native Sovereign Nation,Indian Affairs,Wewoka,OK,ACTIVE,24-Nov-14,2-Dec-15
-SHINNECOCK-NSN.GOV,Native Sovereign Nation,Indian Affairs,SOUTHAMPTON,NY,SERVER-HOLD,13-Aug-13,26-Apr-13
-SHOALWATERBAY-NSN.GOV,Native Sovereign Nation,Indian Affairs,Tokeland,WA,ACTIVE,24-Oct-14,30-Sep-15
-SIR-NSN.GOV,Native Sovereign Nation,Indian Affairs,Susanville,CA,ACTIVE,16-Jun-14,14-Sep-15
-SITKATRIBE-NSN.GOV,Native Sovereign Nation,Indian Affairs,Sitka,AK,ACTIVE,20-Dec-13,16-Nov-14
-SNO-NSN.GOV,Native Sovereign Nation,Indian Affairs,Wewoka,OK,ACTIVE,24-Nov-14,1-Dec-15
-SOBOBA-NSN.GOV,Native Sovereign Nation,Indian Affairs,San Jacinto,CA,ACTIVE,2-Sep-14,30-Sep-15
-SOUTHERNUTE-NSN.GOV,Native Sovereign Nation,Indian Affairs,IGNACIO,CO,ACTIVE,20-Jun-14,28-Jun-15
-SRMT-NSN.GOV,Native Sovereign Nation,Indian Affairs,Akwesasne,NY,ACTIVE,6-Aug-14,30-Sep-15
-SRPMIC-NSN.GOV,Native Sovereign Nation,Indian Affairs,Scottsdale,AZ,ACTIVE,9-Jun-14,26-Aug-15
-SUSANVILLEINDIANRANCHERIA-NSN.GOV,Native Sovereign Nation,Indian Affairs,Susanville,CA,ACTIVE,16-Jun-14,14-Sep-15
-SWINOMISH-NSN.GOV,Native Sovereign Nation,Indian Affairs,La Conner,WA,ACTIVE,2-Sep-14,30-Sep-15
-SWO-NSN.GOV,Native Sovereign Nation,Indian Affairs,Agency Village,SD,ACTIVE,27-Aug-14,16-May-15
-SYCUAN-NSN.GOV,Native Sovereign Nation,Indian Affairs,El Cajon,CA,ACTIVE,26-Aug-14,12-Dec-14
-TACHI-YOKUT-NSN.GOV,Native Sovereign Nation,Indian Affairs,Lemoore,CA,ACTIVE,24-Mar-14,20-Jun-15
-TAMAYA-NSN.GOV,Native Sovereign Nation,Indian Affairs,Santa Ana,NM,ACTIVE,14-Jan-15,10-Mar-16
-TMDCI-NSN.GOV,Native Sovereign Nation,Indian Affairs,Thermal,CA,ACTIVE,18-Sep-14,29-Nov-15
-TOLC-NSN.GOV,Native Sovereign Nation,Indian Affairs,Sells,AZ,SERVER-HOLD,6-Jun-13,5-Jul-14
-TOLOWA-NSN.GOV,Native Sovereign Nation,Indian Affairs,Smith River,CA,ACTIVE,9-Jan-15,26-Jan-16
-TONATION-NSN.GOV,Native Sovereign Nation,Indian Affairs,Sells,AZ,ACTIVE,24-Sep-14,30-Sep-15
-TULALIP-NSN.GOV,Native Sovereign Nation,Indian Affairs,Tulalip,WA,ACTIVE,1-Jul-14,30-Sep-15
-TULALIPAIR-NSN.GOV,Native Sovereign Nation,Indian Affairs,Tulalip,WA,ACTIVE,20-Oct-14,17-Dec-15
-TULALIPTRIBES-NSN.GOV,Native Sovereign Nation,Indian Affairs,Tulalip,WA,ACTIVE,1-Jul-14,30-Sep-15
-TULERIVERTRIBE-NSN.GOV,Native Sovereign Nation,Indian Affairs,Porterville,CA,ACTIVE,15-Jul-14,1-Sep-15
-TWENTYNINEPALMSBOMI-NSN.GOV,Native Sovereign Nation,Indian Affairs,Coachella,CA,ACTIVE,11-Aug-14,7-Nov-15
-UKB-NSN.GOV,Native Sovereign Nation,Indian Affairs,Tahlequah,OK,ACTIVE,11-Mar-15,9-Jun-16
-UPPERSIOUXCOMMUNITY-NSN.GOV,Native Sovereign Nation,Indian Affairs,Granite Falls,MN,ACTIVE,27-Aug-14,14-Sep-15
-UPPERSKAGIT-NSN.GOV,Native Sovereign Nation,Indian Affairs,Sedro-Woolley,WA,SERVER-HOLD,3-Aug-10,30-Sep-11
-VIEJAS-NSN.GOV,Native Sovereign Nation,Indian Affairs,Alpine,CA,ACTIVE,16-Jun-14,13-Sep-15
-WESTERNPEQUOT-NSN.GOV,Native Sovereign Nation,Indian Affairs,Mashantucket,CT,ACTIVE,25-Aug-14,8-Sep-15
-WHITEEARTH-NSN.GOV,Native Sovereign Nation,Indian Affairs,Ogema,MN,ACTIVE,5-Mar-15,23-Jan-16
-WILTONRANCHERIA-NSN.GOV,Native Sovereign Nation,Indian Affairs,Elk Grove,CA,ACTIVE,24-Jun-14,7-Aug-15
-WINNEMUCCAINDIANCOLONYOFNEVADA-NSN.GOV,Native Sovereign Nation,Indian Affairs,Winnemucca,NV,ACTIVE,28-Mar-14,14-Jun-15
-WYANDOTTE-NATION-NSN.GOV,Native Sovereign Nation,Indian Affairs,Wyandotte,OK,ACTIVE,31-Jul-14,31-Jul-15
-YAKAMAFISH-NSN.GOV,Native Sovereign Nation,Indian Affairs,Toppenish,WA,ACTIVE,8-Jan-15,3-Mar-16
-YAKAMANATION-NSN.GOV,Native Sovereign Nation,Indian Affairs,Toppenish,WA,ACTIVE,19-Aug-14,5-Feb-15
-YOCHADEHE-NSN.GOV,Native Sovereign Nation,Indian Affairs,Brooks,CA,ACTIVE,13-Jun-14,11-Sep-15
-YPT-NSN.GOV,Native Sovereign Nation,Indian Affairs,Yerington,NV,ACTIVE,8-Aug-14,31-Aug-15
-CHILKAT-NSN.GOV,Native Sovereign Nation,Non-Federal Agency,Haines,AK,ACTIVE,22-Jan-14,23-Mar-15
-DINEH-NSN.GOV,Native Sovereign Nation,Non-Federal Agency,Window Rock,AZ,ACTIVE,28-Jul-14,25-Aug-15
-LRBOI-NSN.GOV,Native Sovereign Nation,Non-Federal Agency,Manistee,MI,ACTIVE,13-Aug-14,3-Sep-15
-NAVAJO-NSN.GOV,Native Sovereign Nation,Non-Federal Agency,Window Rock,AZ,ACTIVE,28-Jul-14,25-Aug-15
-YDSP-NSN.GOV,Native Sovereign Nation,Non-Federal Agency,El Pas,TX,ACTIVE,14-Jul-14,11-Aug-15
-AZCORRECTIONS.GOV,State/Local Govt,Advisory Commission on Intergovernmental Relations,Phoenix,AZ,ACTIVE,20-Feb-15,2-Nov-15
-OKCOMMERCE.GOV,State/Local Govt,Department of Commerce,Oklahoma city,OK,ACTIVE,5-Sep-14,15-Sep-15
-MCAC-MD.GOV,State/Local Govt,Department of Homeland Security,Calverton ,MD,ACTIVE,25-Feb-14,24-May-15
-MTC.GOV,State/Local Govt,Multistate Tax Commission,Washington,DC,ACTIVE,16-Sep-14,30-Sep-15
-511MAINE.GOV,State/Local Govt,Non-Federal Agency,Augusta,ME,ACTIVE,2-Jul-14,30-Sep-15
-511NY.GOV,State/Local Govt,Non-Federal Agency,Albany,NY,ACTIVE,29-Mar-13,16-May-14
-511TX.GOV,State/Local Govt,Non-Federal Agency,Austin,TX,ACTIVE,27-Feb-15,12-Feb-16
-511WI.GOV,State/Local Govt,Non-Federal Agency,Madison,WI,ACTIVE,30-Sep-14,10-Oct-15
-ACCESSTN.GOV,State/Local Govt,Non-Federal Agency,NASHVILLE,TN,ACTIVE,20-Oct-14,12-Jan-16
-ADAMSCOUNTYMS.GOV,State/Local Govt,Non-Federal Agency,Natchez,MS,ACTIVE,25-Aug-14,30-Sep-15
-ADRCNJ.GOV,State/Local Govt,Non-Federal Agency,Mercerville,NJ,ACTIVE,3-Mar-15,21-Jul-15
-AGAZ.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE,2-Sep-14,30-Sep-15
-AK.GOV,State/Local Govt,Non-Federal Agency,Juneau,AK,ACTIVE,15-Sep-14,15-Sep-15
-AKAEROSPACE.GOV,State/Local Govt,Non-Federal Agency,Anchorage,AK,ACTIVE,8-Apr-14,7-Jul-15
-AKLEG.GOV,State/Local Govt,Non-Federal Agency,Juneau,AK,ACTIVE,11-Feb-15,2-Apr-16
-AL-LEGISLATURE.GOV,State/Local Govt,Non-Federal Agency,Montgomery,AL,ACTIVE,19-Sep-14,30-Sep-15
-AL.GOV,State/Local Govt,Non-Federal Agency,Montgomery,AL,ACTIVE,25-Sep-14,30-Sep-15
-ALABAMA.GOV,State/Local Govt,Non-Federal Agency,Montgomery,AL,ACTIVE,25-Sep-14,30-Sep-15
-ALABAMAAGELINE.GOV,State/Local Govt,Non-Federal Agency,Montgomery,AL,ACTIVE,21-Jan-15,3-Apr-16
-ALABAMACONNECT.GOV,State/Local Govt,Non-Federal Agency,Montgomery,AL,ACTIVE,27-Feb-14,3-Apr-15
-ALABAMADA.GOV,State/Local Govt,Non-Federal Agency,Montgomery,AL,ACTIVE,30-Oct-14,4-Nov-15
-ALABAMAHOUSEPHOTOS.GOV,State/Local Govt,Non-Federal Agency,Montgomery,AL,ACTIVE,4-Mar-15,1-Feb-16
-ALABAMASMP.GOV,State/Local Govt,Non-Federal Agency,Montgomery,AL,ACTIVE,22-May-14,22-May-15
-ALABAMAVOTES.GOV,State/Local Govt,Non-Federal Agency,Montgomery,AL,ACTIVE,27-Aug-14,7-Aug-15
-ALABPP.GOV,State/Local Govt,Non-Federal Agency,Montgomery,AL,ACTIVE,18-Jun-14,31-Aug-15
-ALACHUACOUNTYFL.GOV,State/Local Govt,Non-Federal Agency,Gainesville,FL,ACTIVE,3-Jun-11,26-Aug-12
-ALACOP.GOV,State/Local Govt,Non-Federal Agency,Montgomery,AL,ACTIVE,25-Aug-14,30-Sep-15
-ALACOURT.GOV,State/Local Govt,Non-Federal Agency,Montgomery,AL,ACTIVE,18-Jun-14,31-Aug-15
-ALADA.GOV,State/Local Govt,Non-Federal Agency,Mongomery,AL,ACTIVE,18-Jun-14,31-Aug-15
-ALADNA.GOV,State/Local Govt,Non-Federal Agency,Montgomery,AL,ACTIVE,18-Jun-14,31-Aug-15
-ALASAFE.GOV,State/Local Govt,Non-Federal Agency,Montgomery,AL,ACTIVE,25-Aug-14,4-Oct-15
-ALASKA.GOV,State/Local Govt,Non-Federal Agency,Juneau,AK,ACTIVE,15-Sep-14,15-Sep-15
-ALASKACARE.GOV,State/Local Govt,Non-Federal Agency,Juneau,AK,ACTIVE,23-Feb-15,20-May-16
-ALBUQUERQUE-NM.GOV,State/Local Govt,Non-Federal Agency,Albuquerque,NM,ACTIVE,2-Jul-14,30-Sep-15
-ALDOI.GOV,State/Local Govt,Non-Federal Agency,Montgomery,AL,ACTIVE,27-Aug-14,7-Sep-15
-ALEA.GOV,State/Local Govt,Non-Federal Agency,Montgomery,AL,ACTIVE,21-Aug-14,21-Aug-15
-ALEXANDERCOUNTYNC.GOV,State/Local Govt,Non-Federal Agency,Taylorsville,NC,ACTIVE,31-Oct-14,30-Sep-15
-ALGONAC-MI.GOV,State/Local Govt,Non-Federal Agency,Algonac,MI,ACTIVE,8-Jul-14,30-Sep-15
-ALHOUSE.GOV,State/Local Govt,Non-Federal Agency,Montgomery ,AL,ACTIVE,19-Sep-14,30-Sep-15
-ALLENDALENJ.GOV,State/Local Govt,Non-Federal Agency,Allendale,NJ,ACTIVE,5-Aug-14,30-Sep-15
-ALPHARETTA-GA.GOV,State/Local Govt,Non-Federal Agency,Alpharetta,GA,ACTIVE,24-Jul-14,26-Aug-15
-ALSENATE.GOV,State/Local Govt,Non-Federal Agency,Montgomery ,AL,ACTIVE,19-Sep-14,30-Sep-15
-ALTOONAPA.GOV,State/Local Govt,Non-Federal Agency,Altoona,PA,ACTIVE,10-Sep-14,30-Sep-15
-AMERICANSAMOA.GOV,State/Local Govt,Non-Federal Agency,Pago Pago,AS,ACTIVE,13-Aug-13,26-Feb-14
-AMESBURYMA.GOV,State/Local Govt,Non-Federal Agency,Amesbury,MA,ACTIVE,7-Aug-14,31-Aug-15
-AMITECOUNTYMS.GOV,State/Local Govt,Non-Federal Agency,Liberty,MS,ACTIVE,23-Oct-14,30-Sep-15
-ANNAPOLIS.GOV,State/Local Govt,Non-Federal Agency,Annapolis,MD,ACTIVE,26-Aug-14,30-Sep-15
-ANNAPOLISMD.GOV,State/Local Govt,Non-Federal Agency,Annapolis,MD,ACTIVE,26-Aug-14,30-Sep-15
-ANTIOCHTOWNSHIP-IL.GOV,State/Local Govt,Non-Federal Agency,Lake Villa,IL,ACTIVE,23-Feb-13,23-Feb-14
-ANTIOCHTOWNSHIPIL.GOV,State/Local Govt,Non-Federal Agency,Lake Villa,IL,ACTIVE,25-Mar-14,25-Mar-15
-AQMD.GOV,State/Local Govt,Non-Federal Agency,Diamond Bar,CA,ACTIVE,9-Sep-14,30-Sep-15
-AR.GOV,State/Local Govt,Non-Federal Agency,Little Rock,AR,ACTIVE,23-Sep-14,26-Aug-15
-ARCHDALE-NC.GOV,State/Local Govt,Non-Federal Agency,ARCHDALE,NC,ACTIVE,19-Aug-14,30-Sep-15
-ARCOURTS.GOV,State/Local Govt,Non-Federal Agency,Little Rock,AR,ACTIVE,5-Feb-15,5-Feb-16
-ARIZONA.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE,3-Sep-14,30-Sep-15
-ARIZONAJOBCONNECTION.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE,23-May-14,11-Aug-15
-ARIZONASERVES.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE,21-Jan-15,3-Feb-16
-ARIZONATREASURES.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE,3-Jan-12,1-Feb-13
-ARIZONATURBOCOURT.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE,12-Feb-15,4-May-16
-ARKANSAS.GOV,State/Local Govt,Non-Federal Agency,Little Rock,AR,ACTIVE,23-Sep-14,26-Aug-15
-ARKANSASAG.GOV,State/Local Govt,Non-Federal Agency,Little Rock,AR,ACTIVE,14-Aug-14,30-Sep-15
-ARKLEGAUDIT.GOV,State/Local Govt,Non-Federal Agency,Little Rock,AR,ACTIVE,23-Jun-14,18-Sep-15
-ARTREASURY.GOV,State/Local Govt,Non-Federal Agency,Litlte Rock,AR,ACTIVE,3-Nov-14,18-Nov-15
-ARTRS.GOV,State/Local Govt,Non-Federal Agency,Little Rock,AR,ACTIVE,16-May-14,13-Jul-15
-AS.GOV,State/Local Govt,Non-Federal Agency,Pago Pago,AS,ACTIVE,13-Aug-13,24-Jun-13
-ASAFERFLORIDA.GOV,State/Local Govt,Non-Federal Agency,Tallahassee,FL,ACTIVE,6-May-14,12-Jul-15
-ASEPA.GOV,State/Local Govt,Non-Federal Agency,Pago Pago,AS,ACTIVE,23-Nov-11,18-Dec-12
-ASHEVILLENC.GOV,State/Local Govt,Non-Federal Agency,Asheville,NC,ACTIVE,11-Aug-14,9-Sep-15
-ATHOMEILLINOIS.GOV,State/Local Govt,Non-Federal Agency,Chicago,IL,ACTIVE,10-Dec-14,10-Dec-15
-ATLASALABAMA.GOV,State/Local Govt,Non-Federal Agency,TUSCALOOSA,AL,ACTIVE,17-Oct-14,17-Oct-15
-ATTORNEYGENERAL.GOV,State/Local Govt,Non-Federal Agency,Harrisburg,PA,ACTIVE,29-Jul-14,13-Sep-15
-AUBURNNY.GOV,State/Local Govt,Non-Federal Agency,Auburn,NY,ACTIVE,22-Jul-14,18-Oct-15
-AUBURNWA.GOV,State/Local Govt,Non-Federal Agency,Auburn,WA,ACTIVE,24-Jun-14,20-Aug-15
-AUGUSTAGA.GOV,State/Local Govt,Non-Federal Agency,Augusta,GA,ACTIVE,21-Jul-14,21-Sep-15
-AURORATEXAS.GOV,State/Local Govt,Non-Federal Agency,Rhome,TX,ACTIVE,24-Jul-13,30-Sep-13
-AVON-MA.GOV,State/Local Govt,Non-Federal Agency,Avon,MA,ACTIVE,5-Mar-15,5-Mar-16
-AZ-ACOIHC.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE,17-Apr-13,30-May-14
-AZ-FHSD.GOV,State/Local Govt,Non-Federal Agency,Fountain Hills,AZ,ACTIVE,2-Jul-14,30-Sep-15
-AZ.GOV,State/Local Govt,Non-Federal Agency,Phoeniz,AZ,ACTIVE,31-Aug-14,2-Sep-15
-AZ511.GOV,State/Local Govt,Non-Federal Agency,Pheonix,AZ,ACTIVE,30-Jul-14,26-Oct-15
-AZ529.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE,26-Jun-14,22-Mar-15
-AZ911.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE,28-Apr-14,29-May-15
-AZABRC.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE,31-Dec-14,23-Mar-16
-AZACCOUNTANCY.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE,26-Mar-14,17-Jun-15
-AZACTIC.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE,17-Dec-14,15-Jan-16
-AZAFIS.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE,14-Jul-14,13-Jul-15
-AZAG.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE,2-Sep-14,30-Sep-15
-AZAHCCCS.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE,16-Sep-13,26-Aug-14
-AZARTS.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE,2-Sep-14,30-Sep-15
-AZASRS.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE,7-Aug-14,13-Sep-15
-AZAUDITOR.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE,15-Sep-14,13-Oct-15
-AZBN.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE,2-Sep-14,30-Sep-15
-AZBNP.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE,27-Feb-15,24-Apr-16
-AZBOA.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE,15-Dec-14,17-Feb-16
-AZBOC.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE,24-Dec-14,29-Nov-15
-AZBOEC.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE,30-Sep-14,30-Sep-15
-AZBOF.GOV,State/Local Govt,Non-Federal Agency,PHOENIX,AZ,ACTIVE,21-Aug-14,13-Sep-15
-AZBORDERTRASH.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE,26-Aug-14,27-Jul-15
-AZBOTA.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE,25-Apr-14,25-Apr-15
-AZBOXINGANDMMA.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE,28-Apr-14,29-May-15
-AZBROADBAND.GOV,State/Local Govt,Non-Federal Agency,PHOENIX,AZ,ACTIVE,11-Apr-14,20-Apr-15
-AZBTR.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE,3-Sep-14,6-Sep-15
-AZCANCERCONTROL.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE,18-Dec-14,15-Nov-15
-AZCC.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE,16-Jul-14,30-Sep-15
-AZCENTENNIAL.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE,3-Sep-13,30-Sep-14
-AZCIA.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE,2-Apr-14,2-Apr-15
-AZCJC.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE,18-Dec-14,17-Mar-16
-AZCLEANELECTIONS.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE,3-Oct-14,30-Sep-15
-AZCLIMATECHANGE.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE,13-May-14,17-Nov-14
-AZCOOP.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE,24-Dec-14,4-Dec-15
-AZCORPCOM.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE,16-Jul-14,30-Sep-15
-AZCORPCOMM.GOV,State/Local Govt,Non-Federal Agency,Phoenxi,AZ,ACTIVE,16-Jul-14,30-Sep-15
-AZCOURTDOCS.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE,10-Sep-14,10-Sep-15
-AZCOURTS.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE,12-Feb-15,16-Feb-16
-AZCVD.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE,19-Nov-14,13-Nov-15
-AZDA.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE,13-Aug-14,30-Sep-15
-AZDAARS.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE,8-Sep-14,8-Sep-15
-AZDCS.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE,10-Mar-15,2-Jun-16
-AZDDPC.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE,14-Nov-14,1-Feb-16
-AZDEMA.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE,13-Feb-15,30-Sep-15
-AZDEQ.GOV,State/Local Govt,Non-Federal Agency,Phx,AZ,ACTIVE,26-Aug-14,30-Sep-15
-AZDES.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE,4-Aug-14,30-Sep-15
-AZDFI.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE,5-Dec-14,22-Sep-15
-AZDHS.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE,4-Sep-14,30-Sep-15
-AZDIABETES.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE,27-Feb-15,12-Apr-16
-AZDJC.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE,13-Aug-14,27-Aug-15
-AZDO.GOV,State/Local Govt,Non-Federal Agency,Scottsdale,AZ,ACTIVE,4-Aug-14,31-Oct-15
-AZDOA.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE,21-Oct-14,22-Oct-15
-AZDOC.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE,26-Feb-14,29-Mar-15
-AZDOH.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE,9-Feb-15,14-Feb-16
-AZDOHS.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE,29-Aug-14,15-Sep-15
-AZDOR.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE,2-Sep-14,23-Sep-15
-AZDOSH.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE,29-Jul-14,1-Aug-15
-AZDOT.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE,30-Jul-14,26-Aug-15
-AZDPS.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE,27-Aug-14,27-Aug-15
-AZDVS.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE,20-Jan-15,19-Apr-16
-AZDWM.GOV,State/Local Govt,Non-Federal Agency,Glendale,AZ,ACTIVE,5-Sep-14,8-Sep-15
-AZECALC.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE,1-Oct-14,14-Nov-15
-AZECDH.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE,26-Feb-14,24-Apr-15
-AZED.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE,18-Feb-14,12-May-15
-AZEIN.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE,18-Feb-14,14-May-15
-AZENERGY.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE,24-Feb-14,10-Mar-15
-AZENVIROKIDS.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE,13-May-14,19-Apr-15
-AZEPIP.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE,30-Dec-14,19-Jan-16
-AZFIRSTTHINGSFIRST.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE,5-May-14,6-May-15
-AZFTF.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE,19-Feb-15,2-Jul-15
-AZGADA.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE,3-Mar-15,3-Apr-16
-AZGAMING.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE,8-Sep-14,10-Sep-15
-AZGFD.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE,5-Aug-14,26-Aug-15
-AZGITA.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE,21-Feb-12,30-Sep-12
-AZGOHS.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE,8-Oct-14,30-Sep-15
-AZGOVERNOR.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE,20-Aug-14,24-Sep-15
-AZGRANTS.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE,26-Jun-14,27-Mar-15
-AZGU.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE,27-Aug-13,30-Sep-14
-AZGUARD.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE,10-Feb-15,13-May-15
-AZHC.GOV,State/Local Govt,Non-Federal Agency,Pheonix,AZ,ACTIVE,16-Sep-13,10-Sep-14
-AZHCG.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE,16-Sep-13,14-Oct-14
-AZHEALTH.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE,18-Dec-14,10-Dec-15
-AZHIGHERED.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE,1-Oct-14,30-Sep-15
-AZHOUSE.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE,6-Feb-15,2-Mar-16
-AZHOUSING.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE,12-Jan-15,15-Jan-16
-AZHS.GOV,State/Local Govt,Non-Federal Agency,Tempe,AZ,ACTIVE,23-Jul-14,30-Sep-15
-AZICA.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE,4-Dec-13,30-Jan-15
-AZINSURANCE.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE,11-Apr-12,21-Jun-13
-AZINVESTOR.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE,16-Jul-14,30-Sep-15
-AZJOBCONNECTION.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE,23-May-14,11-Aug-15
-AZJUVED.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE,29-Jan-15,29-Jan-16
-AZKIDSCARE.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE,16-Sep-13,15-Sep-14
-AZKIDSNEEDU.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE,10-Sep-14,30-Sep-15
-AZLAND.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE,26-Jul-14,26-Jul-15
-AZLEG.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE,13-Aug-14,27-Sep-15
-AZLGMA.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE,18-Mar-13,7-Apr-14
-AZLIBRARY.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE,2-Sep-14,30-Sep-15
-AZLINKS.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE,30-Sep-14,30-Nov-15
-AZLIQUOR.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE,30-Sep-14,27-Sep-15
-AZLOTTERY.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE,21-Aug-14,30-Sep-15
-AZMAG.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE,3-Oct-14,15-Oct-15
-AZMD.GOV,State/Local Govt,Non-Federal Agency,Scottsdale,AZ,ACTIVE,24-Mar-14,20-Apr-15
-AZMFRF.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE,22-Dec-14,21-Mar-16
-AZMINORITYHEALTH.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE,4-Sep-14,25-Oct-15
-AZMORTGAGERESOURCE.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE,30-May-14,29-Jul-15
-AZMYFAMILYBENEFITS.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE,8-Sep-14,10-Nov-15
-AZND.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE,28-Apr-14,7-May-15
-AZNET.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE,26-Feb-14,9-Mar-15
-AZOCA.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE,4-Mar-15,25-Jan-16
-AZOSPB.GOV,State/Local Govt,Non-Federal Agency,phoenix,AZ,ACTIVE,19-Feb-14,30-Apr-15
-AZOT.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE,25-Apr-14,1-Feb-15
-AZPA.GOV,State/Local Govt,Non-Federal Agency,Scottsdale,AZ,ACTIVE,24-Mar-14,20-Apr-15
-AZPARKS.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE,22-Jul-14,19-Aug-15
-AZPCRPD.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE,23-Jun-11,29-Jun-12
-AZPH.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE,28-Apr-14,17-May-15
-AZPHARMACY.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE,3-Mar-15,23-Jan-15
-AZPOST.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE,20-Jan-15,19-Apr-16
-AZPPSE.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE,28-Apr-14,29-Apr-15
-AZPSIC.GOV,State/Local Govt,Non-Federal Agency,PHOENIX,AZ,ACTIVE,11-Apr-14,21-Apr-15
-AZQUALITYFIRST.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE,26-Feb-14,23-Apr-15
-AZRACING.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE,24-Jul-14,21-Sep-15
-AZRE.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE,19-Feb-15,31-Aug-15
-AZRECOVERY.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE,21-Feb-12,12-Mar-13
-AZRECYCLES.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE,26-Aug-14,30-Sep-15
-AZREPORTCARD.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE,9-Sep-14,9-Sep-15
-AZROC.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE,31-Aug-14,31-Aug-15
-AZRRA.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE,4-Mar-15,28-Feb-16
-AZRUCO.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE,2-Mar-15,31-May-16
-AZSAL.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE,28-Jan-15,15-Dec-15
-AZSENATE.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE,6-Feb-15,2-Mar-16
-AZSF.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE,26-Oct-14,26-Oct-15
-AZSFB.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE,30-Sep-14,30-Sep-15
-AZSHARE.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE,31-Dec-14,26-Jan-16
-AZSOS.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE,2-Sep-14,30-Sep-15
-AZSOSCHILD.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE,23-May-14,23-May-15
-AZSTATEJOBS.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE,3-Sep-14,21-Sep-15
-AZSTATEPARKS.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE,24-Nov-14,17-Dec-15
-AZSTATS.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE,28-Apr-14,28-Apr-15
-AZSTEPSUP.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE,31-Aug-11,31-Aug-12
-AZSUMMERFOOD.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE,22-May-14,7-Jun-15
-AZSURPLUS.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE,26-Feb-14,29-Mar-15
-AZTAXES.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE,2-Sep-14,30-Sep-15
-AZTRANSPORTATIONBOARD.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE,1-Aug-14,31-Oct-15
-AZTREASURER.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE,6-May-14,1-Jun-15
-AZTREASURY.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE,23-Dec-14,19-Jan-16
-AZTTT.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE,24-Dec-13,21-Mar-14
-AZTURBOCOURT.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE,12-Feb-15,4-May-16
-AZUI.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE,14-Nov-14,10-Feb-16
-AZUITAX.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE,14-Nov-14,10-Feb-16
-AZUNCLAIMED.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE,28-Jul-14,26-Oct-15
-AZVOICES.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE,4-Jun-14,10-Jun-15
-AZWATER.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE,10-Nov-14,22-Nov-15
-AZWATERBANK.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE,6-Mar-15,9-May-16
-AZWIC.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE,4-Sep-14,30-Sep-15
-AZWIFA.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE,3-Mar-15,30-Sep-15
-AZWPF.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE,18-Jul-14,31-Aug-15
-AZYES.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE,21-Jun-12,21-Jun-13
-B4WV.GOV,State/Local Govt,Non-Federal Agency,Charleston,WV,ACTIVE,21-Oct-14,25-Jul-15
-BAAQMD.GOV,State/Local Govt,Non-Federal Agency,San Francisco,CA,ACTIVE,18-Sep-14,30-Sep-15
-BABYARIZONA.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE,17-Apr-13,25-Jan-14
-BAKERSFIELD-CA.GOV,State/Local Govt,Non-Federal Agency,Bakersfield,CA,ACTIVE,6-Aug-13,3-Sep-13
-BARHARBORMAINE.GOV,State/Local Govt,Non-Federal Agency,Bar Harbor,ME,ACTIVE,30-Oct-14,30-Sep-15
-BART.GOV,State/Local Govt,Non-Federal Agency,Oakland,CA,ACTIVE,8-Jul-14,30-Sep-15
-BASSLAKEWI.GOV,State/Local Govt,Non-Federal Agency,Hayward,WI,ACTIVE,22-Jul-14,30-Sep-15
-BATONROUGELA.GOV,State/Local Govt,Non-Federal Agency,Baton Rouge,LA,ACTIVE,4-Aug-14,30-Sep-15
-BATTLEFIELDMO.GOV,State/Local Govt,Non-Federal Agency,Battlefield,MO,ACTIVE,5-Jan-15,4-Apr-16
-BAYCOUNTY-MI.GOV,State/Local Govt,Non-Federal Agency,Bay City,MI,ACTIVE,18-Jun-14,16-Sep-15
-BCCIRCLK.GOV,State/Local Govt,Non-Federal Agency,Princeton,IL,ACTIVE,2-Jul-14,30-Sep-15
-BEAUXARTS-WA.GOV,State/Local Govt,Non-Federal Agency,Beaux Arts,WA,ACTIVE,11-Aug-14,16-Sep-15
-BECKEMEYERIL.GOV,State/Local Govt,Non-Federal Agency,Beckemeyer,IL,ACTIVE,12-Jun-14,2-Sep-15
-BEGA-DC.GOV,State/Local Govt,Non-Federal Agency,Washington,DC,ACTIVE,27-Nov-13,27-Nov-14
-BELMONT.GOV,State/Local Govt,Non-Federal Agency,Belmont,CA,ACTIVE,24-Jul-14,3-Sep-15
-BENBROOK-TX.GOV,State/Local Govt,Non-Federal Agency,Benbrook,TX,ACTIVE,25-Jul-14,30-Sep-15
-BEREADYUTAH.GOV,State/Local Govt,Non-Federal Agency,Salt Lake City,UT,ACTIVE,28-Feb-14,28-Apr-15
-BERRYVILLEVA.GOV,State/Local Govt,Non-Federal Agency,Berryville,VA,ACTIVE,2-Jul-14,30-Sep-15
-BETHLEHEM-PA.GOV,State/Local Govt,Non-Federal Agency,Bethlehem,PA,ACTIVE,9-Sep-14,30-Sep-15
-BIGFLATSNY.GOV,State/Local Govt,Non-Federal Agency,Big Flats,NY,ACTIVE,1-Aug-14,30-Sep-15
-BIGHORNCOUNTYWY.GOV,State/Local Govt,Non-Federal Agency,Basin,WY,ACTIVE,26-Aug-11,30-Sep-12
-BLACKSBURG.GOV,State/Local Govt,Non-Federal Agency,Blacksburg,VA,ACTIVE,6-Oct-14,18-Nov-15
-BLAINE-MN.GOV,State/Local Govt,Non-Federal Agency,Blaine,MN,ACTIVE,10-Jun-14,8-Sep-15
-BLISSFIELDMICHIGAN.GOV,State/Local Govt,Non-Federal Agency,Blissfield,MI,ACTIVE,10-Feb-15,30-Sep-15
-BLNC.GOV,State/Local Govt,Non-Federal Agency,Raleigh,NC,ACTIVE,30-Dec-14,5-Jan-16
-BLOOMINGTONMN.GOV,State/Local Govt,Non-Federal Agency,Bloomington,MN,ACTIVE,3-Sep-14,14-Nov-15
-BOATIDAHO.GOV,State/Local Govt,Non-Federal Agency,Boise,ID,ACTIVE,22-Apr-14,9-May-15
-BOIMI.GOV,State/Local Govt,Non-Federal Agency,Lansing,MI,ACTIVE,27-Oct-14,25-Jan-16
-BOONEVILLE-MS.GOV,State/Local Govt,Non-Federal Agency,Booneville,MS,ACTIVE,1-Sep-14,30-Sep-15
-BOULDER-CO.GOV,State/Local Govt,Non-Federal Agency,Boulder,CO,ACTIVE,2-Jul-14,30-Sep-15
-BOULDERCITY-NV.GOV,State/Local Govt,Non-Federal Agency,Boulder City,NV,ACTIVE,30-Sep-13,30-Sep-14
-BOULDERCITYNV.GOV,State/Local Govt,Non-Federal Agency,Boulder City,NV,ACTIVE,30-Sep-13,30-Sep-14
-BOULDERCOUNTY-CO.GOV,State/Local Govt,Non-Federal Agency,Boulder,CO,ACTIVE,2-Jul-14,30-Sep-15
-BOUNTIFULUTAH.GOV,State/Local Govt,Non-Federal Agency,Bountiful,UT,ACTIVE,2-Jul-14,30-Sep-15
-BOW-NH.GOV,State/Local Govt,Non-Federal Agency,Bow,NH,ACTIVE,2-Jul-14,30-Sep-15
-BRAINTREEMA.GOV,State/Local Govt,Non-Federal Agency,Braintree,MA,ACTIVE,11-Feb-15,9-Mar-16
-BRANDCOLORADO.GOV,State/Local Govt,Non-Federal Agency,Boulder,CO,ACTIVE,29-Jun-14,27-Aug-15
-BREWERMAINE.GOV,State/Local Govt,Non-Federal Agency,Brewer,ME,ACTIVE,24-Feb-14,22-May-15
-BRIDGEWATERNJ.GOV,State/Local Govt,Non-Federal Agency,Bridgewater,NJ,ACTIVE,1-Aug-14,30-Sep-15
-BRIGHTONCO.GOV,State/Local Govt,Non-Federal Agency,Brighton,CO,ACTIVE,3-Oct-14,30-Sep-15
-BROCKTON-MA.GOV,State/Local Govt,Non-Federal Agency,Brockton,MA,ACTIVE,19-Feb-15,27-Aug-15
-BROOKINGSCOUNTYSD.GOV,State/Local Govt,Non-Federal Agency,Brookings,SD,ACTIVE,10-Oct-14,30-Sep-15
-BROOMFIELDCO.GOV,State/Local Govt,Non-Federal Agency,Broomfield,CO,ACTIVE,16-Sep-13,30-Sep-14
-BRUNSWICKMD.GOV,State/Local Govt,Non-Federal Agency,Brunswick,MD,ACTIVE,19-Aug-14,30-Sep-15
-BRYANTX.GOV,State/Local Govt,Non-Federal Agency,Bryan,TX,ACTIVE,19-Jun-14,17-Sep-15
-BUCHANAN-VA.GOV,State/Local Govt,Non-Federal Agency,BUCHANAN,VA,ACTIVE,22-Dec-14,20-Mar-16
-BURKECOUNTY-GA.GOV,State/Local Govt,Non-Federal Agency,Waynesboro,GA,ACTIVE,26-Sep-14,30-Sep-15
-BURLINGTONND.GOV,State/Local Govt,Non-Federal Agency,Burlington,ND,ACTIVE,17-Jun-14,15-Sep-15
-BURLINGTONWA.GOV,State/Local Govt,Non-Federal Agency,Burlington,WA,ACTIVE,3-Jun-14,30-Jul-15
-BUSINESS4WV.GOV,State/Local Govt,Non-Federal Agency,Charleston,WV,ACTIVE,21-Oct-14,30-Sep-15
-BUYNJBONDS.GOV,State/Local Govt,Non-Federal Agency,Trenton,NJ,ACTIVE,2-Sep-14,30-Oct-15
-CA.GOV,State/Local Govt,Non-Federal Agency,Rancho Cordova,CA,ACTIVE,10-Sep-14,30-Sep-15
-CAHWNET.GOV,State/Local Govt,Non-Federal Agency,Sacramento,CA,ACTIVE,10-Sep-14,30-Sep-15
-CALAISVERMONT.GOV,State/Local Govt,Non-Federal Agency,East Calais,VT,ACTIVE,19-Aug-14,30-Sep-15
-CALIFORNIA.GOV,State/Local Govt,Non-Federal Agency,Rancho Cordova,CA,ACTIVE,10-Sep-14,30-Sep-15
-CALIFORNIADESERT.GOV,State/Local Govt,Non-Federal Agency,Barstow,CA,ACTIVE,9-Jul-14,30-Sep-15
-CAMBRIDGERETIREMENTMA.GOV,State/Local Govt,Non-Federal Agency,Cambridge,MA,ACTIVE,6-Aug-14,30-Sep-15
-CAMDENCOUNTYGA.GOV,State/Local Govt,Non-Federal Agency,Woodbine,GA,ACTIVE,6-Jan-15,6-Jan-16
-CAMPBELLCA.GOV,State/Local Govt,Non-Federal Agency,Campbell,CA,ACTIVE,26-Dec-13,27-Dec-14
-CANANDAIGUANEWYORK.GOV,State/Local Govt,Non-Federal Agency,Canandaigua,NY,ACTIVE,1-Oct-13,30-Sep-14
-CAPITALREGION.GOV,State/Local Govt,Non-Federal Agency,Fairfax,VA,ACTIVE,2-Sep-14,1-Dec-15
-CAPITALREGIONUPDATES.GOV,State/Local Govt,Non-Federal Agency,Fairfax,VA,ACTIVE,2-Sep-14,1-Dec-15
-CARTHAGE-MO.GOV,State/Local Govt,Non-Federal Agency,Carthage,MO,ACTIVE,20-Sep-12,15-Sep-13
-CASAAZ.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE,10-Sep-14,10-Sep-15
-CASWELLCOUNTYNC.GOV,State/Local Govt,Non-Federal Agency,Yanceyville,NC,ACTIVE,23-Jul-14,8-Sep-15
-CELINA-TX.GOV,State/Local Govt,Non-Federal Agency,Celina,TX,ACTIVE,4-Aug-14,30-Sep-15
-CENTERLINE.GOV,State/Local Govt,Non-Federal Agency,Center Line,MI,ACTIVE,8-Aug-14,30-Sep-15
-CHAMPAIGN-IL.GOV,State/Local Govt,Non-Federal Agency,Champaign,IL,ACTIVE,13-Aug-14,16-Sep-15
-CHANDLERAZ.GOV,State/Local Govt,Non-Federal Agency,Chandler,AZ,ACTIVE,10-Jun-14,3-Sep-15
-CHEROKEECOUNTY-NC.GOV,State/Local Govt,Non-Federal Agency,Murphy,NC,ACTIVE,4-Aug-14,30-Sep-15
-CHESTERFIELD.GOV,State/Local Govt,Non-Federal Agency,Chesterfield,VA,ACTIVE,10-Nov-14,9-Nov-15
-CHESTERFIELDCOUNTY.GOV,State/Local Govt,Non-Federal Agency,Chesterfield,VA,ACTIVE,10-Nov-14,9-Nov-15
-CHESTERVT.GOV,State/Local Govt,Non-Federal Agency,Chester,VT,ACTIVE,2-Mar-15,31-Mar-16
-CHIAMASS.GOV,State/Local Govt,Non-Federal Agency,Boston,MA,ACTIVE,24-Nov-14,24-Nov-15
-CHIPPEWACOUNTYMI.GOV,State/Local Govt,Non-Federal Agency,Sault Ste Marie,MI,ACTIVE,7-Aug-14,30-Sep-15
-CHOOSEIDAHO.GOV,State/Local Govt,Non-Federal Agency,Boise,ID,ACTIVE,20-Aug-14,20-Aug-15
-CHULAVISTACA.GOV,State/Local Govt,Non-Federal Agency,Chula Vista,CA,ACTIVE,25-Aug-14,30-Sep-15
-CITYOFAUBURNWA.GOV,State/Local Govt,Non-Federal Agency,Auburn,WA,ACTIVE,24-Jun-14,20-Aug-15
-CITYOFBOSTON.GOV,State/Local Govt,Non-Federal Agency,Boston,MA,ACTIVE,22-Jul-14,15-Sep-15
-CITYOFCHAMPAIGN-IL.GOV,State/Local Govt,Non-Federal Agency,Champaign,IL,ACTIVE,13-Aug-14,16-Sep-15
-CITYOFCODY-WY.GOV,State/Local Govt,Non-Federal Agency,Cody,WY,ACTIVE,25-Sep-14,26-Aug-15
-CITYOFFARGO-ND.GOV,State/Local Govt,Non-Federal Agency,Fargo,ND,ACTIVE,1-Aug-14,23-Aug-15
-CITYOFGROTON-CT.GOV,State/Local Govt,Non-Federal Agency,Groton,CT,ACTIVE,13-Feb-15,26-Feb-16
-CITYOFHAYWARD-CA.GOV,State/Local Govt,Non-Federal Agency,Hayward,CA,ACTIVE,15-Oct-14,8-Sep-15
-CITYOFHONDO-TX.GOV,State/Local Govt,Non-Federal Agency,Hondo,TX,ACTIVE,20-May-13,15-Jun-14
-CITYOFHOUSTON.GOV,State/Local Govt,Non-Federal Agency,Houston,TX,ACTIVE,2-Jun-14,23-Aug-15
-CITYOFHUNTSVILLETX.GOV,State/Local Govt,Non-Federal Agency,Huntsville,TX,ACTIVE,8-Jul-14,30-Sep-15
-CITYOFIRONDALEAL.GOV,State/Local Govt,Non-Federal Agency,Irondale,AL,ACTIVE,16-Jun-14,12-Dec-14
-CITYOFLADUE-MO.GOV,State/Local Govt,Non-Federal Agency,Ladue,MO,ACTIVE,21-Aug-14,9-Sep-15
-CITYOFMENASHA-WI.GOV,State/Local Govt,Non-Federal Agency,Menasha,WI,ACTIVE,25-Jul-14,26-Aug-15
-CITYOFNOVI-MI.GOV,State/Local Govt,Non-Federal Agency,Novi,MI,ACTIVE,2-Jul-14,30-Sep-15
-CITYOFOLYMPIA-WA.GOV,State/Local Govt,Non-Federal Agency,Olympia,WA,ACTIVE,9-Oct-14,30-Sep-15
-CITYOFOLYMPIAWA.GOV,State/Local Govt,Non-Federal Agency,Olympia,WA,ACTIVE,9-Oct-14,30-Sep-15
-CITYOFPASSAICNJ.GOV,State/Local Govt,Non-Federal Agency,Passaic,NJ,ACTIVE,6-Aug-14,30-Sep-15
-CITYOFRENONV.GOV,State/Local Govt,Non-Federal Agency,Reno,NV,ACTIVE,30-Sep-13,30-Sep-14
-CITYOFROCHESTER.GOV,State/Local Govt,Non-Federal Agency,Rochester,NY,ACTIVE,27-Aug-14,10-Sep-15
-CITYOFSAFFORD-AZ.GOV,State/Local Govt,Non-Federal Agency,Safford,AZ,ACTIVE,2-Jul-10,30-Sep-11
-CITYOFSANTAANA-CA.GOV,State/Local Govt,Non-Federal Agency,Santa Ana,CA,ACTIVE,4-Sep-13,30-Sep-14
-CITYOFSEATTLE.GOV,State/Local Govt,Non-Federal Agency,Seattle,WA,ACTIVE,15-Jul-14,30-Sep-15
-CITYOFSTMARYSPA.GOV,State/Local Govt,Non-Federal Agency,St. Marys,PA,ACTIVE,26-Feb-15,27-Jan-16
-CITYOFSUNRISEFL.GOV,State/Local Govt,Non-Federal Agency,Sunrise,FL,ACTIVE,17-Sep-14,17-Sep-15
-CITYOFSUNRISEFLORIDA.GOV,State/Local Govt,Non-Federal Agency,Sunrise,FL,ACTIVE,17-Sep-14,17-Sep-15
-CITYOFWARRENPA.GOV,State/Local Govt,Non-Federal Agency,Warren,PA,ACTIVE,1-Jul-14,23-Aug-15
-CITYOFWESTPALMBEACH-FL.GOV,State/Local Govt,Non-Federal Agency,West Palm Beach,FL,ACTIVE,2-Jul-14,30-Sep-15
-CITYOLYMPIA-WA.GOV,State/Local Govt,Non-Federal Agency,Olympia,WA,ACTIVE,9-Oct-14,30-Sep-15
-CITYOLYMPIAWA.GOV,State/Local Govt,Non-Federal Agency,Olympia,WA,ACTIVE,9-Oct-14,30-Sep-15
-CLAIMITTN.GOV,State/Local Govt,Non-Federal Agency,Nashville,TN,ACTIVE,18-Dec-14,11-Mar-16
-CLARKECOUNTY.GOV,State/Local Govt,Non-Federal Agency,Berryville,VA,ACTIVE,18-Jun-14,26-Aug-15
-CLATSOPCOUNTYOR.GOV,State/Local Govt,Non-Federal Agency,Astoria,OR,ACTIVE,3-Mar-15,30-Sep-15
-CLAYCOUNTYIN.GOV,State/Local Govt,Non-Federal Agency,Brazil,IN,ACTIVE,9-Sep-14,30-Sep-15
-CLEVELANDWI.GOV,State/Local Govt,Non-Federal Agency,Cleveland,WI,ACTIVE,1-Aug-14,30-Sep-15
-CLINTONTOWNSHIP-MI.GOV,State/Local Govt,Non-Federal Agency,Clinton Township,MI,ACTIVE,8-Jul-14,30-Sep-15
-CO.GOV,State/Local Govt,Non-Federal Agency,Lakewood,CO,ACTIVE,22-Sep-14,3-Sep-15
-COAG.GOV,State/Local Govt,Non-Federal Agency,Denver,CO,ACTIVE,15-Oct-14,15-Oct-15
-COBBCOUNTYGA.GOV,State/Local Govt,Non-Federal Agency,Marietta,GA,ACTIVE,13-Sep-14,3-Sep-15
-COBERTURAMEDICAILLINOIS.GOV,State/Local Govt,Non-Federal Agency,Chicago,IL,ACTIVE,12-Jan-15,17-Jan-16
-COCICJIS.GOV,State/Local Govt,Non-Federal Agency,Golden,CO,ACTIVE,12-Jan-15,10-Jan-16
-CODOT.GOV,State/Local Govt,Non-Federal Agency,Denver,CO,ACTIVE,22-Aug-14,22-Aug-15
-COHOES-NY.GOV,State/Local Govt,Non-Federal Agency,Cohoes,NY,ACTIVE,1-Aug-14,30-Sep-15
-COLLEGEDALETN.GOV,State/Local Govt,Non-Federal Agency,Collegedale,TN,ACTIVE,6-Mar-15,30-Sep-15
-COLLEGEGOALARIZONA.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE,3-Sep-14,3-Sep-15
-COLLEGEGOALOREGON.GOV,State/Local Govt,Non-Federal Agency,Eugene,OR,ACTIVE,29-Dec-14,28-Dec-15
-COLLIERCOUNTYFL.GOV,State/Local Govt,Non-Federal Agency,Naples,FL,ACTIVE,11-Apr-14,22-Apr-15
-COLORADO.GOV,State/Local Govt,Non-Federal Agency,Lakewood,CO,ACTIVE,22-Sep-14,3-Sep-15
-COLORADOATTORNEYGENERAL.GOV,State/Local Govt,Non-Federal Agency,Denver,CO,ACTIVE,2-Sep-14,11-Sep-15
-COLORADOJUDICIAL.GOV,State/Local Govt,Non-Federal Agency,Denver,CO,ACTIVE,5-Nov-14,4-Jan-16
-COLORADOJUDICIALPERFORMANCE.GOV,State/Local Govt,Non-Federal Agency,Denver,CO,ACTIVE,28-May-14,26-Aug-15
-COLORADOLABORLAW.GOV,State/Local Govt,Non-Federal Agency,Denver,CO,ACTIVE,8-Jan-15,11-Jan-16
-COLORADOPOST.GOV,State/Local Govt,Non-Federal Agency,Denver,CO,ACTIVE,5-Dec-14,5-Dec-15
-COLORADOPOSTGRANTS.GOV,State/Local Govt,Non-Federal Agency,Denver,CO,ACTIVE,15-Jan-15,24-Jan-16
-COLORADORCJC.GOV,State/Local Govt,Non-Federal Agency,Denver,CO,ACTIVE,5-Nov-14,4-Jan-16
-COLORADOUI.GOV,State/Local Govt,Non-Federal Agency,Denver,CO,ACTIVE,11-Feb-15,13-Mar-16
-COLORADOWORKS.GOV,State/Local Govt,Non-Federal Agency,Denver,CO,ACTIVE,26-Mar-14,17-Jun-15
-COLUMBIASC.GOV,State/Local Govt,Non-Federal Agency,Columbia,SC,ACTIVE,6-Nov-14,23-Jan-16
-COMPARECAREWV.GOV,State/Local Govt,Non-Federal Agency,Charleston,WV,ACTIVE,6-Oct-14,16-Nov-15
-CONCORD-MA.GOV,State/Local Govt,Non-Federal Agency,Concord,MA,ACTIVE,8-Jul-10,30-Sep-11
-CONNECTINGALABAMA.GOV,State/Local Govt,Non-Federal Agency,Montgomery,AL,ACTIVE,18-Feb-15,12-Feb-16
-CONNECTND.GOV,State/Local Govt,Non-Federal Agency,Bisamarck,ND,ACTIVE,24-Jun-14,21-Sep-15
-COPIAHCOUNTYMS.GOV,State/Local Govt,Non-Federal Agency,Hazlehurst,MS,ACTIVE,29-Sep-14,30-Sep-15
-CORUNNA-MI.GOV,State/Local Govt,Non-Federal Agency,Corunna,MI,ACTIVE,14-Jul-14,30-Sep-15
-COSIPA.GOV,State/Local Govt,Non-Federal Agency,Denver,CO,ACTIVE,20-Jul-12,12-Aug-13
-COUNCILBLUFFS-IA.GOV,State/Local Govt,Non-Federal Agency,Council Bluffs,IA,ACTIVE,18-Jun-14,16-Sep-15
-COUNTYOFVENTURACA.GOV,State/Local Govt,Non-Federal Agency,VENTURA,CA,ACTIVE,18-Jun-14,17-Apr-15
-COURTNEWSOHIO.GOV,State/Local Govt,Non-Federal Agency,Columbus,OH,ACTIVE,26-Jun-14,20-Jul-15
-COURTSWV.GOV,State/Local Govt,Non-Federal Agency,Charleston,WV,ACTIVE,2-Mar-15,28-Feb-16
-COVERTENNESSEE.GOV,State/Local Govt,Non-Federal Agency,NASHVILLE,TN,ACTIVE,20-Oct-14,12-Jan-16
-COVERTN.GOV,State/Local Govt,Non-Federal Agency,Nashville,TN,ACTIVE,31-Jul-14,31-Aug-15
-COWORKFORCE.GOV,State/Local Govt,Non-Federal Agency,Denver,CO,ACTIVE,26-Mar-14,21-May-15
-CRAWFORDCOUNTYMO.GOV,State/Local Govt,Non-Federal Agency,Steelville,MO,ACTIVE,14-Jan-14,14-Jan-15
-CRESTEDBUTTE-CO.GOV,State/Local Govt,Non-Federal Agency,Crested Butte,CO,ACTIVE,29-Aug-14,30-Sep-15
-CRYSTALMN.GOV,State/Local Govt,Non-Federal Agency,Crystal,MN,ACTIVE,3-Sep-14,30-Sep-15
-CSTX.GOV,State/Local Govt,Non-Federal Agency,College Station,TX,ACTIVE,19-Aug-14,30-Sep-15
-CT.GOV,State/Local Govt,Non-Federal Agency,Hartford,CT,ACTIVE,29-Aug-14,30-Sep-15
-CTALERT.GOV,State/Local Govt,Non-Federal Agency,Middletown,CT,ACTIVE,12-Mar-14,10-Jun-15
-CTBROWNFIELDS.GOV,State/Local Govt,Non-Federal Agency,Hartford,CT,ACTIVE,1-Aug-11,10-Oct-12
-CTGROWN.GOV,State/Local Govt,Non-Federal Agency,Hartford,CT,ACTIVE,22-Oct-14,10-Jan-16
-CTPROBATE.GOV,State/Local Govt,Non-Federal Agency,West Hartford,CT,ACTIVE,4-Feb-15,3-Feb-16
-DA16CO.GOV,State/Local Govt,Non-Federal Agency,LA JUNTA,CO,ACTIVE,19-Feb-15,23-Jan-16
-DANVILLE-VA.GOV,State/Local Govt,Non-Federal Agency,Danville,VA,ACTIVE,24-Jun-14,21-Sep-15
-DARIENCT.GOV,State/Local Govt,Non-Federal Agency,Darien,CT,ACTIVE,18-Sep-14,30-Sep-15
-DAVISCOUNTYUTAH.GOV,State/Local Govt,Non-Federal Agency,Farmington,UT,ACTIVE,7-Aug-14,30-Sep-15
-DC.GOV,State/Local Govt,Non-Federal Agency,Washington,DC,ACTIVE,7-Aug-14,9-Sep-15
-DCAPPEALS.GOV,State/Local Govt,Non-Federal Agency,Washington,DC,ACTIVE,2-Jul-14,30-Sep-15
-DCCODE.GOV,State/Local Govt,Non-Federal Agency,Washington,DC,ACTIVE,17-Jul-14,17-Jul-15
-DCCOUNCIL.GOV,State/Local Govt,Non-Federal Agency,Washington,DC,ACTIVE,17-Jul-14,17-Jul-15
-DCCOURT.GOV,State/Local Govt,Non-Federal Agency,Washington,DC,ACTIVE,21-Aug-14,30-Sep-15
-DCCOURTS.GOV,State/Local Govt,Non-Federal Agency,Washington,DC,ACTIVE,21-Aug-14,30-Sep-15
-DCCOURTSNEWS.GOV,State/Local Govt,Non-Federal Agency,Washington,DC,ACTIVE,3-Dec-14,30-Jan-16
-DE.GOV,State/Local Govt,Non-Federal Agency,Dover,DE,ACTIVE,1-Jul-14,30-Aug-15
-DECATUR-AL.GOV,State/Local Govt,Non-Federal Agency,Decatur,AL,ACTIVE,2-Aug-14,30-Sep-15
-DECATURBRIDGE-AL.GOV,State/Local Govt,Non-Federal Agency,Orlando,FL,ACTIVE,25-Jun-14,25-Jun-15
-DEL.GOV,State/Local Govt,Non-Federal Agency,Dover,DE,ACTIVE,1-Jul-14,30-Aug-15
-DELAWARE.GOV,State/Local Govt,Non-Federal Agency,Dover,DE,ACTIVE,1-Jul-14,30-Aug-15
-DELAWAREINSURANCE.GOV,State/Local Govt,Non-Federal Agency,Dover,DE,ACTIVE,24-Dec-14,19-Jan-16
-DELDOT.GOV,State/Local Govt,Non-Federal Agency,Dover,DE,ACTIVE,24-Dec-14,17-Mar-16
-DESMOINESWA.GOV,State/Local Govt,Non-Federal Agency,Des Moines,WA,ACTIVE,2-Jul-14,30-Sep-15
-DESOTOTEXAS.GOV,State/Local Govt,Non-Federal Agency,DeSoto,TX,ACTIVE,4-Aug-14,1-Sep-15
-DETROITMI.GOV,State/Local Govt,Non-Federal Agency,Detroit,MI,ACTIVE,29-Sep-13,30-Sep-14
-DEVAZ.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE,29-Aug-14,29-Aug-15
-DEXTERMI.GOV,State/Local Govt,Non-Federal Agency,Dexter,MI,ACTIVE,10-Jan-13,10-Jan-14
-DICKINSON-TX.GOV,State/Local Govt,Non-Federal Agency,Dickinson,TX,ACTIVE,3-Mar-15,30-Sep-15
-DIGITALARIZONA.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE,28-Apr-14,3-May-15
-DIGITALAZ.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE,28-Apr-14,3-May-15
-DMG.GOV,State/Local Govt,Non-Federal Agency,Barstow,CA,ACTIVE,9-Jul-14,30-Sep-15
-DNSSECOHIO.GOV,State/Local Govt,Non-Federal Agency,Columbus,OH,ACTIVE,26-Feb-15,19-Mar-16
-DNSTESTOHIO.GOV,State/Local Govt,Non-Federal Agency,Columbus,OH,ACTIVE,26-Feb-15,19-Mar-16
-DOJMT.GOV,State/Local Govt,Non-Federal Agency,Helena,MT,ACTIVE,7-Jan-15,11-Feb-16
-DORAL-FL.GOV,State/Local Govt,Non-Federal Agency,Doral,FL,ACTIVE,9-Mar-15,9-Mar-15
-DOUBLECHECKIOWA.GOV,State/Local Govt,Non-Federal Agency,Des Moines,IA,ACTIVE,18-Feb-15,13-Mar-16
-DRACUTMA.GOV,State/Local Govt,Non-Federal Agency,Dracut,MA,ACTIVE,10-Sep-14,10-Sep-15
-DUDLEYMA.GOV,State/Local Govt,Non-Federal Agency,Dudley,MA,ACTIVE,11-Aug-14,8-Sep-15
-DUMASTX.GOV,State/Local Govt,Non-Federal Agency,Dumas,TX,ACTIVE,3-Sep-14,30-Sep-15
-DURHAMNC.GOV,State/Local Govt,Non-Federal Agency,Durham,NC,ACTIVE,2-Sep-14,2-Sep-15
-DUTCHESSNY.GOV,State/Local Govt,Non-Federal Agency,Poughkeepsie,NY,ACTIVE,22-Jul-14,30-Sep-15
-DWGPA.GOV,State/Local Govt,Non-Federal Agency,Delaware Water Gap,PA,ACTIVE,24-Jul-14,23-Aug-15
-EARLYLEARNINGOHIO.GOV,State/Local Govt,Non-Federal Agency,Columbus,OH,ACTIVE,26-Nov-13,14-Dec-14
-EASTHAM-MA.GOV,State/Local Govt,Non-Federal Agency,Eastham,MA,ACTIVE,2-Sep-14,30-Sep-15
-EASTON-PA.GOV,State/Local Govt,Non-Federal Agency,Easton,PA,ACTIVE,22-Sep-14,30-Sep-15
-EASTVALLEYFUSIONCENTERAZ.GOV,State/Local Govt,Non-Federal Agency,Mesa,AZ,ACTIVE,29-Jul-14,5-Sep-15
-EASTWINDSOR-CT.GOV,State/Local Govt,Non-Federal Agency,Broad Brook,CT,ACTIVE,9-Oct-14,9-Oct-15
-EAUCLAIREWI.GOV,State/Local Govt,Non-Federal Agency,Eau Claire,WI,ACTIVE,2-Jul-14,30-Sep-15
-EDGECOMBECOUNTYNC.GOV,State/Local Govt,Non-Federal Agency,Tarboro,NC,ACTIVE,3-Sep-14,30-Sep-15
-EDGEWOODKY.GOV,State/Local Govt,Non-Federal Agency,Edgewood,KY,ACTIVE,23-Jun-14,26-Aug-15
-EDUCATEIOWA.GOV,State/Local Govt,Non-Federal Agency,Des Moines,IA,ACTIVE,28-May-14,24-May-15
-EFILETEXAS.GOV,State/Local Govt,Non-Federal Agency,Austin,TX,ACTIVE,14-Nov-14,5-Dec-15
-EGREMONT-MA.GOV,State/Local Govt,Non-Federal Agency,Egremont,MA,ACTIVE,29-Aug-14,2-Sep-15
-EHAWAII.GOV,State/Local Govt,Non-Federal Agency,Honolulu,HI,ACTIVE,16-Jul-14,21-Sep-15
-EISGATEWAYPACIFICWA.GOV,State/Local Govt,Non-Federal Agency,Lacey,WA,ACTIVE,7-Sep-12,8-Sep-13
-ELBERTCOUNTY-CO.GOV,State/Local Govt,Non-Federal Agency,Kiowa,CO,ACTIVE,10-Jul-14,30-Sep-15
-ELEARNINGNC.GOV,State/Local Govt,Non-Federal Agency,Raleigh,NC,ACTIVE,17-Sep-14,20-Oct-15
-ELIZABETHTOWNKY.GOV,State/Local Govt,Non-Federal Agency,Elizabethtown,KY,ACTIVE,23-Sep-14,30-Sep-15
-ELMONTECA.GOV,State/Local Govt,Non-Federal Agency,El Monte,CA,ACTIVE,4-Aug-14,2-Sep-15
-EMANUELCO-GA.GOV,State/Local Govt,Non-Federal Agency,Swainsboro,GA,ACTIVE,9-May-14,10-May-15
-ENFIELD-CT.GOV,State/Local Govt,Non-Federal Agency,Enfield,CT,ACTIVE,1-Oct-14,30-Sep-15
-EUGENE-OR.GOV,State/Local Govt,Non-Federal Agency,Eugene,OR,ACTIVE,19-Feb-15,30-Sep-14
-EVFCAZ.GOV,State/Local Govt,Non-Federal Agency,Mesa,AZ,ACTIVE,29-Jul-14,5-Sep-15
-EVFUSIONCENTERAZ.GOV,State/Local Govt,Non-Federal Agency,Mesa,AZ,ACTIVE,29-Jul-14,5-Sep-15
-EWYOMING.GOV,State/Local Govt,Non-Federal Agency,Cheyenne,WY,ACTIVE,14-Jul-14,30-Sep-15
-EXPLOREMAINE.GOV,State/Local Govt,Non-Federal Agency,Augusta,ME,ACTIVE,1-Sep-10,30-Sep-11
-FAIRFAXCOUNTY.GOV,State/Local Govt,Non-Federal Agency,Fairfax,VA,ACTIVE,2-Jun-14,30-Aug-15
-FAIRFAXCOUNTYVA.GOV,State/Local Govt,Non-Federal Agency,Fairfax,VA,ACTIVE,2-Jun-14,30-Aug-15
-FAIRHAVEN-MA.GOV,State/Local Govt,Non-Federal Agency,Fairhaven,MA,ACTIVE,6-Nov-14,7-Sep-15
-FAMILYRESOURCEAZ.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE,2-Jul-14,2-Jul-15
-FARGO-ND.GOV,State/Local Govt,Non-Federal Agency,Fargo,ND,ACTIVE,1-Aug-14,23-Aug-15
-FAYETTECOUNTYGA.GOV,State/Local Govt,Non-Federal Agency,Fayetteville,GA,ACTIVE,2-Oct-14,30-Sep-15
-FAYETTEVILLE-GA.GOV,State/Local Govt,Non-Federal Agency,Fayetteville,GA,ACTIVE,26-Sep-14,27-Aug-15
-FBCIOHIO.GOV,State/Local Govt,Non-Federal Agency,Columbus,OH,ACTIVE,24-Aug-12,3-Sep-13
-FILELOCAL-WA.GOV,State/Local Govt,Non-Federal Agency,Seattle,WA,ACTIVE,10-Mar-15,17-Apr-16
-FIRESTONECO.GOV,State/Local Govt,Non-Federal Agency,Firestone,CO,ACTIVE,12-Sep-14,12-Sep-15
-FIRSTTHINGSFIRSTAZ.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE,5-May-14,6-May-15
-FISHKILL-NY.GOV,State/Local Govt,Non-Federal Agency,Fishkill,NY,ACTIVE,4-Aug-14,30-Sep-15
-FL.GOV,State/Local Govt,Non-Federal Agency,Tallahassee,FL,ACTIVE,8-Aug-14,30-Sep-15
-FLBOARDOFMEDICINE.GOV,State/Local Govt,Non-Federal Agency,TALLAHASSEE,FL,ACTIVE,12-Aug-14,24-Sep-15
-FLCENSUS.GOV,State/Local Govt,Non-Federal Agency,Tallahassee,FL,ACTIVE,24-Mar-11,23-Apr-12
-FLCOURTS1.GOV,State/Local Govt,Non-Federal Agency,Pensacola,FL,ACTIVE,21-Jul-14,17-Oct-15
-FLDOI.GOV,State/Local Govt,Non-Federal Agency,Tallahassee,FL,ACTIVE,6-Nov-14,7-Nov-15
-FLHEALTH.GOV,State/Local Govt,Non-Federal Agency,Tallahassee,FL,ACTIVE,6-Jun-14,19-Aug-15
-FLHEALTH125.GOV,State/Local Govt,Non-Federal Agency,Tallahassee,FL,ACTIVE,16-Dec-14,7-Jan-16
-FLHEALTHSOURCE.GOV,State/Local Govt,Non-Federal Agency,Tallahassee,FL,ACTIVE,2-Dec-14,13-Feb-16
-FLHISTORICCAPITOL.GOV,State/Local Govt,Non-Federal Agency,Tallahassee,FL,ACTIVE,15-Jan-15,23-Feb-16
-FLHL.GOV,State/Local Govt,Non-Federal Agency,Tallahassee,FL,ACTIVE,25-Jun-14,13-Sep-15
-FLHOUSE.GOV,State/Local Govt,Non-Federal Agency,Tallahassee,FL,ACTIVE,10-Apr-14,9-Jun-15
-FLHSMV.GOV,State/Local Govt,Non-Federal Agency,Tallahassee,FL,ACTIVE,10-Dec-14,7-Feb-16
-FLLEG.GOV,State/Local Govt,Non-Federal Agency,Tallahassee,FL,ACTIVE,15-Jan-15,16-Feb-16
-FLLEGISLATIVEMAILINGS.GOV,State/Local Govt,Non-Federal Agency,Tallahassee,FL,ACTIVE,29-Aug-14,25-Sep-15
-FLORIDA.GOV,State/Local Govt,Non-Federal Agency,Tallahassee,FL,ACTIVE,8-Aug-14,30-Sep-15
-FLORIDAABUSEHOTLINE.GOV,State/Local Govt,Non-Federal Agency,Tallahassee,FL,ACTIVE,26-Jan-15,25-Feb-16
-FLORIDAHEALTH.GOV,State/Local Govt,Non-Federal Agency,Tallahassee,FL,ACTIVE,6-Jun-14,19-Aug-15
-FLORIDAHEALTHFINDER.GOV,State/Local Govt,Non-Federal Agency,Tallahassee,FL,ACTIVE,17-Jul-14,11-Oct-15
-FLORIDALOBBYIST.GOV,State/Local Govt,Non-Federal Agency,Tallahassee,FL,ACTIVE,17-Sep-14,17-Sep-15
-FLORIDANET.GOV,State/Local Govt,Non-Federal Agency,Tallahassee,FL,ACTIVE,6-May-14,12-Jul-15
-FLORIDAOPC.GOV,State/Local Govt,Non-Federal Agency,Tallahassee,FL,ACTIVE,7-Aug-14,30-Sep-15
-FLORIDAPACE.GOV,State/Local Govt,Non-Federal Agency,Kissimmee,FL,ACTIVE,4-Jun-14,3-Aug-15
-FLORIDAREDISTRICTING.GOV,State/Local Govt,Non-Federal Agency,Tallahassee,FL,ACTIVE,16-Feb-15,3-Mar-16
-FLORIDASACUPUNCTURE.GOV,State/Local Govt,Non-Federal Agency,TALLAHASSEE,FL,ACTIVE,14-Mar-14,28-May-15
-FLORIDASATHLETICTRAINING.GOV,State/Local Govt,Non-Federal Agency,TALLAHASSEE,FL,ACTIVE,14-Mar-14,28-May-15
-FLORIDASCHIROPRACTICMEDICINE.GOV,State/Local Govt,Non-Federal Agency,TALLAHASSEE,FL,ACTIVE,14-Mar-14,28-May-15
-FLORIDASCHOOLBUSSAFETY.GOV,State/Local Govt,Non-Federal Agency,Tallahassee,FL,ACTIVE,6-May-14,14-Jun-15
-FLORIDASCLINICALLABS.GOV,State/Local Govt,Non-Federal Agency,TALLAHASSEE,FL,ACTIVE,14-Mar-14,28-May-15
-FLORIDASDENTISTRY.GOV,State/Local Govt,Non-Federal Agency,TALLAHASSEE,FL,ACTIVE,2-Dec-14,11-Feb-16
-FLORIDASENATE.GOV,State/Local Govt,Non-Federal Agency,Tallahassee,FL,ACTIVE,29-Aug-14,30-Sep-15
-FLORIDASHEALTH.GOV,State/Local Govt,Non-Federal Agency,Tallahassee,FL,ACTIVE,6-Jun-14,19-Aug-15
-FLORIDASHEARINGAIDSPECIALISTS.GOV,State/Local Govt,Non-Federal Agency,TALLAHASSEE,FL,ACTIVE,14-Mar-14,28-May-15
-FLORIDASMASSAGETHERAPY.GOV,State/Local Govt,Non-Federal Agency,TALLAHASSEE,FL,ACTIVE,14-Mar-14,28-May-15
-FLORIDASMENTALHEALTHPROFESSIONS.GOV,State/Local Govt,Non-Federal Agency,TALLAHASSEE,FL,ACTIVE,14-Mar-14,28-May-15
-FLORIDASNURSING.GOV,State/Local Govt,Non-Federal Agency,TALLAHASSEE,FL,ACTIVE,2-Dec-14,11-Feb-16
-FLORIDASNURSINGHOMEADMIN.GOV,State/Local Govt,Non-Federal Agency,TALLAHASSEE,FL,ACTIVE,14-Mar-14,28-May-15
-FLORIDASOCCUPATIONALTHERAPY.GOV,State/Local Govt,Non-Federal Agency,TALLAHASSEE,FL,ACTIVE,14-Mar-14,28-May-15
-FLORIDASOPTICIANRY.GOV,State/Local Govt,Non-Federal Agency,TALLAHASSEE,FL,ACTIVE,14-Mar-14,28-May-15
-FLORIDASOPTOMETRY.GOV,State/Local Govt,Non-Federal Agency,TALLAHASSEE,FL,ACTIVE,14-Mar-14,28-May-15
-FLORIDASORTHOTISTSPROSTHETISTS.GOV,State/Local Govt,Non-Federal Agency,TALLAHASSEE,FL,ACTIVE,14-Mar-14,28-May-15
-FLORIDASOSTEOPATHICMEDICINE.GOV,State/Local Govt,Non-Federal Agency,TALLAHASSEE,FL,ACTIVE,14-Mar-14,28-May-15
-FLORIDASPHARMACY.GOV,State/Local Govt,Non-Federal Agency,TALLAHASSEE,FL,ACTIVE,2-Dec-14,11-Feb-16
-FLORIDASPHYSICALTHERAPY.GOV,State/Local Govt,Non-Federal Agency,TALLAHASSEE,FL,ACTIVE,14-Mar-14,28-May-15
-FLORIDASPODIATRICMEDICINE.GOV,State/Local Govt,Non-Federal Agency,TALLAHASSEE,FL,ACTIVE,14-Mar-14,28-May-15
-FLORIDASPSYCHOLOGY.GOV,State/Local Govt,Non-Federal Agency,TALLAHASSEE,FL,ACTIVE,14-Mar-14,28-May-15
-FLORIDASRESPIRATORYCARE.GOV,State/Local Govt,Non-Federal Agency,TALLAHASSEE,FL,ACTIVE,14-Mar-14,28-May-15
-FLORIDASSPEECHAUDIOLOGY.GOV,State/Local Govt,Non-Federal Agency,TALLAHASSEE,FL,ACTIVE,14-Mar-14,28-May-15
-FLORIDASUNSETREVIEWS.GOV,State/Local Govt,Non-Federal Agency,Tallahassee,FL,ACTIVE,8-Jul-10,9-Jul-11
-FLORIDASUNSHINE.GOV,State/Local Govt,Non-Federal Agency,Tallahassee,FL,ACTIVE,5-Aug-14,22-Aug-15
-FLRCM.GOV,State/Local Govt,Non-Federal Agency,Tallahassee,FL,ACTIVE,15-Jan-15,23-Feb-16
-FLSENATE.GOV,State/Local Govt,Non-Federal Agency,Tallahassee,FL,ACTIVE,29-Aug-14,30-Sep-15
-FLSUNSHINE.GOV,State/Local Govt,Non-Federal Agency,Tallahassee,FL,ACTIVE,5-Aug-14,22-Aug-15
-FLWG.GOV,State/Local Govt,Non-Federal Agency,Opa Locka,FL,ACTIVE,17-Sep-14,14-Oct-15
-FOIA-DC.GOV,State/Local Govt,Non-Federal Agency,Washington,DC,ACTIVE,13-Jun-14,13-Jun-15
-FOIAXPRESS-DC.GOV,State/Local Govt,Non-Federal Agency,Washington,DC,ACTIVE,11-Jun-14,11-Jun-15
-FORTLAUDERDALE.GOV,State/Local Govt,Non-Federal Agency,Fort Lauderdale,FL,ACTIVE,13-Aug-14,30-Sep-15
-FRAMES.GOV,State/Local Govt,Non-Federal Agency,Moscow,ID,ACTIVE,26-Aug-14,30-Sep-15
-FRANKLIN-NJ.GOV,State/Local Govt,Non-Federal Agency,Someret,NJ,ACTIVE,11-Oct-13,11-Oct-14
-FRANKLINNJ.GOV,State/Local Govt,Non-Federal Agency,Somerset,NJ,ACTIVE,11-Oct-13,11-Oct-14
-FRANKLINWI.GOV,State/Local Govt,Non-Federal Agency,Franklin,WI,ACTIVE,8-Aug-14,30-Sep-15
-FREEPORTFLORIDA.GOV,State/Local Govt,Non-Federal Agency,Freeport,FL,ACTIVE,5-Sep-14,30-Sep-15
-FREMONT.GOV,State/Local Govt,Non-Federal Agency,Fremont,CA,ACTIVE,3-Jul-14,30-Sep-15
-FREMONTCOUNTYWY.GOV,State/Local Govt,Non-Federal Agency,Lander,WY,ACTIVE,17-May-13,17-May-14
-FRESHFROMFLORIDA.GOV,State/Local Govt,Non-Federal Agency,Tallahassee,FL,ACTIVE,5-Sep-12,27-Oct-13
-FRESNO.GOV,State/Local Govt,Non-Federal Agency,Fresno,CA,ACTIVE,28-May-14,26-Aug-15
-FRISCOTEXAS.GOV,State/Local Govt,Non-Federal Agency,Frisco,TX,ACTIVE,2-Jul-14,30-Sep-15
-FRISCOTX.GOV,State/Local Govt,Non-Federal Agency,Frisco,TX,ACTIVE,2-Jul-14,30-Sep-15
-GA.GOV,State/Local Govt,Non-Federal Agency,Atlanta,GA,ACTIVE,28-Jul-14,30-Sep-15
-GACOURTS.GOV,State/Local Govt,Non-Federal Agency,Atlanta,GA,ACTIVE,19-Apr-12,30-Apr-13
-GADOL.GOV,State/Local Govt,Non-Federal Agency,Atlanta,GA,ACTIVE,23-Feb-15,24-Apr-16
-GAITHERSBURGMD.GOV,State/Local Govt,Non-Federal Agency,Gaithersburg,MD,ACTIVE,10-Jun-14,27-Aug-15
-GARDNER-MA.GOV,State/Local Govt,Non-Federal Agency,GARDNER,MA,ACTIVE,2-Jun-14,30-Aug-15
-GATREES.GOV,State/Local Govt,Non-Federal Agency,Dry Branch,GA,ACTIVE,12-Jun-14,6-Sep-15
-GAUTIER-MS.GOV,State/Local Govt,Non-Federal Agency,Gautier,MS,ACTIVE,29-Sep-14,30-Sep-15
-GEARUPIOWA.GOV,State/Local Govt,Non-Federal Agency,Des Moines,IA,ACTIVE,30-Jun-14,30-Jul-15
-GEARUPTN.GOV,State/Local Govt,Non-Federal Agency,Nashville,TN,ACTIVE,5-Feb-15,1-Apr-16
-GEORGETOWNMA.GOV,State/Local Govt,Non-Federal Agency,Georgetown,MA,ACTIVE,24-Sep-14,30-Sep-15
-GEORGIA.GOV,State/Local Govt,Non-Federal Agency,Atlanta,GA,ACTIVE,28-Jul-14,30-Sep-15
-GEORGIACOURTS.GOV,State/Local Govt,Non-Federal Agency,Atlanta,GA,ACTIVE,19-Apr-12,30-Apr-13
-GEORGIAHEALTHINFO.GOV,State/Local Govt,Non-Federal Agency,Atlanta,GA,ACTIVE,20-Oct-10,12-Dec-11
-GETCOVEREDILLINOIS.GOV,State/Local Govt,Non-Federal Agency,Chicago,IL,ACTIVE,23-Sep-14,23-Sep-15
-GETKANSASBENEFITS.GOV,State/Local Govt,Non-Federal Agency,Topeka,KS,ACTIVE,6-Mar-14,2-Jun-15
-GILBERTAZ.GOV,State/Local Govt,Non-Federal Agency,Gilbert,AZ,ACTIVE,4-Aug-14,30-Sep-15
-GLYNNCOUNTY-GA.GOV,State/Local Govt,Non-Federal Agency,Brunswick,GA,ACTIVE,2-Jul-14,30-Sep-15
-GOCC.GOV,State/Local Govt,Non-Federal Agency,Corvallis,OR,ACTIVE,7-Sep-10,30-Sep-11
-GOVOTEVERMONT.GOV,State/Local Govt,Non-Federal Agency,Montpelier,VT,ACTIVE,19-Feb-14,9-Apr-15
-GRANBY-CT.GOV,State/Local Govt,Non-Federal Agency,Granby,CT,ACTIVE,10-Sep-14,29-Sep-15
-GREENSBORO-NC.GOV,State/Local Govt,Non-Federal Agency,Greensboro,NC,ACTIVE,21-Jul-14,30-Sep-15
-GREENSVILLECOUNTYVA.GOV,State/Local Govt,Non-Federal Agency,Emporia,VA,ACTIVE,30-Sep-14,30-Sep-15
-GRFDAZ.GOV,State/Local Govt,Non-Federal Agency,Tucson,AZ,ACTIVE,9-Mar-15,7-Jun-16
-GRINNELLIOWA.GOV,State/Local Govt,Non-Federal Agency,Grinnell,IA,ACTIVE,15-Jul-14,30-Sep-15
-GUAM.GOV,State/Local Govt,Non-Federal Agency,Agana,GU,ACTIVE,27-Aug-14,30-Sep-15
-HADDONFIELD-NJ.GOV,State/Local Govt,Non-Federal Agency,Haddonfield,NJ,ACTIVE,4-Sep-12,30-Sep-13
-HAMILTON-NY.GOV,State/Local Govt,Non-Federal Agency,HAMILTON,NY,ACTIVE,23-Jan-15,16-Apr-16
-HAMILTONMA.GOV,State/Local Govt,Non-Federal Agency,So. Hamilton,MA,ACTIVE,27-Aug-14,30-Sep-15
-HAMILTONTN.GOV,State/Local Govt,Non-Federal Agency,Chattanooga,TN,ACTIVE,12-Feb-15,30-Sep-15
-HAMPTONNH.GOV,State/Local Govt,Non-Federal Agency,Hampton,NH,ACTIVE,5-Aug-14,30-Sep-15
-HAMPTONVA.GOV,State/Local Govt,Non-Federal Agency,Hampton,VA,ACTIVE,19-Feb-15,19-Aug-15
-HANOVER.GOV,State/Local Govt,Non-Federal Agency,Hanover,VA,ACTIVE,24-Jul-14,30-Aug-15
-HANOVERCOUNTY.GOV,State/Local Govt,Non-Federal Agency,Hanover,VA,ACTIVE,24-Jul-14,30-Aug-15
-HANOVERCOUNTYVA.GOV,State/Local Govt,Non-Federal Agency,Hanover,VA,ACTIVE,24-Jul-14,30-Aug-15
-HARFORDCOUNTYMD.GOV,State/Local Govt,Non-Federal Agency,Bel Air,MD,ACTIVE,12-Aug-14,20-Sep-15
-HARRINGTONPARKNJ.GOV,State/Local Govt,Non-Federal Agency,HARRINGTON PARK,NJ,ACTIVE,23-Apr-14,9-May-15
-HARRISON-NY.GOV,State/Local Govt,Non-Federal Agency,Harrison,NY,ACTIVE,7-Jul-14,30-Aug-15
-HARRISONCOUNTY-MS.GOV,State/Local Govt,Non-Federal Agency,Gulfport,MS,ACTIVE,3-Mar-15,30-Sep-15
-HAWAII.GOV,State/Local Govt,Non-Federal Agency,Honolulu,HI,ACTIVE,16-Jul-14,21-Sep-15
-HAYESTOWNSHIPMI.GOV,State/Local Govt,Non-Federal Agency,Charlevoix,MI,ACTIVE,10-Dec-14,10-Dec-15
-HAYWARD-CA.GOV,State/Local Govt,Non-Federal Agency,Hayward,CA,ACTIVE,15-Oct-14,8-Sep-15
-HCGAZ.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE,16-Sep-13,14-Oct-14
-HCSHERIFF.GOV,State/Local Govt,Non-Federal Agency,Chattanooga,TN,ACTIVE,12-Feb-15,30-Sep-15
-HEALTH-E-ARIZONA-PLUS.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE,14-Jul-14,12-Jul-15
-HEALTH-E-ARIZONAPLUS.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE,14-Jul-14,12-Jul-15
-HEALTHCAREHELPMASS.GOV,State/Local Govt,Non-Federal Agency,Boston,MA,ACTIVE,17-Dec-14,17-Dec-15
-HEALTHEARIZONA.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE,14-Jul-14,12-Jul-15
-HEALTHEARIZONAPLUS.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE,14-Jul-14,12-Jul-15
-HEALTHFINDERLA.GOV,State/Local Govt,Non-Federal Agency,Baton Rouge,LA,ACTIVE,2-Mar-15,15-Dec-15
-HEALTHVERMONT.GOV,State/Local Govt,Non-Federal Agency,Burlington,VT,ACTIVE,5-May-14,3-Aug-15
-HEALTHYIOWA.GOV,State/Local Govt,Non-Federal Agency,Des Moines,IA,ACTIVE,26-Feb-14,12-May-15
-HEALTHYSD.GOV,State/Local Govt,Non-Federal Agency,Pierre,SD,ACTIVE,3-Sep-14,13-Sep-15
-HEALTHYTEETHAZ.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE,28-Apr-14,29-Apr-15
-HI.GOV,State/Local Govt,Non-Federal Agency,Honolulu,HI,ACTIVE,16-Jul-14,21-Sep-15
-HIGHPOINT-NC.GOV,State/Local Govt,Non-Federal Agency,High Point,NC,ACTIVE,1-Jul-14,30-Aug-15
-HIGHPOINTNC.GOV,State/Local Govt,Non-Federal Agency,High Point,NC,ACTIVE,1-Jul-14,30-Aug-15
-HIJOSSALUDABLESOREGON.GOV,State/Local Govt,Non-Federal Agency,Salem,OR,ACTIVE,7-Apr-14,28-May-15
-HIREACOLORADOVET.GOV,State/Local Govt,Non-Federal Agency,Denver,CO,ACTIVE,26-Mar-14,21-May-15
-HOMEAGAINNEVADA.GOV,State/Local Govt,Non-Federal Agency,Las Vegas,NV,ACTIVE,17-Oct-14,4-Jan-16
-HOMEBASEIOWA.GOV,State/Local Govt,Non-Federal Agency,Des Moines,IA,ACTIVE,30-Jun-14,1-Jul-15
-HOMEMEANSNEVADA.GOV,State/Local Govt,Non-Federal Agency,Las Vegas,NV,ACTIVE,28-Jan-15,5-Jan-16
-HONDO-TX.GOV,State/Local Govt,Non-Federal Agency,Hondo,TX,ACTIVE,20-May-13,15-Jun-14
-HONOLULU.GOV,State/Local Govt,Non-Federal Agency,Honolulu,HI,ACTIVE,31-Jul-14,30-Aug-15
-HOUSTONTX.GOV,State/Local Govt,Non-Federal Agency,Houston,TX,ACTIVE,2-Jun-14,23-Aug-15
-HUNTSVILLETX.GOV,State/Local Govt,Non-Federal Agency,Huntsville,TX,ACTIVE,8-Jul-14,30-Sep-15
-HURONTOWNSHIP-MI.GOV,State/Local Govt,Non-Federal Agency,New Boston,MI,ACTIVE,14-Jul-14,30-Sep-15
-IA.GOV,State/Local Govt,Non-Federal Agency,Des Moines,IA,ACTIVE,15-Aug-14,30-Sep-15
-IAABATEDOC.GOV,State/Local Govt,Non-Federal Agency,Des Moines,IA,ACTIVE,28-May-14,28-May-15
-IAHEALTHLINK.GOV,State/Local Govt,Non-Federal Agency,Des Moines,IA,ACTIVE,28-May-14,28-May-15
-IASHP.GOV,State/Local Govt,Non-Federal Agency,Des Moines,IA,ACTIVE,28-May-14,28-May-15
-IASIMPLEABATE.GOV,State/Local Govt,Non-Federal Agency,Des Moines,IA,ACTIVE,28-May-14,28-May-15
-IAVOTERS.GOV,State/Local Govt,Non-Federal Agency,Des Moines,IA,ACTIVE,18-Feb-15,1-Mar-16
-ID.GOV,State/Local Govt,Non-Federal Agency,Boise,ID,ACTIVE,17-Jul-14,21-Sep-15
-IDAHO.GOV,State/Local Govt,Non-Federal Agency,Boise,ID,ACTIVE,17-Jul-14,21-Sep-15
-IDAHOBYWAYS.GOV,State/Local Govt,Non-Federal Agency,Boise,ID,ACTIVE,18-Dec-14,28-Dec-15
-IDAHOPREPARES.GOV,State/Local Govt,Non-Federal Agency,Boise,ID,ACTIVE,17-Jul-14,17-Aug-15
-IDAHOVOTES.GOV,State/Local Govt,Non-Federal Agency,Boise,ID,ACTIVE,17-Jul-14,7-Sep-15
-IDAHOWORKS.GOV,State/Local Govt,Non-Federal Agency,Boise,ID,ACTIVE,17-Jul-14,15-Sep-15
-IHAVEAPLANIOWA.GOV,State/Local Govt,Non-Federal Agency,Des Moines,IA,ACTIVE,1-Dec-14,9-May-15
-IJOBSIOWA.GOV,State/Local Govt,Non-Federal Agency,Des Moines,IA,ACTIVE,13-Apr-11,11-Jun-12
-IL.GOV,State/Local Govt,Non-Federal Agency,Springfield,IL,ACTIVE,17-Sep-14,30-Sep-15
-ILGA.GOV,State/Local Govt,Non-Federal Agency,Springfield,IL,ACTIVE,9-Sep-14,30-Sep-15
-ILLINOIS-HISTORY.GOV,State/Local Govt,Non-Federal Agency,Springfield,IL,ACTIVE,1-Oct-14,30-Oct-15
-ILLINOIS.GOV,State/Local Govt,Non-Federal Agency,Springfield,IL,ACTIVE,17-Sep-14,30-Sep-15
-ILLINOISATTORNEYGENERAL.GOV,State/Local Govt,Non-Federal Agency,Chicago,IL,ACTIVE,26-Aug-14,26-Aug-15
-ILLINOISCOURTS.GOV,State/Local Govt,Non-Federal Agency,Springfield,IL,ACTIVE,6-Jun-14,3-Jul-15
-ILLINOISHISTORY.GOV,State/Local Govt,Non-Federal Agency,Springfield,IL,ACTIVE,1-Oct-14,30-Oct-15
-ILLINOISTREASURER.GOV,State/Local Govt,Non-Federal Agency,Springfield,IL,ACTIVE,6-Mar-15,6-Mar-16
-ILSOS.GOV,State/Local Govt,Non-Federal Agency,Springfield,IL,ACTIVE,3-Mar-15,9-Feb-16
-IN.GOV,State/Local Govt,Non-Federal Agency,Indianapolis,IN,ACTIVE,5-Oct-14,30-Sep-15
-INDEPENDENCEMO.GOV,State/Local Govt,Non-Federal Agency,Independence,MO,ACTIVE,4-Aug-14,30-Sep-15
-INDIANA.GOV,State/Local Govt,Non-Federal Agency,Indianapolis,IN,ACTIVE,31-Aug-14,30-Sep-15
-INDIANAMOTORSPORTS.GOV,State/Local Govt,Non-Federal Agency,Indianapolis,IN,ACTIVE,30-May-14,30-May-15
-INDIANAUNCLAIMED.GOV,State/Local Govt,Non-Federal Agency,Indianapolis,IN,ACTIVE,4-Mar-15,20-Nov-15
-INDIANHEADPARK-IL.GOV,State/Local Govt,Non-Federal Agency,Indian Head Park,IL,ACTIVE,2-Jul-14,30-Sep-15
-INNOCENCECOMMISSION-NC.GOV,State/Local Govt,Non-Federal Agency,Raleigh,NC,ACTIVE,11-Aug-14,20-Sep-15
-INTEGRATEAZ.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE,20-Oct-14,20-Oct-15
-INVESTINOHIO.GOV,State/Local Govt,Non-Federal Agency,Columbus,OH,ACTIVE,26-Jun-12,22-Jul-13
-INVESTSMARTIOWA.GOV,State/Local Govt,Non-Federal Agency,Des Moines,IA,ACTIVE,1-Oct-14,6-Oct-15
-INVITATIONTOBID-OHIO.GOV,State/Local Govt,Non-Federal Agency,Columbus,OH,ACTIVE,23-Apr-12,3-May-13
-INVITATIONTOBIDOHIO.GOV,State/Local Govt,Non-Federal Agency,Columbus,OH,ACTIVE,23-Apr-12,3-May-13
-IOWA.GOV,State/Local Govt,Non-Federal Agency,Des Moines,IA,ACTIVE,15-Aug-14,30-Sep-15
-IOWAAGING.GOV,State/Local Govt,Non-Federal Agency,Des Moines,IA,ACTIVE,3-Jun-14,24-May-15
-IOWAAGRICULTURE.GOV,State/Local Govt,Non-Federal Agency,Des Moines,IA,ACTIVE,30-Jun-14,20-Jul-15
-IOWAATTORNEYGENERAL.GOV,State/Local Govt,Non-Federal Agency,Des Moines,IA,ACTIVE,28-May-14,12-May-15
-IOWACHILDSUPPORT.GOV,State/Local Govt,Non-Federal Agency,Des Moines,IA,ACTIVE,24-Mar-14,19-Apr-15
-IOWACLEANAIR.GOV,State/Local Govt,Non-Federal Agency,Des Moines,IA,ACTIVE,30-Jun-14,28-Jun-15
-IOWACOLLEGEAID.GOV,State/Local Govt,Non-Federal Agency,Des Moines,IA,ACTIVE,5-Sep-14,13-Sep-15
-IOWACOLLEGEAIDDATACENTER.GOV,State/Local Govt,Non-Federal Agency,Des Moines,IA,ACTIVE,10-Jul-14,14-Jul-15
-IOWACORE.GOV,State/Local Govt,Non-Federal Agency,Des Moines,IA,ACTIVE,21-Aug-14,21-Aug-15
-IOWACOURTS.GOV,State/Local Govt,Non-Federal Agency,Des Moines,IA,ACTIVE,31-Mar-14,11-Apr-15
-IOWACULTURE.GOV,State/Local Govt,Non-Federal Agency,Des Moines,IA,ACTIVE,28-May-14,28-May-15
-IOWADIVISIONOFLABOR.GOV,State/Local Govt,Non-Federal Agency,Des Moines,IA,ACTIVE,21-Aug-14,21-Sep-15
-IOWADNR.GOV,State/Local Govt,Non-Federal Agency,Des Moines,IA,ACTIVE,21-Aug-14,22-Sep-15
-IOWADOT.GOV,State/Local Govt,Non-Federal Agency,Des Moines,IA,ACTIVE,30-Jun-14,13-Jul-15
-IOWAELECTRICAL.GOV,State/Local Govt,Non-Federal Agency,Des Moines,IA,ACTIVE,16-Dec-14,21-Jan-16
-IOWAELEVATORS.GOV,State/Local Govt,Non-Federal Agency,Des Moines,IA,ACTIVE,2-Jun-14,26-Jun-15
-IOWAFINANCEAUTHORITY.GOV,State/Local Govt,Non-Federal Agency,Des Moines,IA,ACTIVE,1-Jul-14,30-Aug-15
-IOWAFINANCIALAIDAPPLICATION.GOV,State/Local Govt,Non-Federal Agency,Des Moines,IA,ACTIVE,10-Jul-14,14-Jul-15
-IOWAFORMS.GOV,State/Local Govt,Non-Federal Agency,Des Moines,IA,ACTIVE,24-Jul-14,24-Jul-15
-IOWAFRAUDFIGHTERS.GOV,State/Local Govt,Non-Federal Agency,Des Moines,IA,ACTIVE,21-Aug-14,29-Aug-15
-IOWAGRANTS.GOV,State/Local Govt,Non-Federal Agency,Des Moines,IA,ACTIVE,26-Jan-15,9-Feb-16
-IOWAGREATPLACES.GOV,State/Local Govt,Non-Federal Agency,Des Moines,IA,ACTIVE,9-Mar-15,5-Apr-16
-IOWAJNC.GOV,State/Local Govt,Non-Federal Agency,Des Moines,IA,ACTIVE,7-Jul-14,9-Aug-15
-IOWAJQC.GOV,State/Local Govt,Non-Federal Agency,Des Moines,IA,ACTIVE,7-Jul-14,13-Jul-15
-IOWAMORTGAGEHELP.GOV,State/Local Govt,Non-Federal Agency,Des Moines,IA,ACTIVE,1-Oct-14,2-Oct-15
-IOWANEXT.GOV,State/Local Govt,Non-Federal Agency,Des Moines,IA,ACTIVE,12-Feb-15,12-Feb-16
-IOWAOSHA.GOV,State/Local Govt,Non-Federal Agency,Des Moines,IA,ACTIVE,28-May-14,28-May-15
-IOWAPIB.GOV,State/Local Govt,Non-Federal Agency,Des Moines,IA,ACTIVE,17-Sep-13,17-Sep-14
-IOWAPMA.GOV,State/Local Govt,Non-Federal Agency,Des Moines,IA,ACTIVE,28-May-14,28-May-15
-IOWASMOKEFREEAIR.GOV,State/Local Govt,Non-Federal Agency,Des Moines,IA,ACTIVE,27-Feb-14,27-May-15
-IOWASTEM.GOV,State/Local Govt,Non-Federal Agency,Des Moines,IA,ACTIVE,21-Jan-15,18-Jan-16
-IOWATAXANDTAGS.GOV,State/Local Govt,Non-Federal Agency,Des Moines,IA,ACTIVE,16-Dec-14,11-Jan-16
-IOWATEST.GOV,State/Local Govt,Non-Federal Agency,Des Moines,IA,ACTIVE,10-Oct-14,10-Oct-15
-IOWATITLEGUARANTY.GOV,State/Local Govt,Non-Federal Agency,Des Moines,IA,ACTIVE,1-Oct-14,4-Oct-15
-IOWATREASURER.GOV,State/Local Govt,Non-Federal Agency,Des Moines,IA,ACTIVE,20-Nov-14,12-Nov-15
-IOWAWORKCOMP.GOV,State/Local Govt,Non-Federal Agency,Des Moines,IA,ACTIVE,1-Dec-14,19-Nov-15
-IOWAWORKFORCEDEVELOPMENT.GOV,State/Local Govt,Non-Federal Agency,Des Moines,IA,ACTIVE,16-Dec-14,25-Jan-16
-JACKSONVILLENC.GOV,State/Local Govt,Non-Federal Agency,Jacksonville,NC,ACTIVE,30-Jul-14,20-Sep-15
-JASPERINDIANA.GOV,State/Local Govt,Non-Federal Agency,Jasper,IN,ACTIVE,4-Sep-14,30-Sep-15
-JERSEYCITYNJ.GOV,State/Local Govt,Non-Federal Agency,Jersey City,NJ,ACTIVE,16-Apr-14,7-Apr-14
-JOBS4TN.GOV,State/Local Govt,Non-Federal Agency,Nashville,TN,ACTIVE,23-Dec-14,23-Mar-16
-JOBSFORTN.GOV,State/Local Govt,Non-Federal Agency,38401,TN,ACTIVE,23-Dec-14,23-Mar-16
-KANAWHACOUNTYWV.GOV,State/Local Govt,Non-Federal Agency,Charleston,WV,ACTIVE,31-Aug-10,1-Sep-11
-KANSAS.GOV,State/Local Govt,Non-Federal Agency,Topeka,KS,ACTIVE,4-Sep-14,30-Sep-15
-KANSASCITYMO.GOV,State/Local Govt,Non-Federal Agency,Kansas City,MO,ACTIVE,17-Apr-14,17-May-15
-KANSASEMPLOYER.GOV,State/Local Govt,Non-Federal Agency,Topeka,KS,ACTIVE,6-Mar-14,2-Jun-15
-KANSASREADY.GOV,State/Local Govt,Non-Federal Agency,Topeka,KS,ACTIVE,10-Jul-14,30-Sep-15
-KANSASTAG.GOV,State/Local Govt,Non-Federal Agency,Topeka,KS,ACTIVE,12-Aug-14,9-Sep-15
-KCMO.GOV,State/Local Govt,Non-Federal Agency,Kansas City,MO,ACTIVE,17-Apr-14,17-May-15
-KDHEKS.GOV,State/Local Govt,Non-Federal Agency,Topeka,KS,ACTIVE,4-Mar-15,25-Jan-16
-KEITHCOUNTYNE.GOV,State/Local Govt,Non-Federal Agency,Ogallala,NE,ACTIVE,7-Jul-14,23-Sep-15
-KENTCOUNTYMI.GOV,State/Local Govt,Non-Federal Agency,Grand Rapids,MI,ACTIVE,9-Jul-14,30-Sep-15
-KENTUCKY.GOV,State/Local Govt,Non-Federal Agency,Frankfort,KY,ACTIVE,22-Jul-14,30-Sep-15
-KIDCENTRALTENNESSEE.GOV,State/Local Govt,Non-Federal Agency,Nashville,TN,ACTIVE,2-Mar-15,1-May-16
-KIDCENTRALTN.GOV,State/Local Govt,Non-Federal Agency,Nashville,TN,ACTIVE,2-Mar-15,1-May-16
-KPL.GOV,State/Local Govt,Non-Federal Agency,KALAMAZOO,MI,ACTIVE,2-Jun-14,27-Aug-15
-KS.GOV,State/Local Govt,Non-Federal Agency,Topeka,KS,ACTIVE,4-Sep-14,30-Sep-15
-KSDA.GOV,State/Local Govt,Non-Federal Agency,Topeka,KS,ACTIVE,13-Aug-14,30-Sep-15
-KSHOUSINGCORP.GOV,State/Local Govt,Non-Federal Agency,Topeka,KS,ACTIVE,18-Sep-12,30-Sep-13
-KSREADY.GOV,State/Local Govt,Non-Federal Agency,Topeka,KS,ACTIVE,12-Aug-14,30-Sep-15
-KY.GOV,State/Local Govt,Non-Federal Agency,Frankfort,KY,ACTIVE,22-Jul-14,30-Sep-15
-LA.GOV,State/Local Govt,Non-Federal Agency,Baton Rouge,LA,ACTIVE,29-Sep-14,28-Sep-15
-LAFASTSTART.GOV,State/Local Govt,Non-Federal Agency,Baton Rouge,LA,ACTIVE,9-Feb-15,11-Mar-16
-LAFAYETTELA.GOV,State/Local Govt,Non-Federal Agency,Lafayette,LA,ACTIVE,10-Jul-14,30-Sep-15
-LAJUDICIAL.GOV,State/Local Govt,Non-Federal Agency,New Orleans,LA,ACTIVE,30-Jul-14,6-Sep-15
-LAKECOUNTYFL.GOV,State/Local Govt,Non-Federal Agency,Tavares,FL,ACTIVE,1-Aug-14,30-Sep-15
-LAKEJACKSON-TX.GOV,State/Local Govt,Non-Federal Agency,Lake Jackson,TX,ACTIVE,31-Jul-14,30-Sep-15
-LAKEPARK-FL.GOV,State/Local Govt,Non-Federal Agency,Lake Park,FL,ACTIVE,1-Aug-14,30-Sep-15
-LAKEPARKFLORIDA.GOV,State/Local Govt,Non-Federal Agency,Lake Park,FL,ACTIVE,1-Aug-14,30-Sep-15
-LAKESITETN.GOV,State/Local Govt,Non-Federal Agency,Lakesite,TN,ACTIVE,3-Sep-14,28-Sep-15
-LAMOINE-ME.GOV,State/Local Govt,Non-Federal Agency,Lamoine,ME,ACTIVE,26-Aug-14,30-Sep-15
-LANCASTERCOUNTYPA.GOV,State/Local Govt,Non-Federal Agency,Lancaster,PA,ACTIVE,8-Aug-14,30-Sep-15
-LASVEGASNEVADA.GOV,State/Local Govt,Non-Federal Agency,Las Vegas,NV,ACTIVE,19-Aug-14,16-Sep-15
-LAWRENCEBURG-IN.GOV,State/Local Govt,Non-Federal Agency,Lawrenceburg,IN,ACTIVE,12-May-14,12-May-15
-LEADERSHIPAZ.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE,24-Dec-14,27-Nov-15
-LEADVILLE-CO.GOV,State/Local Govt,Non-Federal Agency,Leadville,CO,ACTIVE,3-Sep-14,30-Sep-15
-LEESBURGVA.GOV,State/Local Govt,Non-Federal Agency,Leesburg,VA,ACTIVE,2-Jul-14,30-Sep-15
-LEGALNOTICE-OHIO.GOV,State/Local Govt,Non-Federal Agency,Columbus,OH,ACTIVE,23-Apr-12,16-May-13
-LEGMT.GOV,State/Local Govt,Non-Federal Agency,Helena,MT,ACTIVE,2-Oct-14,6-Dec-15
-LEXINGTON-MA.GOV,State/Local Govt,Non-Federal Agency,Lexington,MA,ACTIVE,23-Sep-14,30-Sep-15
-LEXINGTONMA.GOV,State/Local Govt,Non-Federal Agency,Lexington,MA,ACTIVE,23-Sep-14,30-Sep-15
-LGADMI.GOV,State/Local Govt,Non-Federal Agency,Lansing,MI,ACTIVE,27-Oct-14,25-Jan-16
-LGO-VI.GOV,State/Local Govt,Non-Federal Agency,St. Thomas,VI,ACTIVE,13-Aug-13,30-Sep-13
-LICENSEDINIOWA.GOV,State/Local Govt,Non-Federal Agency,Des Moines,IA,ACTIVE,20-Nov-14,17-Nov-15
-LINCOLNSHIREIL.GOV,State/Local Govt,Non-Federal Agency,Lincolnshire,IL,ACTIVE,5-Aug-14,5-Aug-15
-LISTOVIRGINIA.GOV,State/Local Govt,Non-Federal Agency,Richmond,VA,ACTIVE,16-Jul-14,24-Aug-15
-LIVEHEALTHYNEVADA.GOV,State/Local Govt,Non-Federal Agency,Carson City,NV,ACTIVE,25-Feb-15,23-May-16
-LODI.GOV,State/Local Govt,Non-Federal Agency,Lodi,CA,ACTIVE,2-Jul-14,30-Sep-15
-LODICA.GOV,State/Local Govt,Non-Federal Agency,Lodi,CA,ACTIVE,2-Jul-14,30-Sep-15
-LOGANTOWNSHIP-PA.GOV,State/Local Govt,Non-Federal Agency,Altoona,PA,ACTIVE,25-Jul-14,30-Aug-15
-LONDONBRITAINTOWNSHIP-PA.GOV,State/Local Govt,Non-Federal Agency,Landenberg,PA,ACTIVE,29-Sep-14,30-Sep-15
-LONGVIEW-WA.GOV,State/Local Govt,Non-Federal Agency,Longview,WA,ACTIVE,4-Aug-14,30-Sep-15
-LONGVIEWWA.GOV,State/Local Govt,Non-Federal Agency,Longview,WA,ACTIVE,4-Aug-14,30-Sep-15
-LOSGATOSCA.GOV,State/Local Govt,Non-Federal Agency,Los Gatos,CA,ACTIVE,4-Jun-14,2-Sep-15
-LOSLUNASNM.GOV,State/Local Govt,Non-Federal Agency,Los Lunas,NM,ACTIVE,9-Jul-14,14-Sep-15
-LOUDOUNCOUNTYVA.GOV,State/Local Govt,Non-Federal Agency,Leesburg,VA,ACTIVE,30-Sep-14,30-Sep-15
-LOUISIANA.GOV,State/Local Govt,Non-Federal Agency,Baton Rouge,LA,ACTIVE,29-Sep-14,28-Sep-15
-LOUISIANAENTERTAINMENT.GOV,State/Local Govt,Non-Federal Agency,Baton Rouge,LA,ACTIVE,9-Feb-15,15-Apr-16
-LOUISIANAFASTSTART.GOV,State/Local Govt,Non-Federal Agency,Baton Rouge,LA,ACTIVE,9-Feb-15,11-Mar-16
-LOUISIANAMAP.GOV,State/Local Govt,Non-Federal Agency,Baton Rouge,LA,ACTIVE,9-Sep-14,30-Sep-15
-LOUISIANAMUSIC.GOV,State/Local Govt,Non-Federal Agency,Baton Rouge,LA,ACTIVE,9-Feb-15,14-Mar-16
-LOWELL-OR.GOV,State/Local Govt,Non-Federal Agency,Lowell,OR,ACTIVE,3-Dec-13,30-Sep-14
-LOWELLMA.GOV,State/Local Govt,Non-Federal Agency,Lowell,MA,ACTIVE,25-Jul-14,30-Sep-15
-LOWERPAXTON-PA.GOV,State/Local Govt,Non-Federal Agency,Harrisburg,PA,ACTIVE,23-Jul-14,30-Sep-15
-LOXAHATCHEEGROVESFL.GOV,State/Local Govt,Non-Federal Agency,Loxahatchee Groves,FL,ACTIVE,12-Feb-15,12-Jan-16
-LYNCHBURGVA.GOV,State/Local Govt,Non-Federal Agency,Lynchburg,VA,ACTIVE,3-Jul-14,27-Aug-15
-MA.GOV,State/Local Govt,Non-Federal Agency,Boston,MA,ACTIVE,15-Aug-14,21-Sep-15
-MAHOUSE.GOV,State/Local Govt,Non-Federal Agency,Boston,MA,ACTIVE,4-Aug-14,12-Aug-15
-MAINE.GOV,State/Local Govt,Non-Federal Agency,Augusta,ME,ACTIVE,1-Oct-14,30-Sep-15
-MAINEDOT.GOV,State/Local Govt,Non-Federal Agency,Augusta,ME,ACTIVE,2-Jul-14,30-Sep-15
-MAINEFLU.GOV,State/Local Govt,Non-Federal Agency,Augusta,ME,ACTIVE,4-Feb-15,4-May-16
-MAINEFORESTSERVICE.GOV,State/Local Govt,Non-Federal Agency,AUGUSTA,ME,ACTIVE,23-Apr-14,13-Jul-15
-MAINEPUBLICHEALTH.GOV,State/Local Govt,Non-Federal Agency,Augusta,ME,ACTIVE,2-Jul-14,30-Sep-15
-MAINEQUALITYFORUM.GOV,State/Local Govt,Non-Federal Agency,Augusta,ME,ACTIVE,1-Oct-14,30-Sep-15
-MAINERECOVERY.GOV,State/Local Govt,Non-Federal Agency,Augusta,ME,ACTIVE,24-Feb-11,24-Feb-12
-MAINESERVICECOMMISSION.GOV,State/Local Govt,Non-Federal Agency,Augusta,ME,ACTIVE,6-Aug-14,30-Sep-15
-MAJURY.GOV,State/Local Govt,Non-Federal Agency,Boston,MA,ACTIVE,10-Apr-14,1-May-15
-MAKINGCOLORADO.GOV,State/Local Govt,Non-Federal Agency,Boulder,CO,ACTIVE,4-May-14,29-Mar-15
-MALEGISLATURE.GOV,State/Local Govt,Non-Federal Agency,Boston,MA,ACTIVE,4-Aug-14,12-Aug-15
-MALIBU-CA.GOV,State/Local Govt,Non-Federal Agency,Malibu,CA,ACTIVE,3-Nov-14,2-Sep-15
-MANITOUSPRINGS-CO.GOV,State/Local Govt,Non-Federal Agency,Colorado Springs,CO,ACTIVE,25-Aug-10,30-Sep-11
-MANSFIELD-TX.GOV,State/Local Govt,Non-Federal Agency,Mansfield,TX,ACTIVE,2-Sep-14,30-Sep-15
-MAPWV.GOV,State/Local Govt,Non-Federal Agency,Morgantown,WV,ACTIVE,15-Jan-14,7-Dec-14
-MARICOPA.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE,15-Oct-14,30-Sep-15
-MARIETTAGA.GOV,State/Local Govt,Non-Federal Agency,Marietta,GA,ACTIVE,3-Sep-14,30-Sep-15
-MARIETTAGEORGIA.GOV,State/Local Govt,Non-Federal Agency,Marietta,GA,ACTIVE,3-Sep-14,30-Sep-15
-MARSHFIELD-MA.GOV,State/Local Govt,Non-Federal Agency,Marshfield,MA,ACTIVE,30-Sep-14,30-Sep-15
-MARYLAND.GOV,State/Local Govt,Non-Federal Agency,Annapolis,MD,ACTIVE,12-Aug-14,7-Sep-15
-MARYLANDCOURTS.GOV,State/Local Govt,Non-Federal Agency,Annapolis,MD,ACTIVE,1-Apr-14,1-Apr-15
-MARYLANDHEALTHCONNECTION.GOV,State/Local Govt,Non-Federal Agency,Baltimore,MD,ACTIVE,8-Aug-14,22-Aug-15
-MARYLANDSOS.GOV,State/Local Govt,Non-Federal Agency,ANNAPOLIS,MD,ACTIVE,15-Mar-10,25-Mar-11
-MASENATE.GOV,State/Local Govt,Non-Federal Agency,Boston,MA,ACTIVE,4-Aug-14,12-Aug-15
-MASS.GOV,State/Local Govt,Non-Federal Agency,Boston,MA,ACTIVE,15-Aug-14,21-Sep-15
-MASSACHUSETTS.GOV,State/Local Govt,Non-Federal Agency,Boston,MA,ACTIVE,15-Aug-14,21-Sep-15
-MASTICBEACHVILLAGENY.GOV,State/Local Govt,Non-Federal Agency,Mastic Beach,NY,ACTIVE,12-Jun-14,27-Jun-15
-MATTHEWSNC.GOV,State/Local Govt,Non-Federal Agency,Matthews,NC,ACTIVE,27-Aug-14,15-Nov-15
-MAURYCOUNTY-TN.GOV,State/Local Govt,Non-Federal Agency,Columbia,TN,ACTIVE,15-Jul-13,30-Sep-13
-MCHENRY-IL.GOV,State/Local Govt,Non-Federal Agency,McHenry,IL,ACTIVE,3-Sep-13,30-Sep-14
-MD.GOV,State/Local Govt,Non-Federal Agency,Annapolis,MD,ACTIVE,12-Aug-14,7-Sep-15
-MDCAC.GOV,State/Local Govt,Non-Federal Agency,Woodlawn,MD,ACTIVE,11-Mar-15,15-Feb-16
-MDCACDOM.GOV,State/Local Govt,Non-Federal Agency,Woodlawn,MD,ACTIVE,11-Mar-15,15-Feb-16
-MDCOURTS.GOV,State/Local Govt,Non-Federal Agency,Annapolis,MD,ACTIVE,1-Apr-14,1-Apr-15
-ME.GOV,State/Local Govt,Non-Federal Agency,Augusta,ME,ACTIVE,1-Oct-14,30-Sep-15
-MEASURETN.GOV,State/Local Govt,Non-Federal Agency,Nashville,TN,ACTIVE,8-Nov-14,18-Jan-16
-MEDCMI.GOV,State/Local Govt,Non-Federal Agency,Lansing,MI,ACTIVE,5-Mar-15,19-Mar-16
-MENTORMICHIGAN.GOV,State/Local Govt,Non-Federal Agency,Lansing,MI,ACTIVE,9-Jan-15,9-Jan-16
-MESQUITENV.GOV,State/Local Govt,Non-Federal Agency,Mesquite,NV,ACTIVE,7-Aug-14,24-Sep-15
-MGCBMI.GOV,State/Local Govt,Non-Federal Agency,Lansing,MI,ACTIVE,27-Oct-14,25-Jan-16
-MHB.GOV,State/Local Govt,Non-Federal Agency,Mobile,AL,ACTIVE,10-Sep-14,30-Sep-15
-MI.GOV,State/Local Govt,Non-Federal Agency,Lansing,MI,ACTIVE,12-Sep-14,30-Sep-15
-MI365.GOV,State/Local Govt,Non-Federal Agency,Lansing,MI,ACTIVE,29-Aug-14,29-Aug-15
-MIAMI-FL.GOV,State/Local Govt,Non-Federal Agency,Miami,FL,ACTIVE,11-Jul-14,30-Aug-15
-MIBUSINESS1STOP.GOV,State/Local Govt,Non-Federal Agency,Lansing,MI,ACTIVE,1-Aug-11,30-Oct-12
-MIBUSINESSONESTOP.GOV,State/Local Govt,Non-Federal Agency,Lansing,MI,ACTIVE,1-Aug-11,30-Oct-12
-MICH.GOV,State/Local Govt,Non-Federal Agency,Lansing,MI,ACTIVE,12-Sep-14,30-Sep-15
-MICHIGAN.GOV,State/Local Govt,Non-Federal Agency,Lansing,MI,ACTIVE,17-Jul-12,30-Sep-13
-MIDDLESEXBORO-NJ.GOV,State/Local Govt,Non-Federal Agency,Middlesex,NJ,ACTIVE,30-Sep-14,30-Sep-15
-MILLENNIUMBULKEISWA.GOV,State/Local Govt,Non-Federal Agency,Lacey,WA,ACTIVE,20-Jun-14,26-Jun-15
-MILLERSBURGKY.GOV,State/Local Govt,Non-Federal Agency,Millersburg,KY,ACTIVE,5-Mar-13,9-Mar-14
-MILTON-FREEWATER-OR.GOV,State/Local Govt,Non-Federal Agency,Milton-Freewater,OR,ACTIVE,23-Jul-12,30-Sep-13
-MILWAUKEE.GOV,State/Local Govt,Non-Federal Agency,Milwaukee,WI,ACTIVE,2-Jul-14,13-Sep-15
-MINNESOTA.GOV,State/Local Govt,Non-Federal Agency,St. Paul,MN,ACTIVE,11-Aug-14,30-Sep-15
-MIRAMAR-FL.GOV,State/Local Govt,Non-Federal Agency,Miramar,FL,ACTIVE,2-Jul-14,30-Sep-15
-MISSISSIPPI.GOV,State/Local Govt,Non-Federal Agency,Jackson,MS,ACTIVE,4-Sep-14,30-Sep-15
-MISSOURI.GOV,State/Local Govt,Non-Federal Agency,Jefferson City,MO,ACTIVE,10-Jul-14,14-Sep-15
-MISSOURIINVESTORPROTECTION.GOV,State/Local Govt,Non-Federal Agency,Jefferson City,MO,ACTIVE,21-May-14,17-May-15
-MN.GOV,State/Local Govt,Non-Federal Agency,St. Paul,MN,ACTIVE,11-Aug-14,8-Sep-15
-MNCOURTS.GOV,State/Local Govt,Non-Federal Agency,St. Paul,MN,ACTIVE,7-Apr-14,12-May-15
-MNDISABILITY.GOV,State/Local Govt,Non-Federal Agency,St. Paul,MN,ACTIVE,18-Apr-14,23-May-15
-MNDNR.GOV,State/Local Govt,Non-Federal Agency,St. Paul,MN,ACTIVE,31-Mar-14,29-May-15
-MNDOT.GOV,State/Local Govt,Non-Federal Agency,St. Paul,MN,ACTIVE,26-Aug-14,30-Sep-15
-MNHOUSING.GOV,State/Local Govt,Non-Federal Agency,St. Paul,MN,ACTIVE,15-Aug-14,15-Aug-15
-MO.GOV,State/Local Govt,Non-Federal Agency,Jefferson City,MO,ACTIVE,10-Jul-14,14-Sep-15
-MOAPPED.GOV,State/Local Govt,Non-Federal Agency,St. Louis,MO,ACTIVE,3-Mar-15,4-May-16
-MODOT.GOV,State/Local Govt,Non-Federal Agency,Jefferson City,MO,ACTIVE,26-Aug-14,30-Sep-15
-MONROECOUNTYPA.GOV,State/Local Govt,Non-Federal Agency,Stroudsburg,PA,ACTIVE,1-Aug-14,27-Aug-15
-MONSON-MA.GOV,State/Local Govt,Non-Federal Agency,Monson,MA,ACTIVE,7-Jul-14,30-Sep-15
-MONTANA.GOV,State/Local Govt,Non-Federal Agency,Helena,MT,ACTIVE,2-Jul-14,30-Sep-15
-MOORECOUNTYNC.GOV,State/Local Govt,Non-Federal Agency,Carthage,NC,ACTIVE,24-Sep-14,30-Sep-15
-MOPROSECUTORS.GOV,State/Local Govt,Non-Federal Agency,Jefferson City,MO,ACTIVE,13-May-14,12-Jun-15
-MORIARTYNM.GOV,State/Local Govt,Non-Federal Agency,Moriarty,NM,ACTIVE,26-Nov-14,26-Nov-15
-MORTON-IL.GOV,State/Local Govt,Non-Federal Agency,Morton,IL,ACTIVE,23-Jul-14,30-Sep-15
-MOUNTPROSPECT-IL.GOV,State/Local Govt,Non-Federal Agency,Mount Prospect,IL,ACTIVE,22-Jul-14,20-Sep-15
-MOUNTPROSPECTIL.GOV,State/Local Govt,Non-Federal Agency,Mount Prospect,IL,ACTIVE,22-Jul-14,20-Sep-15
-MRCOG-NM.GOV,State/Local Govt,Non-Federal Agency,Albuquerque,NM,ACTIVE,6-Aug-14,30-Sep-15
-MS.GOV,State/Local Govt,Non-Federal Agency,Jackson,MS,ACTIVE,4-Sep-14,30-Sep-15
-MSHOMEHELP.GOV,State/Local Govt,Non-Federal Agency,Jackson,MS,ACTIVE,6-Feb-12,6-Mar-13
-MSLMI.GOV,State/Local Govt,Non-Federal Agency,Lansing,MI,ACTIVE,27-Oct-14,25-Jan-16
-MSPADMI.GOV,State/Local Govt,Non-Federal Agency,Lansing,MI,ACTIVE,27-Oct-14,25-Jan-16
-MT.GOV,State/Local Govt,Non-Federal Agency,Helena,MT,ACTIVE,2-Jul-14,30-Sep-15
-MUNDELEIN-IL.GOV,State/Local Govt,Non-Federal Agency,Mundelein,IL,ACTIVE,15-Jul-14,30-Sep-15
-MUNDYTWP-MI.GOV,State/Local Govt,Non-Federal Agency,Swartz Creek,MI,ACTIVE,24-Feb-15,30-Sep-15
-MURRAYCOUNTYGA.GOV,State/Local Govt,Non-Federal Agency,Chatsworth,GA,ACTIVE,5-Aug-14,5-Aug-15
-MVPD.GOV,State/Local Govt,Non-Federal Agency,Mountain View,CA,ACTIVE,9-Sep-14,30-Sep-15
-MYALABAMA.GOV,State/Local Govt,Non-Federal Agency,Montgomery,AL,ACTIVE,18-Feb-15,29-Jan-16
-MYALASKA.GOV,State/Local Govt,Non-Federal Agency,Juneau,AK,ACTIVE,15-Sep-14,15-Sep-15
-MYFLORIDA.GOV,State/Local Govt,Non-Federal Agency,Tallahassee,FL,ACTIVE,8-Aug-14,30-Sep-15
-MYFLORIDACENSUS.GOV,State/Local Govt,Non-Federal Agency,Tallahassee,FL,ACTIVE,16-Feb-15,3-Mar-16
-MYFLORIDAHOUSE.GOV,State/Local Govt,Non-Federal Agency,Tallahassee,FL,ACTIVE,25-Sep-14,30-Sep-15
-MYHAWAII.GOV,State/Local Govt,Non-Federal Agency,Honolulu,HI,ACTIVE,16-Jul-14,9-Aug-15
-MYIN.GOV,State/Local Govt,Non-Federal Agency,Indianapolis,IN,ACTIVE,31-Aug-14,30-Sep-15
-MYINDIANA.GOV,State/Local Govt,Non-Federal Agency,Indianapolis,IN,ACTIVE,31-Aug-14,30-Sep-15
-MYNCRETIREMENT.GOV,State/Local Govt,Non-Federal Agency,Raleigh,NC,ACTIVE,9-Jul-14,30-Sep-15
-MYNEVADA.GOV,State/Local Govt,Non-Federal Agency,Carson City,NV,ACTIVE,15-Sep-14,21-Sep-15
-MYOHIO.GOV,State/Local Govt,Non-Federal Agency,Columbus,OH,ACTIVE,19-Aug-14,3-Sep-15
-MYSC.GOV,State/Local Govt,Non-Federal Agency,Cloumbia,SC,ACTIVE,5-Aug-14,30-Sep-15
-MYTENNESSEE.GOV,State/Local Govt,Non-Federal Agency,Smyrna,TN,ACTIVE,21-Aug-14,21-Aug-15
-NAPA-CA.GOV,State/Local Govt,Non-Federal Agency,Napa,CA,ACTIVE,24-Sep-14,30-Sep-15
-NASHCOUNTYNC.GOV,State/Local Govt,Non-Federal Agency,Nashville,NC,ACTIVE,22-Jul-14,30-Sep-15
-NASSAUCOUNTYNY.GOV,State/Local Govt,Non-Federal Agency,Mineola,NY,ACTIVE,8-Aug-14,7-Sep-15
-NATICKMA.GOV,State/Local Govt,Non-Federal Agency,Natick,MA,ACTIVE,23-Jul-14,4-Aug-15
-NATRONACOUNTY-WY.GOV,State/Local Govt,Non-Federal Agency,Casper,WY,ACTIVE,2-Jun-14,30-Aug-15
-NAVASOTATX.GOV,State/Local Govt,Non-Federal Agency,Navasota,TX,ACTIVE,8-Sep-14,30-Sep-15
-NC.GOV,State/Local Govt,Non-Federal Agency,Raleigh,NC,ACTIVE,17-Sep-14,30-Sep-15
-NCAGR.GOV,State/Local Govt,Non-Federal Agency,Raleigh,NC,ACTIVE,6-Mar-15,5-May-16
-NCBAR.GOV,State/Local Govt,Non-Federal Agency,Raleigh,NC,ACTIVE,2-Dec-14,9-Nov-15
-NCBROADBAND.GOV,State/Local Govt,Non-Federal Agency,Raleigh,NC,ACTIVE,4-Mar-15,7-Mar-16
-NCCARELINK.GOV,State/Local Govt,Non-Federal Agency,Raleigh,NC,ACTIVE,14-Aug-13,22-Jun-13
-NCCERTIFIEDPARALEGAL.GOV,State/Local Govt,Non-Federal Agency,Raleigh,NC,ACTIVE,2-Dec-14,9-Nov-15
-NCCIVILWAR150.GOV,State/Local Govt,Non-Federal Agency,Raleigh,NC,ACTIVE,26-Sep-13,26-Oct-14
-NCCOB.GOV,State/Local Govt,Non-Federal Agency,Raleigh,NC,ACTIVE,9-Jul-14,18-Sep-15
-NCCPABOARD.GOV,State/Local Govt,Non-Federal Agency,Raleigh,NC,ACTIVE,21-Aug-14,1-Nov-15
-NCCRIMELAB.GOV,State/Local Govt,Non-Federal Agency,Raleigh,NC,ACTIVE,31-Oct-14,31-Oct-15
-NCDCI.GOV,State/Local Govt,Non-Federal Agency,Raleigh,NC,ACTIVE,30-Oct-14,30-Oct-15
-NCDCR.GOV,State/Local Govt,Non-Federal Agency,Raleigh,NC,ACTIVE,15-Aug-14,19-Oct-15
-NCDENR.GOV,State/Local Govt,Non-Federal Agency,RALEIGH,NC,ACTIVE,6-Aug-14,4-Nov-15
-NCDHHS.GOV,State/Local Govt,Non-Federal Agency,Raleigh,NC,ACTIVE,11-Dec-14,23-Feb-16
-NCDOI.GOV,State/Local Govt,Non-Federal Agency,Raleigh,NC,ACTIVE,15-Dec-14,13-Feb-16
-NCDOJ.GOV,State/Local Govt,Non-Federal Agency,Raleigh,NC,ACTIVE,2-Feb-15,21-Jan-16
-NCDOT.GOV,State/Local Govt,Non-Federal Agency,Raleigh,NC,ACTIVE,6-Nov-14,4-Jan-16
-NCDPS.GOV,State/Local Govt,Non-Federal Agency,Raleigh,NC,ACTIVE,2-Sep-14,30-Nov-15
-NCESC.GOV,State/Local Govt,Non-Federal Agency,Raleigh,NC,ACTIVE,23-Aug-12,30-Sep-13
-NCFINDOFFENDER.GOV,State/Local Govt,Non-Federal Agency,Raleigh,NC,ACTIVE,9-Aug-12,26-Sep-13
-NCFORECLOSUREPREVENTION.GOV,State/Local Govt,Non-Federal Agency,Raleigh,NC,ACTIVE,8-Jul-14,6-Oct-15
-NCFORESTPRODUCTS.GOV,State/Local Govt,Non-Federal Agency,Raleigh,NC,ACTIVE,4-Aug-14,4-Aug-15
-NCFORESTSERVICE.GOV,State/Local Govt,Non-Federal Agency,Raleigh,NC,ACTIVE,21-May-14,19-Jul-15
-NCGRANTS.GOV,State/Local Govt,Non-Federal Agency,Raleigh,NC,ACTIVE,24-Aug-12,31-Aug-13
-NCICAC.GOV,State/Local Govt,Non-Federal Agency,Raleigh,NC,ACTIVE,21-Aug-14,15-Sep-15
-NCISAAC.GOV,State/Local Govt,Non-Federal Agency,Raleigh,NC,ACTIVE,29-Oct-14,19-Oct-15
-NCLAMP.GOV,State/Local Govt,Non-Federal Agency,Raleigh,NC,ACTIVE,2-Dec-14,9-Nov-15
-NCLAP.GOV,State/Local Govt,Non-Federal Agency,Raleigh,NC,ACTIVE,2-Dec-14,9-Nov-15
-NCLAWSPECIALISTS.GOV,State/Local Govt,Non-Federal Agency,Raleigh,NC,ACTIVE,2-Dec-14,9-Nov-15
-NCMORTGAGEHELP.GOV,State/Local Govt,Non-Federal Agency,27609,NC,ACTIVE,11-Feb-15,5-May-16
-NCONEMAP.GOV,State/Local Govt,Non-Federal Agency,Raleigh,NC,ACTIVE,17-Sep-14,31-Aug-15
-NCOPENBOOK.GOV,State/Local Govt,Non-Federal Agency,Raleigh,NC,ACTIVE,3-Feb-15,19-Feb-16
-NCPARKS.GOV,State/Local Govt,Non-Federal Agency,Raleigh,NC,ACTIVE,9-Feb-15,5-Apr-16
-NCPUBLICSCHOOLS.GOV,State/Local Govt,Non-Federal Agency,Raleigh,NC,ACTIVE,15-Apr-14,11-May-15
-NCREC.GOV,State/Local Govt,Non-Federal Agency,Raleigh,NC,ACTIVE,12-Mar-15,31-Mar-16
-NCRETIREMENT.GOV,State/Local Govt,Non-Federal Agency,Raleigh,NC,ACTIVE,9-Jul-14,30-Sep-15
-NCSBE.GOV,State/Local Govt,Non-Federal Agency,Raleigh,NC,ACTIVE,7-Nov-14,5-Jan-16
-NCSBI.GOV,State/Local Govt,Non-Federal Agency,Raleigh,NC,ACTIVE,29-Oct-14,19-Oct-15
-NCSMARTGRID.GOV,State/Local Govt,Non-Federal Agency,Raleigh,NC,ACTIVE,28-May-14,21-May-15
-NCSTA.GOV,State/Local Govt,Non-Federal Agency,Raleigh,NC,ACTIVE,17-Sep-14,30-Sep-15
-NCSTATE.GOV,State/Local Govt,Non-Federal Agency,Raleigh,NC,ACTIVE,4-Feb-15,4-Feb-16
-NCSTATEBAR.GOV,State/Local Govt,Non-Federal Agency,Raleigh,NC,ACTIVE,2-Dec-14,9-Nov-15
-NCTREASURER.GOV,State/Local Govt,Non-Federal Agency,Raleigh,NC,ACTIVE,9-Jul-14,30-Sep-15
-NCVISION25.GOV,State/Local Govt,Non-Federal Agency,Raleigh,NC,ACTIVE,6-Aug-14,6-Aug-15
-NCWORKS.GOV,State/Local Govt,Non-Federal Agency,Raleigh,NC,ACTIVE,28-May-14,23-May-15
-ND.GOV,State/Local Govt,Non-Federal Agency,Bismarck,ND,ACTIVE,7-Jul-14,30-Sep-15
-NDCENSUS.GOV,State/Local Govt,Non-Federal Agency,Bismarck,ND,ACTIVE,22-Jan-15,22-Mar-16
-NDCLOUD.GOV,State/Local Govt,Non-Federal Agency,Bismarck,North Dakota,ACTIVE,10-Apr-14,1-Jul-15
-NDCOURTS.GOV,State/Local Govt,Non-Federal Agency,Bismarck,ND,ACTIVE,19-Sep-14,30-Sep-15
-NDDATACENTER.GOV,State/Local Govt,Non-Federal Agency,Bismarck,ND,ACTIVE,22-Jan-15,22-Mar-16
-NDDOHPRESSROOM.GOV,State/Local Govt,Non-Federal Agency,Bismarck,ND,ACTIVE,9-Jul-14,30-Sep-15
-NDHAN.GOV,State/Local Govt,Non-Federal Agency,Bismarck,ND,ACTIVE,9-Jul-14,30-Sep-15
-NDHEALTH.GOV,State/Local Govt,Non-Federal Agency,Bismarck,ND,ACTIVE,9-Jul-14,30-Sep-15
-NDPANDEMICFLU.GOV,State/Local Govt,Non-Federal Agency,Bismarck,ND,ACTIVE,16-Jun-11,25-Aug-12
-NDSTUDIES.GOV,State/Local Govt,Non-Federal Agency,Bismarck,ND,ACTIVE,27-Jan-15,25-Apr-16
-NE.GOV,State/Local Govt,Non-Federal Agency,Lincoln,NE,ACTIVE,2-Jul-14,30-Sep-15
-NEBRASKA.GOV,State/Local Govt,Non-Federal Agency,Lincoln,NE,ACTIVE,2-Jul-14,30-Sep-15
-NEBRASKACORN.GOV,State/Local Govt,Non-Federal Agency,Lincoln,NE,ACTIVE,24-Sep-14,24-Sep-15
-NEBRASKALEGISLATURE.GOV,State/Local Govt,Non-Federal Agency,Lincoln,NE,ACTIVE,29-Aug-14,17-Nov-15
-NEBRASKAMAP.GOV,State/Local Govt,Non-Federal Agency,Lincoln,NE,ACTIVE,3-Mar-15,19-Feb-16
-NEBRASKASPENDING.GOV,State/Local Govt,Non-Federal Agency,Lincoln,NE,ACTIVE,11-Aug-14,6-Oct-15
-NEBRASKAUNICAMERAL.GOV,State/Local Govt,Non-Federal Agency,Lincoln,NE,ACTIVE,29-Aug-14,17-Nov-15
-NEHEALTHINSURANCEINFO.GOV,State/Local Govt,Non-Federal Agency,Lincoln,NE,ACTIVE,2-Jul-14,30-Sep-15
-NELSONCOUNTY-VA.GOV,State/Local Govt,Non-Federal Agency,Lovingston,VA,ACTIVE,14-Jan-14,15-Mar-15
-NETWORKMARYLAND.GOV,State/Local Govt,Non-Federal Agency,Annapolis,MD,ACTIVE,3-Jul-13,1-Sep-14
-NETWORKNEBRASKA.GOV,State/Local Govt,Non-Federal Agency,Lincoln,NE,ACTIVE,6-Aug-14,6-Aug-15
-NEVADA.GOV,State/Local Govt,Non-Federal Agency,Carson City,NV,ACTIVE,22-Sep-14,30-Sep-15
-NEVADAGUARD.GOV,State/Local Govt,Non-Federal Agency,Carson City,NV,ACTIVE,4-Nov-10,16-Oct-11
-NEVADAHOMEAGAIN.GOV,State/Local Govt,Non-Federal Agency,Las Vegas,NV,ACTIVE,17-Oct-14,4-Jan-16
-NEVADAREADY.GOV,State/Local Govt,Non-Federal Agency,Carson City,NV,ACTIVE,3-Feb-15,6-Feb-16
-NEVADATREASURER.GOV,State/Local Govt,Non-Federal Agency,Carson City,NV,ACTIVE,30-Jun-14,26-Aug-15
-NEWFIELDSNH.GOV,State/Local Govt,Non-Federal Agency,Newfields,NH,ACTIVE,12-Aug-14,30-Sep-15
-NEWHAMPSHIRE.GOV,State/Local Govt,Non-Federal Agency,Concord,NH,ACTIVE,12-Mar-15,30-Sep-14
-NEWJERSEY.GOV,State/Local Govt,Non-Federal Agency,Trenton,NJ,ACTIVE,16-Sep-14,30-Sep-15
-NEWJERSEYBUSINESS.GOV,State/Local Govt,Non-Federal Agency,Trenton,NJ,ACTIVE,29-Mar-10,19-Apr-11
-NEWJERSEYHOMEKEEPER.GOV,State/Local Govt,Non-Federal Agency,Trenton,NJ,ACTIVE,3-Jun-14,2-Jun-15
-NEWMEXICO.GOV,State/Local Govt,Non-Federal Agency,Santa Fe,NM,ACTIVE,9-Sep-14,7-Oct-15
-NEWTONMA.GOV,State/Local Govt,Non-Federal Agency,Newton,MA,ACTIVE,2-Sep-14,30-Sep-15
-NEWWINDSOR-NY.GOV,State/Local Govt,Non-Federal Agency,New Windsor,NY,ACTIVE,18-Jun-14,6-Sep-15
-NEWYORKHEALTH.GOV,State/Local Govt,Non-Federal Agency,Albany,NY,ACTIVE,10-Dec-14,20-Dec-15
-NEXTCHAPTERTN.GOV,State/Local Govt,Non-Federal Agency,Smyrna,TN,ACTIVE,5-Nov-14,5-Nov-15
-NH.GOV,State/Local Govt,Non-Federal Agency,Concord,NH,ACTIVE,25-Sep-12,30-Sep-13
-NIAGARACOUNTY-NY.GOV,State/Local Govt,Non-Federal Agency,LOCKPORT,NY,ACTIVE,25-Feb-15,27-Mar-16
-NICHOLSHILLS-OK.GOV,State/Local Govt,Non-Federal Agency,Nichols Hills,OK,ACTIVE,15-Sep-14,15-Sep-15
-NJ.GOV,State/Local Govt,Non-Federal Agency,Trenton,NJ,ACTIVE,16-Sep-14,30-Sep-15
-NJ2.GOV,State/Local Govt,Non-Federal Agency,Trenton,NJ,ACTIVE,9-Feb-15,3-Mar-16
-NJALERT.GOV,State/Local Govt,Non-Federal Agency,Hamilton,NJ,ACTIVE,7-Oct-14,29-Oct-15
-NJCANCER.GOV,State/Local Govt,Non-Federal Agency,Trenton,NJ,ACTIVE,11-Mar-14,17-Feb-15
-NJCCC.GOV,State/Local Govt,Non-Federal Agency,Atlantic City,NJ,ACTIVE,11-Jul-14,7-Sep-15
-NJCCR.GOV,State/Local Govt,Non-Federal Agency,Trenton,NJ,ACTIVE,11-Mar-14,6-Jan-15
-NJCIVILRIGHTS.GOV,State/Local Govt,Non-Federal Agency,Trenton,NJ,ACTIVE,29-Dec-14,25-Mar-16
-NJCONSUMERAFFAIRS.GOV,State/Local Govt,Non-Federal Agency,Trenton,NJ,ACTIVE,24-Nov-14,5-Nov-15
-NJDOC.GOV,State/Local Govt,Non-Federal Agency,Trenton,NJ,ACTIVE,31-Jul-14,16-Sep-15
-NJFLUPANDEMIC.GOV,State/Local Govt,Non-Federal Agency,Trenton,NJ,ACTIVE,25-Jul-13,25-Sep-14
-NJHAS.GOV,State/Local Govt,Non-Federal Agency,Trenton,NJ,ACTIVE,13-Aug-14,9-Nov-15
-NJHMFA.GOV,State/Local Govt,Non-Federal Agency,Trenton,NJ,ACTIVE,23-Feb-15,23-Feb-16
-NJHOMEKEEPER.GOV,State/Local Govt,Non-Federal Agency,Trenton,NJ,ACTIVE,5-Feb-15,17-Mar-16
-NJHOMELANDSECURITY.GOV,State/Local Govt,Non-Federal Agency,Hamilton,NJ,ACTIVE,7-Oct-14,30-Sep-15
-NJHOUSING.GOV,State/Local Govt,Non-Federal Agency,Trenton,NJ,ACTIVE,5-Feb-15,18-Feb-16
-NJHOUSINGRESOURCECENTER.GOV,State/Local Govt,Non-Federal Agency,Trenton,NJ,ACTIVE,5-Feb-15,8-Mar-16
-NJHRC.GOV,State/Local Govt,Non-Federal Agency,Trenton,NJ,ACTIVE,5-Feb-15,8-Mar-16
-NJHUMANTRAFFICKING.GOV,State/Local Govt,Non-Federal Agency,Trenton,NJ,ACTIVE,9-May-14,28-May-15
-NJMEADOWLANDS.GOV,State/Local Govt,Non-Federal Agency,Lyndhurst,NJ,ACTIVE,2-Jun-14,26-Aug-15
-NJMEDICALBOARD.GOV,State/Local Govt,Non-Federal Agency,Trenton,NJ,ACTIVE,24-Nov-14,22-Nov-15
-NJMVC.GOV,State/Local Govt,Non-Federal Agency,Trenton,NJ,ACTIVE,2-Sep-14,30-Sep-15
-NJMVCONLINE.GOV,State/Local Govt,Non-Federal Agency,Trenton,NJ,ACTIVE,16-Dec-14,12-Dec-15
-NJOHSP.GOV,State/Local Govt,Non-Federal Agency,Hamilton,NJ,ACTIVE,3-Jul-14,13-Jul-15
-NJPAAD.GOV,State/Local Govt,Non-Federal Agency,Mercerville,NJ,ACTIVE,3-Mar-15,11-Aug-15
-NJSDA.GOV,State/Local Govt,Non-Federal Agency,Trenton,NJ,ACTIVE,30-May-14,5-Jul-15
-NJSECURITIES.GOV,State/Local Govt,Non-Federal Agency,Trenton,NJ,ACTIVE,2-Sep-14,16-Sep-15
-NJSENIORGOLD.GOV,State/Local Govt,Non-Federal Agency,Mercerville,NJ,ACTIVE,3-Mar-15,28-Sep-15
-NJSHC.GOV,State/Local Govt,Non-Federal Agency,Trenton,NJ,ACTIVE,23-Feb-15,23-Feb-16
-NJSNAP.GOV,State/Local Govt,Non-Federal Agency,Trenton,NJ,ACTIVE,27-Oct-14,27-Oct-15
-NJSPEAKUP.GOV,State/Local Govt,Non-Federal Agency,Trenton,NJ,ACTIVE,25-Jul-13,30-Jun-14
-NJSRGOLD.GOV,State/Local Govt,Non-Federal Agency,Mercerville,NJ,ACTIVE,3-Mar-15,11-Aug-15
-NJSTART.GOV,State/Local Govt,Non-Federal Agency,Trenton,NJ,ACTIVE,11-Feb-15,22-Apr-16
-NM.GOV,State/Local Govt,Non-Federal Agency,Santa Fe,NM,ACTIVE,9-Sep-14,7-Oct-15
-NMAG.GOV,State/Local Govt,Non-Federal Agency,Santa Fe,NM,ACTIVE,28-Jul-14,3-Aug-15
-NMCOURTS.GOV,State/Local Govt,Non-Federal Agency,Santa Fe,NM,ACTIVE,7-May-14,6-Jul-15
-NMLEGIS.GOV,State/Local Govt,Non-Federal Agency,Santa Fe,NM,ACTIVE,6-Jan-15,4-Jan-16
-NMSTO.GOV,State/Local Govt,Non-Federal Agency,Santa Fe,NM,ACTIVE,30-Oct-12,21-Jul-13
-NORTH-DAKOTA.GOV,State/Local Govt,Non-Federal Agency,Bismarck,ND,ACTIVE,7-Jul-14,30-Sep-15
-NORTHCAROLINA.GOV,State/Local Govt,Non-Federal Agency,Raleigh,NC,ACTIVE,17-Sep-14,30-Sep-15
-NORTHDAKOTA.GOV,State/Local Govt,Non-Federal Agency,Bismarck,ND,ACTIVE,7-Jul-14,30-Sep-15
-NORTHHAMPTON-NH.GOV,State/Local Govt,Non-Federal Agency,North Hampton,NH,ACTIVE,2-Sep-14,30-Sep-15
-NORTHMIAMIFL.GOV,State/Local Govt,Non-Federal Agency,North Miami,FL,ACTIVE,26-Sep-14,30-Sep-15
-NORTHUNIONTOWNSHIP-PA.GOV,State/Local Govt,Non-Federal Agency,Lemont Furnace,PA,ACTIVE,19-Sep-14,30-Sep-15
-NOSCAMNC.GOV,State/Local Govt,Non-Federal Agency,Raleigh,NC,ACTIVE,9-Aug-12,23-Aug-13
-NV.GOV,State/Local Govt,Non-Federal Agency,Carson City,NV,ACTIVE,22-Sep-14,30-Sep-15
-NVCOURTS.GOV,State/Local Govt,Non-Federal Agency,Carson City,NV,ACTIVE,7-Jul-14,5-Aug-15
-NVDPSPUB.GOV,State/Local Govt,Non-Federal Agency,Carson City,NV,ACTIVE,22-Sep-14,30-Sep-15
-NVEASE.GOV,State/Local Govt,Non-Federal Agency,Carson City,NV,ACTIVE,13-Aug-14,13-Aug-15
-NVGGMS.GOV,State/Local Govt,Non-Federal Agency,Carson City,NV,ACTIVE,30-Jun-14,9-Jul-15
-NVPREPAID.GOV,State/Local Govt,Non-Federal Agency,Carson City,NV,ACTIVE,5-Aug-14,3-Oct-15
-NVSEXOFFENDERS.GOV,State/Local Govt,Non-Federal Agency,Carson City,NV,ACTIVE,26-Sep-14,30-Sep-15
-NVSILVERFLUME.GOV,State/Local Govt,Non-Federal Agency,Carson City,NV,ACTIVE,5-Aug-14,1-Aug-15
-NVSOS.GOV,State/Local Govt,Non-Federal Agency,Carson City,NV,ACTIVE,5-Aug-14,9-Oct-15
-NY.GOV,State/Local Govt,Non-Federal Agency,Albany,NY,ACTIVE,8-Jul-14,30-Sep-15
-NYALERT.GOV,State/Local Govt,Non-Federal Agency,Albany,NY,ACTIVE,19-May-14,25-May-15
-NYASSEMBLY.GOV,State/Local Govt,Non-Federal Agency,Albany,NY,ACTIVE,10-Mar-15,8-Jun-16
-NYC-NY.GOV,State/Local Govt,Non-Federal Agency,Brooklyn,NY,ACTIVE,1-Aug-14,30-Sep-15
-NYC.GOV,State/Local Govt,Non-Federal Agency,Brooklyn,NY,ACTIVE,1-Aug-14,30-Sep-15
-NYCOURTHELP.GOV,State/Local Govt,Non-Federal Agency,Troy,NY,ACTIVE,5-Sep-14,30-Sep-15
-NYCOURTS.GOV,State/Local Govt,Non-Federal Agency,Troy,NY,ACTIVE,5-Sep-14,16-Sep-15
-NYGOVOFFICE.GOV,State/Local Govt,Non-Federal Agency,Albany,NY,ACTIVE,3-Mar-15,24-Aug-15
-NYHALLOFGOVERNORS.GOV,State/Local Govt,Non-Federal Agency,Albany,NY,ACTIVE,13-Jul-11,13-Jul-12
-NYHEALTH.GOV,State/Local Govt,Non-Federal Agency,Albany,NY,ACTIVE,10-Dec-14,20-Dec-15
-NYHOUSINGSEARCH.GOV,State/Local Govt,Non-Federal Agency,Albany,NY,ACTIVE,4-Nov-14,14-Nov-15
-NYJUROR.GOV,State/Local Govt,Non-Federal Agency,New York,NY,ACTIVE,5-Sep-14,22-Sep-15
-NYOPENFORBUSINESS.GOV,State/Local Govt,Non-Federal Agency,Albany,NY,ACTIVE,3-Mar-15,14-Mar-15
-NYPA.GOV,State/Local Govt,Non-Federal Agency,WHITE PLAINS,NY,ACTIVE,5-Aug-14,30-Sep-15
-NYPREPARE.GOV,State/Local Govt,Non-Federal Agency,Albany,NY,ACTIVE,4-Sep-13,5-Aug-14
-NYSCANALS.GOV,State/Local Govt,Non-Federal Agency,Albany,NY,ACTIVE,2-Oct-14,18-Dec-15
-NYSDHCR.GOV,State/Local Govt,Non-Federal Agency,Albany,NY,ACTIVE,25-Jun-13,25-Jun-14
-NYSDOT.GOV,State/Local Govt,Non-Federal Agency,Albany,NY,ACTIVE,27-Jul-12,1-Sep-13
-NYSED.GOV,State/Local Govt,Non-Federal Agency,Albany,NY,ACTIVE,4-Aug-14,30-Sep-15
-NYSENATE.GOV,State/Local Govt,Non-Federal Agency,Albany,NY,ACTIVE,2-Mar-15,19-Mar-16
-NYSTART.GOV,State/Local Govt,Non-Federal Agency,Albany,NY,ACTIVE,9-Mar-15,9-Feb-16
-NYSTAX.GOV,State/Local Govt,Non-Federal Agency,Albany,NY,ACTIVE,22-Jul-14,30-Sep-15
-NYSTHRUWAY.GOV,State/Local Govt,Non-Federal Agency,Albany,NY,ACTIVE,26-Jan-15,24-Mar-16
-OCFODC.GOV,State/Local Govt,Non-Federal Agency,Washington,DC,ACTIVE,2-Oct-14,20-Nov-15
-OCPR.GOV,State/Local Govt,Non-Federal Agency,San Juan,PR,ACTIVE,21-Oct-14,28-Sep-15
-ODESSA-TX.GOV,State/Local Govt,Non-Federal Agency,Odessa,TX,ACTIVE,2-Jul-14,30-Sep-15
-OGALLALA-NE.GOV,State/Local Govt,Non-Federal Agency,Ogallala,NE,ACTIVE,12-Aug-14,30-Sep-15
-OH.GOV,State/Local Govt,Non-Federal Agency,Columbus,OH,ACTIVE,19-Aug-14,3-Sep-15
-OHIO.GOV,State/Local Govt,Non-Federal Agency,Columbus,OH,ACTIVE,19-Aug-14,3-Sep-15
-OHIOAGRICULTURE.GOV,State/Local Govt,Non-Federal Agency,Columbus,OH,ACTIVE,19-Aug-14,3-Sep-15
-OHIOAMBASSADOR.GOV,State/Local Govt,Non-Federal Agency,Columbus,OH,ACTIVE,24-Aug-12,8-Sep-13
-OHIOANALYTICS.GOV,State/Local Govt,Non-Federal Agency,Columbus,OH,ACTIVE,22-Apr-14,7-May-15
-OHIOATTORNEYGENERAL.GOV,State/Local Govt,Non-Federal Agency,Columbus,OH,ACTIVE,29-Dec-14,8-Jan-16
-OHIOAUDITOR.GOV,State/Local Govt,Non-Federal Agency,Columbus,OH,ACTIVE,1-Dec-14,29-Dec-15
-OHIOBMV.GOV,State/Local Govt,Non-Federal Agency,Columbus,OH,ACTIVE,29-Dec-14,8-Jan-16
-OHIOBONDS.GOV,State/Local Govt,Non-Federal Agency,Columbus,OH,ACTIVE,21-May-12,29-Jun-13
-OHIOCENTERFORNURSING.GOV,State/Local Govt,Non-Federal Agency,Columbus,OH,ACTIVE,25-Sep-14,24-Oct-15
-OHIOCHECKBOOK.GOV,State/Local Govt,Non-Federal Agency,Columbus,OH,ACTIVE,17-Dec-14,17-Dec-15
-OHIOCOURTOFCLAIMS.GOV,State/Local Govt,Non-Federal Agency,Columbus,OH,ACTIVE,30-Jul-14,14-Aug-15
-OHIOCOURTS.GOV,State/Local Govt,Non-Federal Agency,Columbus,OH,ACTIVE,29-Dec-14,16-Jan-16
-OHIODNR.GOV,State/Local Govt,Non-Federal Agency,Columbus,OH,ACTIVE,19-Aug-14,30-Sep-15
-OHIOHERETOHELP.GOV,State/Local Govt,Non-Federal Agency,Columbus,OH,ACTIVE,26-Jun-14,20-Jul-15
-OHIOHOUSE.GOV,State/Local Govt,Non-Federal Agency,Columbus,OH,ACTIVE,26-Feb-15,29-Mar-16
-OHIOHOUSINGLOCATOR.GOV,State/Local Govt,Non-Federal Agency,Columbus,OH,ACTIVE,22-Apr-14,18-May-15
-OHIOJOBS.GOV,State/Local Govt,Non-Federal Agency,Columbus,OH,ACTIVE,27-Mar-14,10-Apr-15
-OHIOJUDICIALCENTER.GOV,State/Local Govt,Non-Federal Agency,Columbus,OH,ACTIVE,27-Oct-14,15-Nov-15
-OHIOLIVESTOCKCARESTANDARDS.GOV,State/Local Govt,Non-Federal Agency,Columbus,OH,ACTIVE,25-Jun-13,20-Jul-14
-OHIOLIVESTOCKCARESTANDARDSBOARD.GOV,State/Local Govt,Non-Federal Agency,Reynoldsburg,OH,ACTIVE,25-Apr-13,7-May-14
-OHIOMEANSACCESSIBILITY.GOV,State/Local Govt,Non-Federal Agency,Columbus,OH,ACTIVE,28-May-14,28-May-15
-OHIOMEANSJOBS.GOV,State/Local Govt,Non-Federal Agency,Columbus,OH,ACTIVE,27-Mar-14,10-Apr-15
-OHIOMEANSTRAINING.GOV,State/Local Govt,Non-Federal Agency,Columbus,OH,ACTIVE,26-Feb-15,20-Mar-16
-OHIOMEANSVETERANSJOBS.GOV,State/Local Govt,Non-Federal Agency,Columbus,OH,ACTIVE,26-Jun-14,5-Jul-15
-OHIONOSMOKELAW.GOV,State/Local Govt,Non-Federal Agency,Columbus,OH,ACTIVE,28-Jan-15,28-Feb-16
-OHIOPMP.GOV,State/Local Govt,Non-Federal Agency,Columbus,OH,ACTIVE,27-Mar-14,21-Apr-15
-OHIORED.GOV,State/Local Govt,Non-Federal Agency,Columbus,OH,ACTIVE,28-May-14,18-Jun-15
-OHIORESPONDS.GOV,State/Local Govt,Non-Federal Agency,Columbus,OH,ACTIVE,29-Dec-14,24-Jan-16
-OHIOSAFEID.GOV,State/Local Govt,Non-Federal Agency,Columbus,OH,ACTIVE,19-Aug-14,26-Sep-15
-OHIOSECRETARYOFSTATE.GOV,State/Local Govt,Non-Federal Agency,Columbus,OH,ACTIVE,22-Apr-14,4-May-15
-OHIOSENATE.GOV,State/Local Govt,Non-Federal Agency,Columbus,OH,ACTIVE,27-Mar-14,3-Apr-15
-OHIOSUPREMECOURT.GOV,State/Local Govt,Non-Federal Agency,Columbus,OH,ACTIVE,26-Jun-14,20-Jul-15
-OHIOTALENTREADY.GOV,State/Local Govt,Non-Federal Agency,Columbus,OH,ACTIVE,27-Sep-11,24-Oct-12
-OHIOTAXAMNESTY.GOV,State/Local Govt,Non-Federal Agency,Columbus,OH,ACTIVE,28-Jan-13,7-Feb-14
-OHIOTHIRDFRONTIER.GOV,State/Local Govt,Non-Federal Agency,Columbus,OH,ACTIVE,28-May-14,22-Jun-15
-OHIOTPES.GOV,State/Local Govt,Non-Federal Agency,Columbus,OH,ACTIVE,28-Jan-15,10-Feb-16
-OHIOTRAILS.GOV,State/Local Govt,Non-Federal Agency,Columbus,OH,ACTIVE,27-Mar-14,15-Apr-15
-OHIOTREASURER.GOV,State/Local Govt,Non-Federal Agency,Columbus,OH,ACTIVE,22-Apr-14,31-May-15
-OHIOVALUESVETERANS.GOV,State/Local Govt,Non-Federal Agency,Columbus,OH,ACTIVE,30-Jul-14,30-Jul-15
-OHIOVALUESVETS.GOV,State/Local Govt,Non-Federal Agency,Columbus,OH,ACTIVE,30-Jul-14,30-Jul-15
-OHIOVET.GOV,State/Local Govt,Non-Federal Agency,Columbus,OH,ACTIVE,27-Mar-14,16-Apr-15
-OHIOVETERANSHOME.GOV,State/Local Govt,Non-Federal Agency,Columbus,OH,ACTIVE,19-Aug-14,8-Sep-15
-OHIOVETHOF.GOV,State/Local Govt,Non-Federal Agency,Columbus,OH,ACTIVE,19-Aug-14,14-Sep-15
-OHIOVETS.GOV,State/Local Govt,Non-Federal Agency,Columbus,OH,ACTIVE,27-Mar-14,16-Apr-15
-OHIOVETSHOF.GOV,State/Local Govt,Non-Federal Agency,Columbus,OH,ACTIVE,19-Aug-14,14-Sep-15
-OK.GOV,State/Local Govt,Non-Federal Agency,Oklahoma City,OK,ACTIVE,5-Mar-15,30-Sep-15
-OKC.GOV,State/Local Govt,Non-Federal Agency,Oklahoma City,OK,ACTIVE,2-Jul-14,30-Sep-15
-OKDHS.GOV,State/Local Govt,Non-Federal Agency,Oklahoma City,OK,ACTIVE,3-Dec-14,16-Dec-15
-OKDRS.GOV,State/Local Govt,Non-Federal Agency,Oklahoma City,OK,ACTIVE,11-Mar-14,9-Jun-15
-OKGEOSURVEY1.GOV,State/Local Govt,Non-Federal Agency,LEONARD,OK,ACTIVE,6-Nov-14,30-Sep-15
-OKHOUSE.GOV,State/Local Govt,Non-Federal Agency,Oklahoma City,OK,ACTIVE,15-Jul-14,30-Sep-15
-OKLAHOMA.GOV,State/Local Govt,Non-Federal Agency,Oklahoma City,OK,ACTIVE,5-Mar-15,30-Sep-15
-OKLAHOMAWORKS.GOV,State/Local Govt,Non-Federal Agency,Oklahoma City,OK,ACTIVE,29-Dec-14,29-Dec-15
-OKLATOURISM.GOV,State/Local Govt,Non-Federal Agency,Oklahoma City,OK,ACTIVE,14-Jun-12,9-Jun-13
-OKLEGISLATURE.GOV,State/Local Govt,Non-Federal Agency,Oklahoma City,OK,ACTIVE,15-Jul-14,14-Sep-15
-OKSENATE.GOV,State/Local Govt,Non-Federal Agency,Oklahoma City,OK,ACTIVE,15-Jul-14,28-Sep-15
-OLATHEKS.GOV,State/Local Govt,Non-Federal Agency,Olathe,KS,ACTIVE,19-Dec-13,30-Sep-14
-OLDLYME-CT.GOV,State/Local Govt,Non-Federal Agency,Old Lyme,CT,ACTIVE,2-Jul-14,30-Sep-15
-OLYMPIA-WA.GOV,State/Local Govt,Non-Federal Agency,Olympia,WA,ACTIVE,9-Oct-14,30-Sep-15
-OLYMPIAWA.GOV,State/Local Govt,Non-Federal Agency,Olympia,WA,ACTIVE,9-Oct-14,30-Sep-15
-ONESTOPFLORIDA.GOV,State/Local Govt,Non-Federal Agency,Tallahassee,FL,ACTIVE,4-Feb-15,4-Feb-16
-ONSLOWCOUNTYNC.GOV,State/Local Govt,Non-Federal Agency,Jacksonville,NC,ACTIVE,7-Jul-14,25-Aug-15
-OPC-DC.GOV,State/Local Govt,Non-Federal Agency,Washington,DC,ACTIVE,6-Oct-14,30-Sep-15
-OPELIKA-AL.GOV,State/Local Govt,Non-Federal Agency,Opelika,AL,ACTIVE,24-Jul-14,24-Jul-15
-OPEN-DC.GOV,State/Local Govt,Non-Federal Agency,Washington,DC,ACTIVE,27-Nov-13,27-Nov-14
-OPENOHIO.GOV,State/Local Govt,Non-Federal Agency,Columbus,OH,ACTIVE,3-Nov-14,3-Nov-15
-OR-MEDICAID.GOV,State/Local Govt,Non-Federal Agency,Salem,OR,ACTIVE,24-Nov-14,8-Dec-15
-OR.GOV,State/Local Govt,Non-Federal Agency,Salem,OR,ACTIVE,30-May-14,27-Aug-15
-ORANGE-CT.GOV,State/Local Govt,Non-Federal Agency,Orange,CT,ACTIVE,22-Sep-14,30-Sep-15
-ORCLIMATECHANGE.GOV,State/Local Govt,Non-Federal Agency,Salem,OR,ACTIVE,20-Jan-15,20-Mar-16
-OREGON.GOV,State/Local Govt,Non-Federal Agency,Salem,OR,ACTIVE,30-May-14,27-Aug-15
-OREGONATTORNEYGENERAL.GOV,State/Local Govt,Non-Federal Agency,Salem,OR,ACTIVE,17-Nov-14,17-Dec-15
-OREGONBENEFITSONLINE.GOV,State/Local Govt,Non-Federal Agency,Salem,OR,ACTIVE,15-Aug-14,29-Aug-15
-OREGONBUDGET.GOV,State/Local Govt,Non-Federal Agency,Salem,OR,ACTIVE,3-Feb-15,2-Apr-16
-OREGONCHILDSUPPORT.GOV,State/Local Govt,Non-Federal Agency,Salem,OR,ACTIVE,24-Nov-14,23-Dec-15
-OREGONCONSUMER.GOV,State/Local Govt,Non-Federal Agency,Salem,OR,ACTIVE,6-Jan-15,4-Feb-16
-OREGONFORESTRY.GOV,State/Local Govt,Non-Federal Agency,Salem,OR,ACTIVE,5-Jan-15,26-Jan-16
-OREGONHEALTHCARE.GOV,State/Local Govt,Non-Federal Agency,Salem,OR,ACTIVE,29-Aug-14,29-Aug-15
-OREGONHEALTHYKIDS.GOV,State/Local Govt,Non-Federal Agency,Salem,OR,ACTIVE,5-Jan-15,18-Jan-16
-OREGONHOMEOWNERSUPPORT.GOV,State/Local Govt,Non-Federal Agency,Salem,OR,ACTIVE,15-Aug-14,29-Aug-15
-OREGONLEGISLATURE.GOV,State/Local Govt,Non-Federal Agency,Salem,OR,ACTIVE,5-Jan-15,2-Feb-16
-OREGONMETRO.GOV,State/Local Govt,Non-Federal Agency,Portland,OR,ACTIVE,24-Nov-14,4-Feb-16
-OREGONRX.GOV,State/Local Govt,Non-Federal Agency,Salem,OR,ACTIVE,18-Aug-14,27-Aug-15
-OREGONSTUDENTAID.GOV,State/Local Govt,Non-Federal Agency,Salem,OR,ACTIVE,24-Dec-14,7-Jan-16
-OREGONUSF.GOV,State/Local Govt,Non-Federal Agency,Salem,OR,ACTIVE,5-Jan-15,30-Dec-15
-OREGONVOTES.GOV,State/Local Govt,Non-Federal Agency,Salem,OR,ACTIVE,30-May-14,27-Jun-15
-ORHEALTHCARE.GOV,State/Local Govt,Non-Federal Agency,Salem,OR,ACTIVE,29-Aug-14,29-Aug-15
-OSE-CT.GOV,State/Local Govt,Non-Federal Agency,Hartford,CT,ACTIVE,1-Aug-12,31-Aug-13
-OTAYWATER.GOV,State/Local Govt,Non-Federal Agency,Spring Valley,CA,ACTIVE,8-Sep-14,30-Sep-14
-OUTDOORNEBRASKA.GOV,State/Local Govt,Non-Federal Agency,Lincoln,NE,ACTIVE,2-Jul-14,27-Aug-15
-OVERLANDPARKKS.GOV,State/Local Govt,Non-Federal Agency,Overland Park,KS,ACTIVE,4-Aug-14,2-Sep-15
-OXFORD-CT.GOV,State/Local Govt,Non-Federal Agency,Oxford,CT,ACTIVE,2-Sep-14,30-Sep-15
-PA.GOV,State/Local Govt,Non-Federal Agency,Harrisburg,PA,ACTIVE,30-Sep-14,30-Sep-15
-PAACPAMMMI.GOV,State/Local Govt,Non-Federal Agency,Lansing,MI,ACTIVE,27-Oct-14,25-Jan-16
-PAAUDITOR.GOV,State/Local Govt,Non-Federal Agency,Harrisburg,PA,ACTIVE,30-Jan-15,30-Jan-16
-PACIFICFLYWAY.GOV,State/Local Govt,Non-Federal Agency,Vancouver,WA,ACTIVE,9-Jun-14,7-Sep-15
-PACIFICWA.GOV,State/Local Govt,Non-Federal Agency,Pacific,WA,ACTIVE,23-Sep-14,20-Jul-15
-PADILLABAY.GOV,State/Local Govt,Non-Federal Agency,MOUNT VERNON,WA,ACTIVE,19-Sep-14,21-Sep-15
-PAHOUSE.GOV,State/Local Govt,Non-Federal Agency,Harrisburg,PA,ACTIVE,7-Oct-14,9-Oct-15
-PAINVEST.GOV,State/Local Govt,Non-Federal Agency,Harrisburg,PA,ACTIVE,23-Dec-14,17-Jan-16
-PALMBEACHCOUNTYTAXCOLLECTOR-FL.GOV,State/Local Govt,Non-Federal Agency,West Palm Beach,FL,ACTIVE,12-May-14,6-May-15
-PALOALTO-CA.GOV,State/Local Govt,Non-Federal Agency,Palo Alto,CA,ACTIVE,4-Oct-12,30-Sep-13
-PANYNJ.GOV,State/Local Govt,Non-Federal Agency,New York,NY,ACTIVE,22-Jul-14,15-Sep-15
-PAOPENFORBUSINESS.GOV,State/Local Govt,Non-Federal Agency,Harrisburg,PA,ACTIVE,30-Sep-14,30-Sep-15
-PARTNERSFORHEALTHTN.GOV,State/Local Govt,Non-Federal Agency,Nashville,TN,ACTIVE,8-Jan-15,1-Apr-16
-PASEN.GOV,State/Local Govt,Non-Federal Agency,Harrisburg,PA,ACTIVE,21-Aug-14,30-Sep-15
-PASENATE.GOV,State/Local Govt,Non-Federal Agency,Harrisburg,PA,ACTIVE,30-Oct-14,11-Jan-16
-PATREASURY.GOV,State/Local Govt,Non-Federal Agency,Harrisburg,PA,ACTIVE,5-Mar-14,5-Apr-15
-PAULDING.GOV,State/Local Govt,Non-Federal Agency,Dallas,GA,ACTIVE,7-Jul-14,30-Sep-14
-PAY4COLLEGEARIZONA.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE,24-Feb-15,25-Feb-16
-PEACHTREECORNERSGA.GOV,State/Local Govt,Non-Federal Agency,PEACHTREE CORNERS,GA,ACTIVE,17-Jul-14,5-Sep-15
-PEMBINACOUNTYND.GOV,State/Local Govt,Non-Federal Agency,Cavalier,ND,ACTIVE,2-Jun-14,27-Aug-15
-PENNSYLVANIA.GOV,State/Local Govt,Non-Federal Agency,Harrisburg,PA,ACTIVE,30-Sep-14,30-Sep-15
-PEORIAAZ.GOV,State/Local Govt,Non-Federal Agency,Peoria,AZ,ACTIVE,8-Sep-14,30-Sep-15
-PEQUOTLAKES-MN.GOV,State/Local Govt,Non-Federal Agency,Pequot Lakes,MN,ACTIVE,5-Aug-14,30-Sep-15
-PERFORMANCEOHIO.GOV,State/Local Govt,Non-Federal Agency,Columbus,OH,ACTIVE,24-Aug-12,8-Sep-13
-PERRY-GA.GOV,State/Local Govt,Non-Federal Agency,Perry,GA,ACTIVE,12-Aug-14,30-Sep-15
-PERRY-WI.GOV,State/Local Govt,Non-Federal Agency,Mount Horeb,WI,ACTIVE,26-Nov-14,23-Feb-16
-PHILIPSBURGMT.GOV,State/Local Govt,Non-Federal Agency,Philipsburg,MT,ACTIVE,18-Feb-15,18-Feb-16
-PHOENIX.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE,27-Aug-14,30-Sep-15
-PIERMONT-NY.GOV,State/Local Govt,Non-Federal Agency,Piermont,NY,ACTIVE,4-Aug-14,7-Sep-15
-PILOTPOINTAK.GOV,State/Local Govt,Non-Federal Agency,Pilot Point,AK,ACTIVE,30-Jan-14,31-Jan-15
-PINECREST-FL.GOV,State/Local Govt,Non-Federal Agency,Pinecrest,FL,ACTIVE,2-Jul-14,30-Sep-15
-PINELLASCOUNTY-FL.GOV,State/Local Govt,Non-Federal Agency,Clearwater,FL,ACTIVE,21-Jul-14,30-Sep-15
-PINELLASCOUNTYFL.GOV,State/Local Govt,Non-Federal Agency,Clearwater,FL,ACTIVE,21-Jul-14,30-Sep-15
-PINETOPLAKESIDEAZ.GOV,State/Local Govt,Non-Federal Agency,LAKESIDE,AZ,ACTIVE,25-Jul-14,25-Jul-15
-PLAINVILLE-CT.GOV,State/Local Govt,Non-Federal Agency,Plainville,CT,ACTIVE,26-Jun-14,17-Sep-15
-PLANO.GOV,State/Local Govt,Non-Federal Agency,Plano,TX,ACTIVE,7-Jul-14,30-Sep-15
-PLATTSBURG-MO.GOV,State/Local Govt,Non-Federal Agency,Plattsburg,MO,ACTIVE,1-Aug-14,30-Sep-15
-POCONOPA.GOV,State/Local Govt,Non-Federal Agency,Tannersville,PA,ACTIVE,3-Feb-15,3-May-16
-POMFRETCT.GOV,State/Local Govt,Non-Federal Agency,Pomfret Center,CT,ACTIVE,21-Aug-14,16-Sep-15
-PORTAGE-MI.GOV,State/Local Govt,Non-Federal Agency,Portage,MI,ACTIVE,19-Nov-14,30-Sep-15
-PORTAGEMI.GOV,State/Local Govt,Non-Federal Agency,Portage,MI,ACTIVE,19-Nov-14,30-Sep-15
-PORTSMOUTHVA.GOV,State/Local Govt,Non-Federal Agency,Portsmouth,VA,ACTIVE,3-Sep-14,21-Sep-15
-POYNETTE-WI.GOV,State/Local Govt,Non-Federal Agency,Poynette,WI,ACTIVE,8-Sep-14,30-Sep-15
-PR.GOV,State/Local Govt,Non-Federal Agency,San Juan,PR,ACTIVE,16-Jan-15,20-Jan-16
-PREVENTHAIAZ.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE,15-May-14,3-Aug-15
-PRINCEGEORGECOUNTYVA.GOV,State/Local Govt,Non-Federal Agency,Prince George,VA,ACTIVE,9-Jun-14,17-Jul-15
-PROVINCETOWN-MA.GOV,State/Local Govt,Non-Federal Agency,Provincetown,MA,ACTIVE,6-Aug-14,30-Sep-15
-PUBLICNOTICE-OHIO.GOV,State/Local Govt,Non-Federal Agency,Columbus,OH,ACTIVE,23-Apr-12,16-May-13
-PUERTORICO.GOV,State/Local Govt,Non-Federal Agency,San Juan,PR,ACTIVE,21-Feb-12,20-Jan-13
-PULASKICOUNTYVA.GOV,State/Local Govt,Non-Federal Agency,Pulaski,VA,ACTIVE,15-Aug-14,30-Sep-15
-PULLMAN-WA.GOV,State/Local Govt,Non-Federal Agency,Pullman,WA,ACTIVE,2-Jul-14,30-Sep-15
-PUTNAMCOUNTYTN.GOV,State/Local Govt,Non-Federal Agency,Cookeville,TN,ACTIVE,21-Jul-14,15-Sep-15
-QAAZ.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE,29-Aug-14,29-Aug-15
-QUALITYFIRSTAZ.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE,26-Feb-14,21-Mar-15
-RAMAPO-NY.GOV,State/Local Govt,Non-Federal Agency,Suffern,NY,ACTIVE,8-Jul-14,21-Sep-15
-RANDOLPHMAINE.GOV,State/Local Govt,Non-Federal Agency,Randolph,ME,ACTIVE,17-Aug-12,30-Sep-13
-READYALABAMA.GOV,State/Local Govt,Non-Federal Agency,Montgomery,AL,ACTIVE,14-Aug-14,21-Aug-15
-READYNH.GOV,State/Local Govt,Non-Federal Agency,Concord,NH,ACTIVE,19-Aug-14,19-Aug-15
-READYVIRGINIA.GOV,State/Local Govt,Non-Federal Agency,Richmond,VA,ACTIVE,15-Apr-14,16-May-15
-READYWV.GOV,State/Local Govt,Non-Federal Agency,Charleston,WV,ACTIVE,24-May-13,18-Jun-14
-RECYCLEOHIO.GOV,State/Local Govt,Non-Federal Agency,Columbus,OH,ACTIVE,22-Apr-14,22-Apr-15
-REDDING-CA.GOV,State/Local Govt,Non-Federal Agency,Redding,CA,ACTIVE,3-Sep-13,30-Sep-14
-REDISTRICTINGFLORIDA.GOV,State/Local Govt,Non-Federal Agency,Tallahassee,FL,ACTIVE,30-Apr-10,30-Apr-11
-REEDSBURGWI.GOV,State/Local Govt,Non-Federal Agency,Reedsburg,WI,ACTIVE,9-Jun-14,7-Sep-15
-REGISTERTOVOTENV.GOV,State/Local Govt,Non-Federal Agency,Carson City,NV,ACTIVE,5-May-14,4-May-15
-RELAYUTAH.GOV,State/Local Govt,Non-Federal Agency,Salt Lake City,UT,ACTIVE,7-Jul-14,30-Sep-15
-RENO.GOV,State/Local Govt,Non-Federal Agency,Reno,NV,ACTIVE,30-Sep-13,30-Sep-14
-RENTONWA.GOV,State/Local Govt,Non-Federal Agency,Renton,WA,ACTIVE,23-Oct-12,21-Sep-13
-RHODEISLAND.GOV,State/Local Govt,Non-Federal Agency,Providence,RI,ACTIVE,4-Sep-14,30-Sep-15
-RI.GOV,State/Local Govt,Non-Federal Agency,Providence,RI,ACTIVE,4-Sep-14,30-Sep-15
-RIALTOCA.GOV,State/Local Govt,Non-Federal Agency,Rialto,CA,ACTIVE,25-Aug-14,30-Sep-15
-RICHLANDMS.GOV,State/Local Govt,Non-Federal Agency,Richland,MS,ACTIVE,25-Mar-14,5-Apr-15
-RIDESHAREWI.GOV,State/Local Govt,Non-Federal Agency,Madison,WI,ACTIVE,7-Jul-14,3-Sep-15
-RIDESHAREWISCONSIN.GOV,State/Local Govt,Non-Federal Agency,Madison,WI,ACTIVE,7-Jul-14,3-Sep-15
-RIORANCHONM.GOV,State/Local Govt,Non-Federal Agency,Rio Rancho,NM,ACTIVE,5-Mar-15,5-Mar-16
-RIVERTONWY.GOV,State/Local Govt,Non-Federal Agency,Riverton,WY,ACTIVE,11-Aug-14,1-Sep-15
-ROANOKECOUNTY-VA.GOV,State/Local Govt,Non-Federal Agency,Roanoke,VA,ACTIVE,31-Jul-14,23-Aug-15
-ROANOKECOUNTYVA.GOV,State/Local Govt,Non-Federal Agency,Roanoke,VA,ACTIVE,31-Jul-14,23-Aug-15
-ROANOKECOUNTYVIRGINIA.GOV,State/Local Govt,Non-Federal Agency,Roanoke,VA,ACTIVE,31-Jul-14,23-Aug-15
-ROCHELLEPARKNJ.GOV,State/Local Govt,Non-Federal Agency,Rochelle Park,NJ,ACTIVE,29-Jul-14,30-Sep-15
-ROCHESTERMN.GOV,State/Local Govt,Non-Federal Agency,Rochester,MN,ACTIVE,14-Nov-14,15-Sep-15
-ROCKINGHAMCOUNTYVA.GOV,State/Local Govt,Non-Federal Agency,Harrisonburg,VA,ACTIVE,22-Sep-14,10-Sep-15
-ROCKISLANDTOWNSHIPIL.GOV,State/Local Govt,Non-Federal Agency,Rock Island,IL,ACTIVE,11-Jun-14,11-Jun-15
-ROGERSMN.GOV,State/Local Govt,Non-Federal Agency,Rogers,MN,ACTIVE,22-Jul-14,22-Jul-15
-ROMI.GOV,State/Local Govt,Non-Federal Agency,Royal Oak,MI,ACTIVE,10-Nov-14,9-Oct-15
-ROWANCOUNTYNC.GOV,State/Local Govt,Non-Federal Agency,Salisbury,NC,ACTIVE,5-Aug-14,30-Sep-15
-ROYALOAKMI.GOV,State/Local Govt,Non-Federal Agency,Royal Oak,MI,ACTIVE,10-Nov-14,9-Oct-15
-RSA-AL.GOV,State/Local Govt,Non-Federal Agency,Montgomery,AL,ACTIVE,8-Jul-14,31-Aug-15
-RULEWATCHOHIO.GOV,State/Local Govt,Non-Federal Agency,Columbus,OH,ACTIVE,1-Dec-14,12-Dec-15
-SACOMAINE.GOV,State/Local Govt,Non-Federal Agency,Saco,ME,ACTIVE,1-Aug-14,30-Sep-15
-SAFEHOMEALABAMA.GOV,State/Local Govt,Non-Federal Agency,Montgomery,AL,ACTIVE,18-Jun-14,17-Aug-15
-SAFERFLORIDAHIGHWAYS.GOV,State/Local Govt,Non-Federal Agency,Tallahassee,FL,ACTIVE,6-May-14,12-Jul-15
-SAFERFLORIDAROADS.GOV,State/Local Govt,Non-Federal Agency,Tallahassee,FL,ACTIVE,6-May-14,12-Jul-15
-SAFESD.GOV,State/Local Govt,Non-Federal Agency,Pierre,SD,ACTIVE,3-Sep-14,1-Dec-15
-SAFFORD-AZ.GOV,State/Local Govt,Non-Federal Agency,Safford,AZ,ACTIVE,2-Jul-10,30-Sep-11
-SALINA-KS.GOV,State/Local Govt,Non-Federal Agency,Salina,KS,ACTIVE,17-Oct-14,30-Sep-15
-SANDIEGO.GOV,State/Local Govt,Non-Federal Agency,San Diego,CA,ACTIVE,30-Jul-14,27-Aug-15
-SANNET.GOV,State/Local Govt,Non-Federal Agency,San Diego,CA,ACTIVE,30-Jul-14,1-Sep-15
-SANTAANA-CA.GOV,State/Local Govt,Non-Federal Agency,Santa Ana,CA,ACTIVE,4-Sep-13,30-Sep-14
-SANTABARBARACA.GOV,State/Local Govt,Non-Federal Agency,Santa Barbara,CA,ACTIVE,2-Sep-14,30-Sep-15
-SAVEMYHOMEAZ.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE,1-May-14,10-May-15
-SAVEOURHOMEAZ.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE,2-Jun-14,15-Jun-15
-SC.GOV,State/Local Govt,Non-Federal Agency,Columbia,SC,ACTIVE,5-Aug-14,30-Sep-15
-SCAG.GOV,State/Local Govt,Non-Federal Agency,Columbia,SC,ACTIVE,26-Sep-14,6-Nov-15
-SCCONSUMER.GOV,State/Local Govt,Non-Federal Agency,Columbia,SC,ACTIVE,24-Jul-14,30-Sep-15
-SCDEW.GOV,State/Local Govt,Non-Federal Agency,Columbia,SC,ACTIVE,12-May-14,18-Jun-15
-SCDHEC.GOV,State/Local Govt,Non-Federal Agency,Columbia,SC,ACTIVE,18-Jun-14,10-Sep-15
-SCDHHS.GOV,State/Local Govt,Non-Federal Agency,Columbia,SC,ACTIVE,20-Jan-15,3-Feb-16
-SCDPS.GOV,State/Local Govt,Non-Federal Agency,Blythewood,SC,ACTIVE,5-May-14,16-May-15
-SCFC.GOV,State/Local Govt,Non-Federal Agency,Columbia,SC,ACTIVE,7-Jul-14,28-Aug-15
-SCHELP.GOV,State/Local Govt,Non-Federal Agency,Columbia`,SC,ACTIVE,2-Feb-15,2-Apr-16
-SCHOHARIECOUNTY-NY.GOV,State/Local Govt,Non-Federal Agency,Schoharie,NY,ACTIVE,1-Oct-12,30-Sep-13
-SCHOUSE.GOV,State/Local Govt,Non-Federal Agency,Columbia,SC,ACTIVE,3-Jul-14,31-Aug-15
-SCOH.GOV,State/Local Govt,Non-Federal Agency,Columbus,OH,ACTIVE,28-Jan-15,21-Feb-16
-SCOHIO.GOV,State/Local Govt,Non-Federal Agency,Columbus,OH,ACTIVE,26-Feb-15,7-Mar-16
-SCOTTCOUNTYIOWA.GOV,State/Local Govt,Non-Federal Agency,Davenport,IA,ACTIVE,4-Aug-14,26-Aug-15
-SCOTTCOUNTYMS.GOV,State/Local Govt,Non-Federal Agency,Forest,MS,ACTIVE,1-Sep-14,30-Sep-15
-SCOTTSDALEAZ.GOV,State/Local Govt,Non-Federal Agency,Scottsdale,AZ,ACTIVE,31-Jul-14,30-Aug-15
-SCQUITLINE.GOV,State/Local Govt,Non-Federal Agency,Columbia,SC,ACTIVE,29-Oct-12,29-Oct-13
-SCSENATE.GOV,State/Local Govt,Non-Federal Agency,Columbia,SC,ACTIVE,3-Jul-14,31-Aug-15
-SCSERV.GOV,State/Local Govt,Non-Federal Agency,Columbia,SC,ACTIVE,25-Jul-12,25-Jul-13
-SCSTATEHOUSE.GOV,State/Local Govt,Non-Federal Agency,Columbia,SC,ACTIVE,3-Jul-14,31-Aug-15
-SD.GOV,State/Local Govt,Non-Federal Agency,Pierre,SD,ACTIVE,3-Sep-14,10-Sep-15
-SDAUDITOR.GOV,State/Local Govt,Non-Federal Agency,Pierre,SD,ACTIVE,3-Sep-14,10-Sep-15
-SDBMOE.GOV,State/Local Govt,Non-Federal Agency,Pierre,SD,ACTIVE,3-Sep-14,16-Oct-15
-SDSOS.GOV,State/Local Govt,Non-Federal Agency,Pierre,SD,ACTIVE,3-Sep-14,10-Sep-15
-SDTREASURER.GOV,State/Local Govt,Non-Federal Agency,Pierre,SD,ACTIVE,3-Sep-14,3-Sep-15
-SEATTLE.GOV,State/Local Govt,Non-Federal Agency,Seattle,WA,ACTIVE,15-Jul-14,30-Sep-15
-SEDGWICK.GOV,State/Local Govt,Non-Federal Agency,Wichita,KS,ACTIVE,22-Apr-14,21-Jul-15
-SEELYVILLE-IN.GOV,State/Local Govt,Non-Federal Agency,Seelyville,IN,ACTIVE,14-Jul-14,10-Sep-15
-SEMINOLECOUNTYFL.GOV,State/Local Govt,Non-Federal Agency,Sanford,FL,ACTIVE,15-Oct-14,15-Sep-15
-SERVEALABAMA.GOV,State/Local Govt,Non-Federal Agency,Montgomery,AL,ACTIVE,14-Aug-14,30-Sep-15
-SERVEIDAHO.GOV,State/Local Govt,Non-Federal Agency,Boise,ID,ACTIVE,5-Feb-15,1-Mar-16
-SERVEOHIO.GOV,State/Local Govt,Non-Federal Agency,Columb us,OH,ACTIVE,26-Jun-14,20-Jul-15
-SERVGA.GOV,State/Local Govt,Non-Federal Agency,Atlanta,GA,ACTIVE,15-Aug-13,16-Jul-14
-SFWMD.GOV,State/Local Govt,Non-Federal Agency,West Palm Beach,FL,ACTIVE,5-Aug-14,30-Sep-15
-SHAFTSBURYVT.GOV,State/Local Govt,Non-Federal Agency,Shaftsbury,VT,ACTIVE,3-Jun-14,3-Jun-15
-SHAPINGNEWJERSEY.GOV,State/Local Govt,Non-Federal Agency,Trenton,NJ,ACTIVE,25-Jul-13,10-Aug-14
-SHAPINGNJ.GOV,State/Local Govt,Non-Federal Agency,Trenton,NJ,ACTIVE,25-Jul-13,10-Aug-14
-SHAREOHIO.GOV,State/Local Govt,Non-Federal Agency,Columbus,OH,ACTIVE,27-Mar-14,12-Apr-15
-SHOWLOWAZ.GOV,State/Local Govt,Non-Federal Agency,Show Low,AZ,ACTIVE,15-Aug-14,12-Sep-15
-SHREWSBURY-MA.GOV,State/Local Govt,Non-Federal Agency,Shrewsbury,MA,ACTIVE,2-Jul-14,30-Sep-15
-SIMSBURY-CT.GOV,State/Local Govt,Non-Federal Agency,Simsbury,CT,ACTIVE,9-Jul-14,7-Sep-15
-SMITHTOWNNY.GOV,State/Local Govt,Non-Federal Agency,Smithtown,NY,ACTIVE,25-Aug-14,24-Sep-15
-SNOHOMISHCOUNTYWA.GOV,State/Local Govt,Non-Federal Agency,Everett,WA,ACTIVE,20-Jun-14,8-Sep-15
-SOCORRONM.GOV,State/Local Govt,Non-Federal Agency,Socorro,NM,ACTIVE,19-Dec-13,30-Sep-14
-SOUTHCAROLINA.GOV,State/Local Govt,Non-Federal Agency,Columbia,SC,ACTIVE,5-Aug-14,30-Sep-15
-SOUTHERNSHORES-NC.GOV,State/Local Govt,Non-Federal Agency,Southern Shores,NC,ACTIVE,30-Oct-14,30-Sep-15
-SOUTHOLDTOWNNY.GOV,State/Local Govt,Non-Federal Agency,Southold,NY,ACTIVE,30-Jan-15,14-Mar-16
-SPACEFLORIDA.GOV,State/Local Govt,Non-Federal Agency,Cape Canaveral,FL,ACTIVE,10-Apr-14,13-Jun-15
-SPRINGFIELDMO.GOV,State/Local Govt,Non-Federal Agency,Springfield,MO,ACTIVE,11-Jun-14,8-Sep-15
-STAGINGAZ.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE,29-Aug-14,29-Aug-15
-STATEOFSOUTHCAROLINA.GOV,State/Local Govt,Non-Federal Agency,Columbia,SC,ACTIVE,5-Aug-14,30-Sep-15
-STATEOFWV.GOV,State/Local Govt,Non-Federal Agency,Charleston,WV,ACTIVE,5-Jun-14,10-May-15
-STAYSAFENEBRASKA.GOV,State/Local Govt,Non-Federal Agency,Lincoln,NE,ACTIVE,12-Nov-14,7-Oct-15
-STCHARLESIL.GOV,State/Local Govt,Non-Federal Agency,St. Charles,IL,ACTIVE,15-Sep-14,30-Sep-15
-STONECOUNTYMS.GOV,State/Local Govt,Non-Federal Agency,Wiggins,MS,ACTIVE,23-Oct-14,30-Sep-15
-STOPFRAUDCOLORADO.GOV,State/Local Govt,Non-Federal Agency,Denver,CO,ACTIVE,17-Oct-14,17-Oct-15
-STOUGHTON-MA.GOV,State/Local Govt,Non-Federal Agency,Stoughton,MA,ACTIVE,12-Sep-14,30-Sep-15
-STOW-MA.GOV,State/Local Govt,Non-Federal Agency,Stow,MA,ACTIVE,30-Jul-14,30-Sep-15
-STPAULSNC.GOV,State/Local Govt,Non-Federal Agency,St. Pauls,NC,ACTIVE,30-Sep-14,30-Sep-15
-STURTEVANT-WI.GOV,State/Local Govt,Non-Federal Agency,Sturtevant,WI,ACTIVE,12-Sep-14,30-Sep-15
-SUFFOLKCOUNTYNY.GOV,State/Local Govt,Non-Federal Agency,Hauppauge,NY,ACTIVE,15-Oct-14,30-Sep-15
-SULLIVANCOUNTYNH.GOV,State/Local Govt,Non-Federal Agency,Newport,NH,ACTIVE,7-Jul-14,30-Sep-15
-SUNRISEFL.GOV,State/Local Govt,Non-Federal Agency,Sunrise,FL,ACTIVE,17-Sep-14,17-Sep-15
-SUNRISEFLORIDA.GOV,State/Local Govt,Non-Federal Agency,Sunrise,FL,ACTIVE,17-Sep-14,17-Sep-15
-SUPREMECOURTOFOHIO.GOV,State/Local Govt,Non-Federal Agency,Columbus,OH,ACTIVE,22-Apr-14,31-May-15
-SUTTON-NH.GOV,State/Local Govt,Non-Federal Agency,Sutton,NH,ACTIVE,18-Aug-14,24-Sep-15
-SWEETHOMEALABAMA.GOV,State/Local Govt,Non-Federal Agency,Montgomery,AL,ACTIVE,3-Nov-14,3-Nov-15
-TAKOMAPARKMD.GOV,State/Local Govt,Non-Federal Agency,Takoma Park,MD,ACTIVE,3-Jul-14,30-Sep-15
-TALENTREADYOHIO.GOV,State/Local Govt,Non-Federal Agency,Columbus,OH,ACTIVE,27-Sep-11,24-Oct-12
-TAPPAHANNOCK-VA.GOV,State/Local Govt,Non-Federal Agency,Tappahannock,VA,ACTIVE,11-Dec-14,11-Jan-16
-TCCC.GOV,State/Local Govt,Non-Federal Agency,Columbia,SC,ACTIVE,6-Jan-15,17-Jan-16
-TEACHIOWA.GOV,State/Local Govt,Non-Federal Agency,Des Moines,IA,ACTIVE,17-Nov-14,5-Nov-15
-TEAMGA.GOV,State/Local Govt,Non-Federal Agency,Atlanta,GA,ACTIVE,19-May-14,12-Aug-15
-TEAMGEORGIA.GOV,State/Local Govt,Non-Federal Agency,Atlanta,GA,ACTIVE,19-May-14,12-Aug-15
-TENNESSEE.GOV,State/Local Govt,Non-Federal Agency,Nashville,TN,ACTIVE,31-Jul-14,30-Sep-15
-TENNESSEEIIS.GOV,State/Local Govt,Non-Federal Agency,Smyrna,TN,ACTIVE,28-Aug-14,29-Aug-15
-TENNESSEEPROMISE.GOV,State/Local Govt,Non-Federal Agency,Smyrna,TN,ACTIVE,13-Aug-14,14-Aug-15
-TENNESSEERECONNECT.GOV,State/Local Govt,Non-Federal Agency,Smyrna,TN,ACTIVE,18-Dec-14,18-Dec-15
-TESTOHIO.GOV,State/Local Govt,Non-Federal Agency,Columbus,OH,ACTIVE,26-Feb-15,19-Mar-16
-TEWKSBURY-MA.GOV,State/Local Govt,Non-Federal Agency,Tewksbury,MA,ACTIVE,15-Oct-14,30-Sep-15
-TEXAS.GOV,State/Local Govt,Non-Federal Agency,Austin,TX,ACTIVE,30-Sep-14,30-Sep-15
-TEXAS511.GOV,State/Local Govt,Non-Federal Agency,Austin,TX,ACTIVE,29-May-13,23-Aug-14
-TEXASAGRICULTURE.GOV,State/Local Govt,Non-Federal Agency,Austin,TX,ACTIVE,30-Sep-14,14-Oct-15
-TEXASATTORNEYGENERAL.GOV,State/Local Govt,Non-Federal Agency,Austin,TX,ACTIVE,9-Mar-15,28-Feb-16
-TEXASCHILDRENSCOMMISSION.GOV,State/Local Govt,Non-Federal Agency,Austin,TX,ACTIVE,4-Apr-14,5-Apr-15
-TEXASFIGHTSIDTHEFT.GOV,State/Local Govt,Non-Federal Agency,Austin,TX,ACTIVE,9-Mar-15,27-Feb-16
-TEXASFILE.GOV,State/Local Govt,Non-Federal Agency,Austin,TX,ACTIVE,14-Nov-14,3-Jan-16
-TEXASONLINE.GOV,State/Local Govt,Non-Federal Agency,Austin,TX,ACTIVE,30-Sep-14,30-Sep-15
-TEXASSTATEPARKS.GOV,State/Local Govt,Non-Federal Agency,Austin,TX,ACTIVE,4-Feb-15,16-Feb-15
-TEXASSUPREMECOURTCOMMISSION.GOV,State/Local Govt,Non-Federal Agency,Austin,TX,ACTIVE,4-Apr-14,5-Apr-15
-THA.GOV,State/Local Govt,Non-Federal Agency,Topeka,KS,ACTIVE,14-Jul-14,30-Sep-15
-THEFTAZ.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE,10-Feb-15,11-Apr-16
-THERIGHTCALLIOWA.GOV,State/Local Govt,Non-Federal Agency,Des Moines,IA,ACTIVE,1-Oct-14,25-Oct-15
-THESTATEOFSOUTHCAROLINA.GOV,State/Local Govt,Non-Federal Agency,Columbia,SC,ACTIVE,5-Aug-14,30-Sep-15
-THINKGREENVT.GOV,State/Local Govt,Non-Federal Agency,Montpelier,VT,ACTIVE,20-Dec-12,6-Jan-14
-TN.GOV,State/Local Govt,Non-Federal Agency,Nashville,TN,ACTIVE,31-Jul-14,30-Sep-15
-TNAG.GOV,State/Local Govt,Non-Federal Agency,Nashville,TN,ACTIVE,18-Dec-14,15-Mar-16
-TNCOURTS.GOV,State/Local Govt,Non-Federal Agency,Nashville,TN,ACTIVE,21-Oct-14,14-Dec-15
-TNECD.GOV,State/Local Govt,Non-Federal Agency,Nashville,TN,ACTIVE,31-Jul-14,30-Sep-15
-TNEDU.GOV,State/Local Govt,Non-Federal Agency,Nashville,TN,ACTIVE,24-Jun-14,23-Aug-15
-TNIIS.GOV,State/Local Govt,Non-Federal Agency,Smyrna,TN,ACTIVE,28-Aug-14,29-Aug-15
-TNINVESTCO.GOV,State/Local Govt,Non-Federal Agency,Nashville,TN,ACTIVE,3-Aug-14,22-Oct-15
-TNK12.GOV,State/Local Govt,Non-Federal Agency,Nashville,TN,ACTIVE,24-Jun-14,23-Aug-15
-TNPROMISE.GOV,State/Local Govt,Non-Federal Agency,Smyrna,TN,ACTIVE,23-Jun-14,23-Jun-15
-TNQUITLINE.GOV,State/Local Govt,Non-Federal Agency,Smyrna,TN,ACTIVE,5-Sep-14,5-Sep-15
-TNRECONNECT.GOV,State/Local Govt,Non-Federal Agency,Smyrna,TN,ACTIVE,18-Dec-14,18-Dec-15
-TNTOOLKIT.GOV,State/Local Govt,Non-Federal Agency,Smyrna,TN,ACTIVE,18-Jun-14,19-Jun-15
-TNTREASURY.GOV,State/Local Govt,Non-Federal Agency,Nashville,TN,ACTIVE,31-Jul-14,27-Sep-15
-TNVACATION.GOV,State/Local Govt,Non-Federal Agency,Nashville,TN,ACTIVE,20-Oct-14,11-Dec-15
-TOMGREENCOUNTYTX.GOV,State/Local Govt,Non-Federal Agency,San Angelo,TX,ACTIVE,10-Sep-14,30-Sep-15
-TOURISMOHIO.GOV,State/Local Govt,Non-Federal Agency,Columbus,OH,ACTIVE,22-Apr-14,23-May-15
-TOWERLAKES-IL.GOV,State/Local Govt,Non-Federal Agency,Tower Lakes,IL,ACTIVE,23-Feb-15,22-May-16
-TOWNOFDUNNWI.GOV,State/Local Govt,Non-Federal Agency,McFarland,WI,ACTIVE,17-Nov-14,21-Nov-15
-TOWNOFGOLDENMEADOW-LA.GOV,State/Local Govt,Non-Federal Agency,Golden Meadow,LA,ACTIVE,5-Jan-15,3-Jan-16
-TOWNOFRAMAPO-NY.GOV,State/Local Govt,Non-Federal Agency,Suffern,NY,ACTIVE,8-Jul-14,21-Sep-15
-TOWNOFRIVERHEADNY.GOV,State/Local Govt,Non-Federal Agency,Riverhead,NY,ACTIVE,20-Aug-14,21-Sep-15
-TOWNOFSMYRNA-TN.GOV,State/Local Govt,Non-Federal Agency,Smyrna,TN,ACTIVE,15-Dec-14,12-Jan-16
-TOWNOFTROUTVILLE-VA.GOV,State/Local Govt,Non-Federal Agency,Troutville,VA,ACTIVE,8-May-14,8-May-15
-TOWNOFWALLINGFORD-CT.GOV,State/Local Govt,Non-Federal Agency,Wallingford,CT,ACTIVE,10-Sep-12,24-Sep-13
-TOWNOFWINGATENC.GOV,State/Local Govt,Non-Federal Agency,Wingate,NC,ACTIVE,5-Nov-14,4-Jan-16
-TRANSPARENCYFLORIDA.GOV,State/Local Govt,Non-Federal Agency,Tallahassee,FL,ACTIVE,8-Jul-14,16-Jul-15
-TRANSPARENCYWV.GOV,State/Local Govt,Non-Federal Agency,Charleston,WV,ACTIVE,1-Aug-14,11-Oct-15
-TRUSTTENNESSEE.GOV,State/Local Govt,Non-Federal Agency,Nashville,TN,ACTIVE,5-Feb-15,5-Feb-16
-TRUSTTN.GOV,State/Local Govt,Non-Federal Agency,Nashville,TN,ACTIVE,5-Feb-15,5-Feb-16
-TTD.GOV,State/Local Govt,Non-Federal Agency,East Norwalk,CT,ACTIVE,15-Oct-13,26-Oct-14
-TUCSONAZ.GOV,State/Local Govt,Non-Federal Agency,Tucson,AZ,ACTIVE,7-Aug-14,7-Sep-15
-TUPPERLAKENY.GOV,State/Local Govt,Non-Federal Agency,Tupper Lake,NY,ACTIVE,11-Jun-14,21-Aug-15
-TUSCALOOSA-AL.GOV,State/Local Govt,Non-Federal Agency,Tuscaloosa,AL,ACTIVE,6-Aug-13,30-Sep-14
-TX.GOV,State/Local Govt,Non-Federal Agency,Austin,TX,ACTIVE,30-Sep-14,30-Sep-15
-TX511.GOV,State/Local Govt,Non-Federal Agency,Austin,TX,ACTIVE,27-Feb-15,12-Feb-16
-TXAG.GOV,State/Local Govt,Non-Federal Agency,Austin,TX,ACTIVE,9-Mar-15,16-May-16
-TXCOURTS.GOV,State/Local Govt,Non-Federal Agency,Austin,TX,ACTIVE,4-Apr-14,14-May-15
-TXDMV.GOV,State/Local Govt,Non-Federal Agency,Austin,TX,ACTIVE,15-Nov-12,20-Oct-13
-TXDOT.GOV,State/Local Govt,Non-Federal Agency,Austin,TX,ACTIVE,12-Mar-15,4-May-16
-TXDPS.GOV,State/Local Govt,Non-Federal Agency,Austin,TX,ACTIVE,21-Oct-14,18-Jan-16
-TXFILE.GOV,State/Local Govt,Non-Federal Agency,Austin,TX,ACTIVE,14-Nov-14,3-Jan-16
-TXMAP.GOV,State/Local Govt,Non-Federal Agency,Austin,TX,ACTIVE,19-Mar-14,15-Apr-15
-TXOAG.GOV,State/Local Govt,Non-Federal Agency,Austin,TX,ACTIVE,9-Mar-15,16-May-16
-UNITYNH.GOV,State/Local Govt,Non-Federal Agency,Charlestown,NH,ACTIVE,30-Jul-14,5-Sep-15
-US41WISCONSIN.GOV,State/Local Govt,Non-Federal Agency,Madison,WI,ACTIVE,11-Mar-14,8-Jun-15
-UTAH.GOV,State/Local Govt,Non-Federal Agency,Salt Lake City,UT,ACTIVE,22-Aug-14,30-Sep-15
-UTAHLAKE.GOV,State/Local Govt,Non-Federal Agency,Salt Lake City,UT,ACTIVE,30-Dec-14,16-Mar-16
-UTAHTRUST.GOV,State/Local Govt,Non-Federal Agency,North Salt Lake,UT,ACTIVE,22-Mar-13,20-Jun-14
-UTCOURTS.GOV,State/Local Govt,Non-Federal Agency,Salt Lake City,UT,ACTIVE,8-Jul-14,30-Sep-15
-VACOURTS.GOV,State/Local Govt,Non-Federal Agency,Richmond,VA,ACTIVE,9-Mar-15,9-Mar-16
-VAEMERGENCY.GOV,State/Local Govt,Non-Federal Agency,Richmond,VA,ACTIVE,16-Jul-14,16-Sep-15
-VBHIL.GOV,State/Local Govt,Non-Federal Agency,Barrington Hills,IL,ACTIVE,20-Nov-14,13-Feb-16
-VERMONT.GOV,State/Local Govt,Non-Federal Agency,Montpelier,VT,ACTIVE,2-Jul-14,30-Sep-15
-VERMONTHEALTHCONNECT.GOV,State/Local Govt,Non-Federal Agency,Montpelier,VT,ACTIVE,21-Oct-14,20-Nov-15
-VERMONTTAXAMNESTY.GOV,State/Local Govt,Non-Federal Agency,Montpelier,VT,ACTIVE,15-Jul-14,16-Jul-15
-VERMONTTREASURER.GOV,State/Local Govt,Non-Federal Agency,Montpelier,VT,ACTIVE,12-Jun-14,10-Sep-15
-VERMONTVOTESFORKIDS.GOV,State/Local Govt,Non-Federal Agency,Montpelier,VT,ACTIVE,19-Feb-14,9-Apr-15
-VERNONTWP-PA.GOV,State/Local Govt,Non-Federal Agency,Meadville,PA,ACTIVE,7-Jul-14,30-Sep-15
-VI.GOV,State/Local Govt,Non-Federal Agency,St. Thomas,VI,ACTIVE,19-Nov-14,6-Dec-15
-VIALERT.GOV,State/Local Govt,Non-Federal Agency,St. Thomas,VI,ACTIVE,20-Jun-14,20-Apr-15
-VIBIR.GOV,State/Local Govt,Non-Federal Agency,St. Thomas,VI,ACTIVE,27-Aug-14,12-Jul-15
-VIDOL.GOV,State/Local Govt,Non-Federal Agency,St. Thomas,VI,ACTIVE,30-Sep-14,30-Sep-15
-VIHFA.GOV,State/Local Govt,Non-Federal Agency,St. Thomas,VI,ACTIVE,2-Jul-10,30-Sep-11
-VILLAGEOFPENINSULA-OH.GOV,State/Local Govt,Non-Federal Agency,Peninsula,OH,ACTIVE,12-Jun-14,13-Jun-15
-VILLAGEOFSCOTIANY.GOV,State/Local Govt,Non-Federal Agency,Scotia,NY,ACTIVE,22-Aug-14,13-Sep-15
-VINTONVA.GOV,State/Local Govt,Non-Federal Agency,Vinton,VA,ACTIVE,3-Sep-14,30-Sep-15
-VIRGINIA.GOV,State/Local Govt,Non-Federal Agency,Chester,VA,ACTIVE,17-Jul-14,20-Sep-15
-VIRGINIACAPITAL.GOV,State/Local Govt,Non-Federal Agency,Richmond,VA,ACTIVE,8-Jan-15,9-Mar-16
-VIRGINIACAPITOL.GOV,State/Local Govt,Non-Federal Agency,Richmond,VA,ACTIVE,2-Jul-14,30-Sep-15
-VIRGINIAGENERALASSEMBLY.GOV,State/Local Govt,Non-Federal Agency,Richmond,VA,ACTIVE,10-Mar-15,3-May-16
-VIRGINIASTATEPARKS.GOV,State/Local Govt,Non-Federal Agency,Richmond,VA,ACTIVE,28-Oct-14,24-Jan-16
-VISITIDAHO.GOV,State/Local Govt,Non-Federal Agency,Boise,ID,ACTIVE,17-Jul-14,15-Sep-15
-VISITNEBRASKA.GOV,State/Local Govt,Non-Federal Agency,Lincoln,NE,ACTIVE,12-Nov-14,11-Jan-16
-VISITNH.GOV,State/Local Govt,Non-Federal Agency,Concord,NH,ACTIVE,30-Sep-14,30-Sep-15
-VISITWYO.GOV,State/Local Govt,Non-Federal Agency,Cheyenne,WY,ACTIVE,21-Jan-15,21-Apr-16
-VISITWYOMING.GOV,State/Local Govt,Non-Federal Agency,Cheyenne,WY,ACTIVE,17-Mar-14,13-Jun-15
-VITEMA.GOV,State/Local Govt,Non-Federal Agency,St. Thomas,VI,ACTIVE,7-Aug-13,21-Jun-13
-VIVOTE.GOV,State/Local Govt,Non-Federal Agency,St Croix,VI,ACTIVE,1-Aug-12,30-Sep-13
-VOLUNTEERLOUISIANA.GOV,State/Local Govt,Non-Federal Agency,Baton Rouge,LA,ACTIVE,14-Jan-14,12-Apr-15
-VOTETEXAS.GOV,State/Local Govt,Non-Federal Agency,Austin,TX,ACTIVE,10-Nov-14,1-Dec-15
-VT.GOV,State/Local Govt,Non-Federal Agency,Montpelier,VT,ACTIVE,2-Jul-14,30-Sep-15
-VTALERT.GOV,State/Local Govt,Non-Federal Agency,Montpelier,VT,ACTIVE,25-Nov-14,20-Feb-16
-WA.GOV,State/Local Govt,Non-Federal Agency,Olympia,WA,ACTIVE,8-Jul-14,30-Sep-15
-WADNR.GOV,State/Local Govt,Non-Federal Agency,Olympia,WA,ACTIVE,16-Sep-14,30-Sep-15
-WAKECOUNTYNC.GOV,State/Local Govt,Non-Federal Agency,Raleigh,NC,ACTIVE,16-Nov-12,30-Sep-13
-WALDOCOUNTYME.GOV,State/Local Govt,Non-Federal Agency,Belfast,ME,ACTIVE,10-Aug-14,10-Sep-15
-WALLAWALLAWA.GOV,State/Local Govt,Non-Federal Agency,Walla Walla,WA,ACTIVE,2-Jul-14,30-Sep-15
-WALPOLE-MA.GOV,State/Local Govt,Non-Federal Agency,Walpole,MA,ACTIVE,25-Aug-14,24-Sep-15
-WALTONCOUNTYGA.GOV,State/Local Govt,Non-Federal Agency,Monroe,GA,ACTIVE,3-Jul-14,30-Sep-15
-WARRACRES-OK.GOV,State/Local Govt,Non-Federal Agency,Warr Acres,OK,ACTIVE,21-Sep-14,27-Sep-15
-WARRENPA.GOV,State/Local Govt,Non-Federal Agency,Warren,PA,ACTIVE,1-Jul-14,23-Aug-15
-WASHINGTON-NC.GOV,State/Local Govt,Non-Federal Agency,Washington,NC,ACTIVE,5-Aug-14,30-Sep-15
-WASHINGTON.GOV,State/Local Govt,Non-Federal Agency,Olympia,WA,ACTIVE,19-May-14,19-Jul-15
-WASHINGTONCOUNTYNY.GOV,State/Local Govt,Non-Federal Agency,Fort Edward,NY,ACTIVE,12-Dec-14,12-Dec-15
-WASHINGTONDC.GOV,State/Local Govt,Non-Federal Agency,"Washington,",DC,ACTIVE,7-Aug-14,9-Sep-15
-WASHINGTONNC.GOV,State/Local Govt,Non-Federal Agency,Washington,NC,ACTIVE,5-Aug-14,30-Sep-15
-WASHINGTONPA.GOV,State/Local Govt,Non-Federal Agency,Washington,PA,ACTIVE,13-Nov-14,13-Nov-15
-WASHINGTONSTATE.GOV,State/Local Govt,Non-Federal Agency,Olympia,WA,ACTIVE,19-May-14,19-Jul-15
-WASHINGTONVILLE-NY.GOV,State/Local Govt,Non-Federal Agency,Washingtonville,NY,ACTIVE,21-Oct-14,7-Dec-14
-WASHTENAWCOUNTY-MI.GOV,State/Local Govt,Non-Federal Agency,Ann Arbor,MI,ACTIVE,25-Mar-14,18-Mar-15
-WATAUGACOUNTYNC.GOV,State/Local Govt,Non-Federal Agency,Boone,NC,ACTIVE,2-Jul-14,30-Sep-15
-WAUKESHACOUNTY-WI.GOV,State/Local Govt,Non-Federal Agency,Waukesha,WI,ACTIVE,21-Jul-14,7-Sep-15
-WAUKESHACOUNTY.GOV,State/Local Govt,Non-Federal Agency,Waukesha,WI,ACTIVE,21-Jul-14,7-Sep-15
-WAYNECOUNTYMS.GOV,State/Local Govt,Non-Federal Agency,Waynesboro,MS,ACTIVE,23-Oct-14,30-Sep-15
-WCNYH.GOV,State/Local Govt,Non-Federal Agency,New YOrk,NY,ACTIVE,7-Jan-14,30-Mar-15
-WEBBCOUNTYTX.GOV,State/Local Govt,Non-Federal Agency,Laredo,TX,ACTIVE,2-Oct-14,30-Sep-15
-WELCOMEHOMEILLINOIS.GOV,State/Local Govt,Non-Federal Agency,Chicago,IL,ACTIVE,24-Mar-14,24-Mar-15
-WENHAMMA.GOV,State/Local Govt,Non-Federal Agency,Wenham,MA,ACTIVE,27-Aug-14,30-Sep-15
-WESTBENDWI.GOV,State/Local Govt,Non-Federal Agency,West Bend,WI,ACTIVE,22-Aug-14,30-Sep-15
-WESTCHESTERCOUNTYNY.GOV,State/Local Govt,Non-Federal Agency,White Plains,NY,ACTIVE,24-Jul-14,30-Sep-15
-WESTFORKAR.GOV,State/Local Govt,Non-Federal Agency,West Fork,AR,ACTIVE,27-Aug-14,30-Sep-15
-WESTMINSTER-CA.GOV,State/Local Govt,Non-Federal Agency,Westminster,CA,ACTIVE,3-Jun-14,2-Sep-15
-WESTMORELANDTN.GOV,State/Local Govt,Non-Federal Agency,Westmoreland,TN,ACTIVE,3-Mar-15,25-Apr-15
-WESTVALLEYCITY-UT.GOV,State/Local Govt,Non-Federal Agency,West Valley City,UT,ACTIVE,2-Jul-14,30-Sep-15
-WHITMAN-MA.GOV,State/Local Govt,Non-Federal Agency,Whitman,MA,ACTIVE,4-Aug-14,2-Sep-15
-WHYNEVADA.GOV,State/Local Govt,Non-Federal Agency,Carson City,NV,ACTIVE,5-May-14,10-Jun-15
-WI-TIME.GOV,State/Local Govt,Non-Federal Agency,Madison,WI,ACTIVE,8-Jan-13,8-Apr-14
-WI-WORCS.GOV,State/Local Govt,Non-Federal Agency,Madison,WI,ACTIVE,31-Aug-12,29-Nov-13
-WI.GOV,State/Local Govt,Non-Federal Agency,Madison,WI,ACTIVE,25-Aug-14,30-Sep-15
-WIBADGERTRACS.GOV,State/Local Govt,Non-Federal Agency,Madison,WI,ACTIVE,3-Mar-15,23-Apr-16
-WICONNECTIONS2030.GOV,State/Local Govt,Non-Federal Agency,Madison,WI,ACTIVE,7-Jul-14,3-Sep-15
-WICOURTS.GOV,State/Local Govt,Non-Federal Agency,MADISON,WI,ACTIVE,11-Sep-14,30-Sep-15
-WIGRANTS.GOV,State/Local Govt,Non-Federal Agency,Madison,WI,ACTIVE,22-Apr-14,15-Jul-15
-WILAWLIBRARY.GOV,State/Local Govt,Non-Federal Agency,Madison,WI,ACTIVE,16-Dec-14,15-Jan-16
-WILDOHIO.GOV,State/Local Govt,Non-Federal Agency,Columbus,OH,ACTIVE,10-Apr-14,10-Apr-15
-WILLIAMSBURGVA.GOV,State/Local Govt,Non-Federal Agency,Williamsburg,VA,ACTIVE,8-Sep-14,30-Sep-15
-WILMINGTON-NC.GOV,State/Local Govt,Non-Federal Agency,Wilmington,NC,ACTIVE,2-Sep-14,9-Sep-15
-WILMINGTONNC.GOV,State/Local Govt,Non-Federal Agency,Wilmington,NC,ACTIVE,2-Sep-14,9-Sep-15
-WINTERGARDEN-FL.GOV,State/Local Govt,Non-Federal Agency,Winter Garden,FL,ACTIVE,16-Jul-13,30-Sep-13
-WINTERPORTMAINE.GOV,State/Local Govt,Non-Federal Agency,Winterport,ME,ACTIVE,26-Sep-14,30-Sep-15
-WINTERSPRINGSFL.GOV,State/Local Govt,Non-Federal Agency,Winter Springs,FL,ACTIVE,1-Aug-14,30-Sep-15
-WISC.GOV,State/Local Govt,Non-Federal Agency,Madison,WI,ACTIVE,1-Jul-14,30-Sep-15
-WISCONSIN.GOV,State/Local Govt,Non-Federal Agency,Madison,WI,ACTIVE,25-Aug-14,30-Sep-15
-WISCONSINCRIMEALERT.GOV,State/Local Govt,Non-Federal Agency,Madison,WI,ACTIVE,4-Mar-15,10-Feb-16
-WISCONSINDMV.GOV,State/Local Govt,Non-Federal Agency,Madison,WI,ACTIVE,3-Oct-14,15-Oct-15
-WISCONSINDOT.GOV,State/Local Govt,Non-Federal Agency,Madison,WI,ACTIVE,7-Jul-14,3-Sep-15
-WISCONSINRAIL.GOV,State/Local Govt,Non-Federal Agency,Madison,WI,ACTIVE,22-Apr-14,6-Jul-15
-WISCONSINRAILPLAN.GOV,State/Local Govt,Non-Federal Agency,Madison,WI,ACTIVE,11-Nov-14,16-Nov-15
-WISCONSINROUNDABOUTS.GOV,State/Local Govt,Non-Federal Agency,Madison,WI,ACTIVE,3-Mar-15,27-Apr-16
-WMATA.GOV,State/Local Govt,Non-Federal Agency,Washington,DC,ACTIVE,2-Jul-14,30-Sep-15
-WORKFORNC.GOV,State/Local Govt,Non-Federal Agency,Raleigh,NC,ACTIVE,3-Dec-14,3-Dec-15
-WSDOT.GOV,State/Local Govt,Non-Federal Agency,Olympia,WA,ACTIVE,30-Apr-14,16-Jun-15
-WV.GOV,State/Local Govt,Non-Federal Agency,Charleston,WV,ACTIVE,21-Oct-14,30-Sep-15
-WVAGO.GOV,State/Local Govt,Non-Federal Agency,Charleston,WV,ACTIVE,21-Oct-14,20-Dec-15
-WVBTI.GOV,State/Local Govt,Non-Federal Agency,Charleston,WV,ACTIVE,8-Dec-11,22-Feb-13
-WVCOMMERCE.GOV,State/Local Govt,Non-Federal Agency,Charleston,WV,ACTIVE,15-Jul-14,12-Sep-15
-WVCONSUMERPROTECTION.GOV,State/Local Govt,Non-Federal Agency,Charleston,WV,ACTIVE,22-May-14,22-May-15
-WVCSI.GOV,State/Local Govt,Non-Federal Agency,Charleston,WV,ACTIVE,19-May-14,21-May-15
-WVDHSEM.GOV,State/Local Govt,Non-Federal Agency,Charleston,WV,ACTIVE,18-Jul-14,12-Oct-15
-WVDMV.GOV,State/Local Govt,Non-Federal Agency,Charleston,WV,ACTIVE,10-Sep-14,30-Sep-15
-WVDNR.GOV,State/Local Govt,Non-Federal Agency,South Charleston,WV,ACTIVE,18-Sep-14,30-Sep-15
-WVHOUSE.GOV,State/Local Govt,Non-Federal Agency,Charleston,WV,ACTIVE,30-Sep-14,30-Sep-15
-WVINSURANCE.GOV,State/Local Govt,Non-Federal Agency,Charleson,WV,ACTIVE,28-Jul-14,30-Sep-15
-WVLEGISLATURE.GOV,State/Local Govt,Non-Federal Agency,Charleston,WV,ACTIVE,30-Sep-14,30-Sep-15
-WVOASIS.GOV,State/Local Govt,Non-Federal Agency,Charleston,WV,ACTIVE,1-Aug-14,26-Sep-15
-WVOT.GOV,State/Local Govt,Non-Federal Agency,Charleston,WV,ACTIVE,5-Jun-14,21-Jul-15
-WVOTA.GOV,State/Local Govt,Non-Federal Agency,Charleston,WV,ACTIVE,15-Aug-14,30-Sep-15
-WVPRESIDENT.GOV,State/Local Govt,Non-Federal Agency,Morgantown,WV,ACTIVE,19-May-14,14-May-15
-WVPURCHASING.GOV,State/Local Govt,Non-Federal Agency,Charleston,WV,ACTIVE,3-Jun-14,26-Jun-15
-WVREVENUE.GOV,State/Local Govt,Non-Federal Agency,Charleston,WV,ACTIVE,14-Aug-14,30-Sep-15
-WVSAO.GOV,State/Local Govt,Non-Federal Agency,Charleston,WV,ACTIVE,1-Aug-14,26-Aug-15
-WVSENATE.GOV,State/Local Govt,Non-Federal Agency,Charleston,WV,ACTIVE,30-Sep-14,30-Sep-15
-WVSENIORSERVICES.GOV,State/Local Govt,Non-Federal Agency,Charleston,WV,ACTIVE,16-Sep-14,4-Oct-15
-WVSP.GOV,State/Local Govt,Non-Federal Agency,South Charleston,WV,ACTIVE,27-Mar-14,16-May-15
-WVSPEAKER.GOV,State/Local Govt,Non-Federal Agency,Morgantown,WV,ACTIVE,19-May-14,14-May-15
-WVSTO.GOV,State/Local Govt,Non-Federal Agency,Charleston,WV,ACTIVE,27-Aug-14,16-Sep-15
-WVSURPLUS.GOV,State/Local Govt,Non-Federal Agency,Dunbar,WV,ACTIVE,2-Feb-15,14-Feb-16
-WVTAX.GOV,State/Local Govt,Non-Federal Agency,Charleston,WV,ACTIVE,1-Aug-14,30-Sep-15
-WY.GOV,State/Local Govt,Non-Federal Agency,Cheyenne,WY,ACTIVE,14-Jul-14,30-Sep-15
-WYCAMPAIGNFINANCE.GOV,State/Local Govt,Non-Federal Agency,Cheyenne,WY,ACTIVE,30-May-14,28-Aug-15
-WYINVESTORAWARENESS.GOV,State/Local Govt,Non-Federal Agency,Cheyenne,WY,ACTIVE,14-Mar-14,12-Jun-15
-WYO.GOV,State/Local Govt,Non-Federal Agency,Cheyenne,WY,ACTIVE,14-Jul-14,30-Sep-15
-WYOBOARDS.GOV,State/Local Govt,Non-Federal Agency,Cheyenne,WY,ACTIVE,8-Dec-14,4-Feb-16
-WYOLEG.GOV,State/Local Govt,Non-Federal Agency,Cheyenne,WY,ACTIVE,20-Mar-14,9-Jun-15
-WYOMING.GOV,State/Local Govt,Non-Federal Agency,Cheyenne,WY,ACTIVE,14-Jul-14,30-Sep-15
-WYOMINGAGCARE.GOV,State/Local Govt,Non-Federal Agency,Cheyenne,WY,ACTIVE,25-Aug-14,21-Oct-15
-WYOMINGFOSTERCARE.GOV,State/Local Govt,Non-Federal Agency,Cheyenne,WY,ACTIVE,7-Apr-13,5-Jul-14
-WYOMINGLMI.GOV,State/Local Govt,Non-Federal Agency,cheyenne,WY,ACTIVE,9-Feb-15,7-May-16
-WYOMINGOFFICEOFTOURISM.GOV,State/Local Govt,Non-Federal Agency,Cheyenne,WY,ACTIVE,24-Dec-14,24-Mar-16
-WYOREG.GOV,State/Local Govt,Non-Federal Agency,cheyenne,WY,ACTIVE,8-Mar-14,5-Jun-15
-WYWINDFALL.GOV,State/Local Govt,Non-Federal Agency,cheyenne,WY,ACTIVE,14-Jul-14,12-Oct-15
-YADKINCOUNTY.GOV,State/Local Govt,Non-Federal Agency,Yadkinville,NC,ACTIVE,15-Jul-14,7-Sep-15
-YADKINCOUNTYNC.GOV,State/Local Govt,Non-Federal Agency,Yadkinville,NC,ACTIVE,15-Jul-14,7-Sep-15
-YAMHILLCOUNTY-OR.GOV,State/Local Govt,Non-Federal Agency,McMinnville,OR,ACTIVE,2-Jul-14,30-Sep-15
-YANCEYVILLENC.GOV,State/Local Govt,Non-Federal Agency,Roxboro,NC,ACTIVE,28-May-14,26-Aug-15
-YUCAIPA-CA.GOV,State/Local Govt,Non-Federal Agency,Yucaipa,CA,ACTIVE,6-Sep-11,30-Sep-12
-ZAPATACOUNTYTX.GOV,State/Local Govt,Non-Federal Agency,Zapata,TX,ACTIVE,12-Dec-12,12-Dec-13
-ZEROINWISCONSIN.GOV,State/Local Govt,Non-Federal Agency,Madison,WI,ACTIVE,1-Dec-14,30-Dec-15
-ZIONSVILLE-IN.GOV,State/Local Govt,Non-Federal Agency,Zionsville,IN,ACTIVE,3-Sep-14,3-Sep-15
+Domain Name,Domain Type,Agency,City,State
+18F.GOV,Federal Agency,General Services Administration,Washington,DC
+ACUS.GOV,Federal Agency,Administrative Conference of the United States,WASHINGTON,DC
+ACHP.GOV,Federal Agency,Advisory Council on Historic Preservation,Washington,DC
+PRESERVEAMERICA.GOV,Federal Agency,Advisory Council on Historic Preservation,Washington,DC
+ADF.GOV,Federal Agency,African Development Foundation,Washington,DC
+USADF.GOV,Federal Agency,African Development Foundation,Washington,DC
+ABMC.GOV,Federal Agency,American Battle Monuments Commission,Arlington,VA
+AMTRAKOIG.GOV,Federal Agency,AMTRAK,Washington,DC
+ARC.GOV,Federal Agency,Appalachian Regional Commission,Washington,DC
+ASC.GOV,Federal Agency,Appraisal Subcommittee,Washington,DC
+AFRH.GOV,Federal Agency,Armed Forces Retirement Home,Washington,DC
+CIA.GOV,Federal Agency,Central Intelligence Agency,Washington,DC
+IC.GOV,Federal Agency,Central Intelligence Agency,Washington,DC
+ISTAC.GOV,Federal Agency,Central Intelligence Agency,Washington,DC
+NCTC.GOV,Federal Agency,Central Intelligence Agency,Washington,DC
+ODCI.GOV,Federal Agency,Central Intelligence Agency,Washington,DC
+OPENSOURCE.GOV,Federal Agency,Central Intelligence Agency,Washington,DC
+OSDE.GOV,Federal Agency,Central Intelligence Agency,Reston,VA
+TTIC.GOV,Federal Agency,Central Intelligence Agency,Washington,DC
+UCIA.GOV,Federal Agency,Central Intelligence Agency,Washington,DC
+CHRISTOPHERCOLUMBUSFOUNDATION.GOV,Federal Agency,Christopher Columbus Fellowship Foundation,Washington,DC
+CAP.GOV,Federal Agency,Civil Air Patrol,BIRMINGHAM,MI
+CAPNHQ.GOV,Federal Agency,Civil Air Patrol,MAXWELL AFB,AL
+ABILITYONE.FED.US,Federal Agency,Comm for People Who Are Blind/Severly Disabled,Arlington,VA
+ABILITYONE.GOV,Federal Agency,Comm for People Who Are Blind/Severly Disabled,Arlington,VA
+JWOD.GOV,Federal Agency,Comm for People Who Are Blind/Severly Disabled,Arlington,VA
+CFTC.GOV,Federal Agency,Commodity Futures Trading Commission,Washington,DC
+SMARTCHECK.GOV,Federal Agency,Commodity Futures Trading Commission,Washington,DC
+COMPLIANCE.GOV,Federal Agency,Congressional Office of Compliance,Washington,DC
+BCFP.GOV,Federal Agency,Consumer Financial Protection Bureau,Washington,DC
+CFPA.GOV,Federal Agency,Consumer Financial Protection Bureau,Washington,DC
+CFPB.GOV,Federal Agency,Consumer Financial Protection Bureau,Washington,DC
+CONSUMERBUREAU.GOV,Federal Agency,Consumer Financial Protection Bureau,Washington,DC
+CONSUMERFINANCE.GOV,Federal Agency,Consumer Financial Protection Bureau,Washington,DC
+CONSUMERFINANCIAL.GOV,Federal Agency,Consumer Financial Protection Bureau,Washington,DC
+CONSUMERFINANCIALBUREAU.GOV,Federal Agency,Consumer Financial Protection Bureau,Washington,DC
+CONSUMERFINANCIALPROTECTIONBUREAU.GOV,Federal Agency,Consumer Financial Protection Bureau,Washington,DC
+CONSUMERPROTECTION.GOV,Federal Agency,Consumer Financial Protection Bureau,Washington,DC
+CONSUMERPROTECTIONBUREAU.GOV,Federal Agency,Consumer Financial Protection Bureau,Washington,DC
+ATVSAFETY.GOV,Federal Agency,Consumer Product Safety Commission,Bethesda,MD
+CPSC.GOV,Federal Agency,Consumer Product Safety Commission,Bethesda,MD
+DRYWALLRESPONSE.GOV,Federal Agency,Consumer Product Safety Commission,Bethesda,MD
+POOLSAFELY.GOV,Federal Agency,Consumer Product Safety Commission,Bethesda,MD
+POOLSAFETY.GOV,Federal Agency,Consumer Product Safety Commission,Bethesda,MD
+RECALLS.GOV,Federal Agency,Consumer Product Safety Commission,Bethesda,MD
+SAFERPRODUCT.GOV,Federal Agency,Consumer Product Safety Commission,Bethesda,MD
+SAFERPRODUCTS.GOV,Federal Agency,Consumer Product Safety Commission,Bethesda,MD
+SEGURIDADCONSUMIDOR.GOV,Federal Agency,Consumer Product Safety Commission,Bethesda,MD
+AMERICORE.GOV,Federal Agency,Corporation for National & Community Service,Washington,DC
+AMERICORP.GOV,Federal Agency,Corporation for National & Community Service,Washington,DC
+AMERICORPS.GOV,Federal Agency,Corporation for National & Community Service,Washington,DC
+AMERICORPSCONNECT.GOV,Federal Agency,Corporation for National & Community Service,Washington,DC
+AMERICORPSWEEK.GOV,Federal Agency,Corporation for National & Community Service,Washington,DC
+CNCS.GOV,Federal Agency,Corporation for National & Community Service,Washington,DC
+CNCSOIG.GOV,Federal Agency,Corporation for National & Community Service,Washington,DC
+CNS.GOV,Federal Agency,Corporation for National & Community Service,Washington,DC
+FEDERALMENTORINGCOUNCIL.GOV,Federal Agency,Corporation for National & Community Service,Washington,DC
+GETINVOLVED.GOV,Federal Agency,Corporation for National & Community Service,Washington ,DC
+LEARNANDSERVE.GOV,Federal Agency,Corporation for National & Community Service,Washington,DC
+MLKDAY.GOV,Federal Agency,Corporation for National & Community Service,Washington,DC
+NATIONALSERVICE.GOV,Federal Agency,Corporation for National & Community Service,Washington,DC
+NATIONALSERVICEGEAR.GOV,Federal Agency,Corporation for National & Community Service,Washington,DC
+NATIONALSERVICERESOURCES.GOV,Federal Agency,Corporation for National & Community Service,Washington,DC
+PRESIDENTIALSERVICEAWARDS.GOV,Federal Agency,Corporation for National & Community Service,Washington,DC
+SENIORCORPS.GOV,Federal Agency,Corporation for National & Community Service,Washington,DC
+SERVE.GOV,Federal Agency,Corporation for National & Community Service,Washington,DC
+SERVICE.GOV,Federal Agency,Corporation for National & Community Service,Washington,DC
+SERVICELEARNING.GOV,Federal Agency,Corporation for National & Community Service,Washington ,DC
+SERVIR.GOV,Federal Agency,Corporation for National & Community Service,Washington,DC
+VISTA.GOV,Federal Agency,Corporation for National & Community Service,Washington,DC
+VISTACAMPUS.GOV,Federal Agency,Corporation for National & Community Service,Washington,DC
+VOLUNTEERINGINAMERICA.GOV,Federal Agency,Corporation for National & Community Service,Washington,DC
+CIGIE.GOV,Federal Agency,Council of Inspector General on Integrity and Efficiency,WASHINGTON,DC
+IGNET.GOV,Federal Agency,Council of Inspector General on Integrity and Efficiency,Washington,DC
+CSOSA.FED.US,Federal Agency,Court Services and Offender Supervision,Washington,DC
+CSOSA.GOV,Federal Agency,Court Services and Offender Supervision,Washington,DC
+DCPSA.GOV,Federal Agency,Court Services and Offender Supervision,Washington,DC
+PRETRIALSERVICES.GOV,Federal Agency,Court Services and Offender Supervision,Washington,DC
+PSA.GOV,Federal Agency,Court Services and Offender Supervision,Washington,DC
+DNFSB.GOV,Federal Agency,Defense Nuclear Facilities Safety Board,Washington,DC
+DRA.GOV,Federal Agency,Delta Regional Authority,Clarksdale,MS
+DENALI.GOV,Federal Agency,Denali Commission,Anchorage,AK
+AFF.GOV,Federal Agency,Department of Agriculture,Boise,ID
+AG.GOV,Federal Agency,Department of Agriculture,Fort Collins,CO
+ARS-GRIN.GOV,Federal Agency,Department of Agriculture,Beltsville,MD
+ARSUSDA.GOV,Federal Agency,Department of Agriculture,Beltsville,MD
+ASKKAREN.GOV,Federal Agency,Department of Agriculture,Washington,DC
+BEFOODSAFE.GOV,Federal Agency,Department of Agriculture,Washington,DC
+BIOPREFERRED.GOV,Federal Agency,Department of Agriculture,Washington,DC
+CHOOSEMYPLATE.GOV,Federal Agency,Department of Agriculture,Alexandria,VA
+COASTALAMERICA.GOV,Federal Agency,Department of Agriculture,Washington,DC
+DIETARYGUIDELINES.GOV,Federal Agency,Department of Agriculture,Alexandria,VA
+EMPOWHR.GOV,Federal Agency,Department of Agriculture,New Orleans,LA
+EXECSEC.GOV,Federal Agency,Department of Agriculture,Washington,DC
+FARMERCLAIMS.GOV,Federal Agency,Department of Agriculture,St. Louis,MO
+FEMALEFARMERCLAIMS.GOV,Federal Agency,Department of Agriculture,St. Louis,MO
+FIREINSTITUTE.GOV,Federal Agency,Department of Agriculture,Tucson,AZ
+FOODSAFETYJOBS.GOV,Federal Agency,Department of Agriculture,Washington,DC
+FOODSAFETYWORKINGGROUP.GOV,Federal Agency,Department of Agriculture,Washington,DC
+FORESTSANDRANGELANDS.GOV,Federal Agency,Department of Agriculture,Washington,DC
+FS.FED.US,Federal Agency,Department of Agriculture,Washington,DC
+FSWG.GOV,Federal Agency,Department of Agriculture,Washington,DC
+GREEN.GOV,Federal Agency,Department of Agriculture,Washington,DC
+HISPANICFARMERCLAIMS.GOV,Federal Agency,Department of Agriculture,St. Louis,MO
+ICBEMP.GOV,Federal Agency,Department of Agriculture,Portland,OR
+IIOG.GOV,Federal Agency,Department of Agriculture,Meridian,ID
+INVASIVESPECIESINFO.GOV,Federal Agency,Department of Agriculture,Beltsville,MD
+IPM.GOV,Federal Agency,Department of Agriculture,Washington,DC
+ISITDONEYET.GOV,Federal Agency,Department of Agriculture,Washington,DC
+ITAP.GOV,Federal Agency,Department of Agriculture,Beltsville,MD
+JUNIORFORESTRANGER.GOV,Federal Agency,Department of Agriculture,Washington,DC
+LATINOFARMERCLAIMS.GOV,Federal Agency,Department of Agriculture,St. Louis,MO
+LCACOMMONS.GOV,Federal Agency,Department of Agriculture,Beltsville,MD
+MTBS.GOV,Federal Agency,Department of Agriculture,Salt Lake City,UT
+NAFRI.GOV,Federal Agency,Department of Agriculture,Tucson,AZ
+NEL.GOV,Federal Agency,Department of Agriculture,Alexandria,VA
+NSTL.GOV,Federal Agency,Department of Agriculture,Ames,IA
+NUTRITION.GOV,Federal Agency,Department of Agriculture,Washington,DC
+NUTRITIONEVIDENCELIBRARY.GOV,Federal Agency,Department of Agriculture,Alexandria,VA
+NWCG.GOV,Federal Agency,Department of Agriculture,Boise,ID
+PREGUNTELEAKAREN.GOV,Federal Agency,Department of Agriculture,Washington,DC
+RECREATION.GOV,Federal Agency,Department of Agriculture,Ogden,UT
+REO.GOV,Federal Agency,Department of Agriculture,Portland,OR
+SMOKEYBEAR.GOV,Federal Agency,Department of Agriculture,Washington,DC
+START2FARM.GOV,Federal Agency,Department of Agriculture,Beltsville,MD
+SYMBOLS.GOV,Federal Agency,Department of Agriculture,Washington,DC
+THEPEOPLESGARDEN.GOV,Federal Agency,Department of Agriculture,Wahington,DC
+USDA.GOV,Federal Agency,Department of Agriculture,Ft. Collins,CO
+USDAPII.GOV,Federal Agency,Department of Agriculture,Washington,DC
+VALLESCALDERA.GOV,Federal Agency,Department of Agriculture,Jemez Springs,NM
+WILDFIRE.GOV,Federal Agency,Department of Agriculture,Boise,ID
+WOMENFARMERCLAIMS.GOV,Federal Agency,Department of Agriculture,St. Louis,MO
+WOODSY.GOV,Federal Agency,Department of Agriculture,Washington,DC
+WOODSYOWL.GOV,Federal Agency,Department of Agriculture,Washington,DC
+AP.GOV,Federal Agency,Department of Commerce,Washington,DC
+AVIATIONWEATHER.GOV,Federal Agency,Department of Commerce,Silver Spring,MD
+BEA.GOV,Federal Agency,Department of Commerce,Washington,DC
+BLDRDOC.GOV,Federal Agency,Department of Commerce,Boulder,CO
+BUYUSA.GOV,Federal Agency,Department of Commerce,Washington,DC
+CBP.GOV,Federal Agency,Department of Commerce,Alexandria,VA
+CENSUS.GOV,Federal Agency,Department of Commerce,Suitland,MD
+CIVILRIGHTSUSA.GOV,Federal Agency,Department of Commerce,Alexandria,VA
+CLIMATE.GOV,Federal Agency,Department of Commerce,Silver Spring,MD
+CLIMATECHANGE.GOV,Federal Agency,Department of Commerce,Oak Ridge,TN
+COMMERCE.GOV,Federal Agency,Department of Commerce,Washington,DC
+COOP-USPTO.GOV,Federal Agency,Department of Commerce,Arlington,VA
+DIGITALLITERACY.GOV,Federal Agency,Department of Commerce,Washington,DC
+DNSOPS.GOV,Federal Agency,Department of Commerce,Gaithersburg,MD
+DOC.GOV,Federal Agency,Department of Commerce,Washington,DC
+DROUGHT.GOV,Federal Agency,Department of Commerce,Asheville,NC
+E3.GOV,Federal Agency,Department of Commerce,Gaithersburg,MD
+EDA.GOV,Federal Agency,Department of Commerce,Washington,DC
+ESA.GOV,Federal Agency,Department of Commerce,Washington,DC
+EXPORT.GOV,Federal Agency,Department of Commerce,Washington,DC
+FCSM.GOV,Federal Agency,Department of Commerce,Suitland,MD
+FEDSTATS.GOV,Federal Agency,Department of Commerce,Washington,DC
+FIRSTNET.GOV,Federal Agency,Department of Commerce,Washington,DC
+FISHWATCH.GOV,Federal Agency,Department of Commerce,Silver Spring,MD
+GETYOUHOME.GOV,Federal Agency,Department of Commerce,Alexandria,VA
+GLOBALENTRY.GOV,Federal Agency,Department of Commerce,Alexandria,VA
+GOES-R.GOV,Federal Agency,Department of Commerce,Greenbelt,MD
+GPS.GOV,Federal Agency,Department of Commerce,Washington,DC
+HURRICANES.GOV,Federal Agency,Department of Commerce,Miami,FL
+ITDS.GOV,Federal Agency,Department of Commerce,Springfield,VA
+MANUFACTURING.GOV,Federal Agency,Department of Commerce,Washington,DC
+MAPSTATS.GOV,Federal Agency,Department of Commerce,Washington,DC
+MARINECADASTRE.GOV,Federal Agency,Department of Commerce,Charleston,SC
+MBDA.GOV,Federal Agency,Department of Commerce,Washington,DC
+NEHRP.GOV,Federal Agency,Department of Commerce,Gaithersburg,MD
+NIST.GOV,Federal Agency,Department of Commerce,Gaithersburg,MD
+NOAA.GOV,Federal Agency,Department of Commerce,Silver Spring,MD
+NOAAWATCH.GOV,Federal Agency,Department of Commerce,Silver Spring,MD
+NTIS.GOV,Federal Agency,Department of Commerce,Alexandria,VA
+OFCM.GOV,Federal Agency,Department of Commerce,Silver Spring,MD
+PAPAHANAUMOKUAKEA.GOV,Federal Agency,Department of Commerce,Silver Spring,MD
+PSCR.GOV,Federal Agency,Department of Commerce,Boulder,CO
+RESTORETHEGULF.GOV,Federal Agency,Department of Commerce,Silver Spring,MD
+SDR.GOV,Federal Agency,Department of Commerce,Washington,DC
+SELECTUSA.GOV,Federal Agency,Department of Commerce,Washington,DC
+SPACEWEATHER.GOV,Federal Agency,Department of Commerce,Boulder,CO
+SPECTRUM.GOV,Federal Agency,Department of Commerce,Washington,DC
+STANDARDS.GOV,Federal Agency,Department of Commerce,Gaithersburg,MD
+TIME.GOV,Federal Agency,Department of Commerce,Boulder,CO
+TRADE.GOV,Federal Agency,Department of Commerce,Washington,DC
+TSUNAMI.GOV,Federal Agency,Department of Commerce,Palmer,AK
+USPTO.GOV,Federal Agency,Department of Commerce,Washington,DC
+WDOL.GOV,Federal Agency,Department of Commerce,Alexandria,VA
+WEATHER.GOV,Federal Agency,Department of Commerce,Silver Spring,MD
+ADLNET.GOV,Federal Agency,Department of Defense,Washington,DC
+AFTAC.GOV,Federal Agency,Department of Defense,Patrick AFB,FL
+ALTUSANDC.GOV,Federal Agency,Department of Defense,"patrick, afb",FL
+BRAC.GOV,Federal Agency,Department of Defense,Alexandria,VA
+CMTS.GOV,Federal Agency,Department of Defense,Mobile,AL
+CNSS.GOV,Federal Agency,Department of Defense,Ft George G. Meade,MD
+CTTSO.GOV,Federal Agency,Department of Defense,Arlington,VA
+DEFENSE.GOV,Federal Agency,Department of Defense,Fort Meade,MD
+DOD.GOV,Federal Agency,Department of Defense,Fort Meade,MD
+EACLEARINGHOUSE.GOV,Federal Agency,Department of Defense,Arlington,VA
+ERDC.GOV,Federal Agency,Department of Defense,Vicksburg,MS
+FVAP.GOV,Federal Agency,Department of Defense,Alexandria,VA
+IAD.GOV,Federal Agency,Department of Defense,Ft Meade,MD
+IOSS.GOV,Federal Agency,Department of Defense,Greenbelt,MD
+ITC.GOV,Federal Agency,Department of Defense,Ft. Washington,MD
+JCCS.GOV,Federal Agency,Department of Defense,Alexandria,VA
+MCRMC.GOV,Federal Agency,Department of Defense,Arlington,VA
+MOJAVEDATA.GOV,Federal Agency,Department of Defense,Barstow,CA
+MTMC.GOV,Federal Agency,Department of Defense,Alexandria,VA
+MYPAY.GOV,Federal Agency,Department of Defense,Pensacola,FL
+NCR.GOV,Federal Agency,Department of Defense,Washington,DC
+NRO.GOV,Federal Agency,Department of Defense,Chantilly,VA
+NROJR.GOV,Federal Agency,Department of Defense,Chantilly,VA
+NSA.GOV,Federal Agency,Department of Defense,Ft. Meade,MD
+NSEP.GOV,Federal Agency,Department of Defense,Arlington,VA
+OEA.GOV,Federal Agency,Department of Defense,Arlington,VA
+OSDBU.GOV,Federal Agency,Department of Defense,Washington,DC
+PENTAGON.GOV,Federal Agency,Department of Defense,Fort Meade,MD
+SAFEXCHANGE.GOV,Federal Agency,Department of Defense,Falls Church,VA
+SITEIDIQ.GOV,Federal Agency,Department of Defense,Arlington,VA
+TSWG.GOV,Federal Agency,Department of Defense,Arlington,VA
+USANDC.GOV,Federal Agency,Department of Defense,Patrick AFB,FL
+AAPI.GOV,Federal Agency,Department of Education,Washington,DC
+BFELOB.GOV,Federal Agency,Department of Education,Washington,DC
+CHILDSTATS.GOV,Federal Agency,Department of Education,Washington,DC
+COLLEGE.GOV,Federal Agency,Department of Education,Washington,DC
+COLLEGENAVIGATOR.GOV,Federal Agency,Department of Education,Washington,DC
+ED.GOV,Federal Agency,Department of Education,Washington,DC
+EDPUBS.GOV,Federal Agency,Department of Education,Washington ,DC
+EDUCATION.GOV,Federal Agency,Department of Education,Washington,DC
+FAFSA.GOV,Federal Agency,Department of Education,Washington,DC
+FSAPUBS.GOV,Federal Agency,Department of Education,Washington,DC
+G5.GOV,Federal Agency,Department of Education,Washington,DC
+NAGB.GOV,Federal Agency,Department of Education,Washington,DC
+NATIONSREPORTCARD.GOV,Federal Agency,Department of Education,Washington,DC
+OPPORTUNITY.GOV,Federal Agency,Department of Education,Washington,DC
+STUDENTAID.GOV,Federal Agency,Department of Education,Washington,DC
+STUDENTLOANS.GOV,Federal Agency,Department of Education,Washington,DC
+AMESLAB.GOV,Federal Agency,Department of Energy,Ames,IA
+ANL.GOV,Federal Agency,Department of Energy,Argonne,IL
+ARM.GOV,Federal Agency,Department of Energy,Richland,WA
+BIOMASSBOARD.GOV,Federal Agency,Department of Energy,Washington,DC
+BNL.GOV,Federal Agency,Department of Energy,Upton,NY
+BPA.GOV,Federal Agency,Department of Energy,Portland,OR
+BRC.GOV,Federal Agency,Department of Energy,Washington,DC
+BUILDINGAMERICA.GOV,Federal Agency,Department of Energy,Golden,CO
+CASL.GOV,Federal Agency,Department of Energy,Oak Ridge,TN
+CEBAF.GOV,Federal Agency,Department of Energy,Newport News,VA
+CENDI.GOV,Federal Agency,Department of Energy,Oak Ridge,TN
+CRT2014-2024REVIEW.GOV,Federal Agency,Department of Energy,Portland,OR
+DOE.GOV,Federal Agency,Department of Energy,Washington,DC
+DOEAL.GOV,Federal Agency,Department of Energy,Albuquerque,NM
+EIA.GOV,Federal Agency,Department of Energy,Washington,DC
+ENERGY.GOV,Federal Agency,Department of Energy,Washington,DC
+ENERGYCODES.GOV,Federal Agency,Department of Energy,Richland,WA
+ENERGYPLUS.GOV,Federal Agency,Department of Energy,Washington,DC
+ENERGYSAVER.GOV,Federal Agency,Department of Energy,Washington,DC
+ENERGYSAVERS.GOV,Federal Agency,Department of Energy,Washington,DC
+FNAL.GOV,Federal Agency,Department of Energy,Batavia,IL
+FUELECONOMY.GOV,Federal Agency,Department of Energy,Oak Ridge,TN
+HANFORD.GOV,Federal Agency,Department of Energy,Richland,WA
+HIGHPERFORMANCEBUILDINGS.GOV,Federal Agency,Department of Energy,Golden,CO
+HOMEENERGYSCORE.GOV,Federal Agency,Department of Energy,Washington,DC
+HYDROGEN.GOV,Federal Agency,Department of Energy,Washington,DC
+INEL.GOV,Federal Agency,Department of Energy,Idaho Falls,ID
+INL.GOV,Federal Agency,Department of Energy,Idaho Falls,ID
+ISCIENCE.GOV,Federal Agency,Department of Energy,Oak Ridge,TN
+ISOTOPE.GOV,Federal Agency,Department of Energy,Oak Ridge,TN
+ISOTOPES.GOV,Federal Agency,Department of Energy,Oak Ridge,TN
+KAPL.GOV,Federal Agency,Department of Energy,Schenectady,NY
+LANL.GOV,Federal Agency,Department of Energy,Los Alamos,NM
+LBL.GOV,Federal Agency,Department of Energy,Berkeley,CA
+LLNL.GOV,Federal Agency,Department of Energy,Livermore,CA
+NCCRC.GOV,Federal Agency,Department of Energy,Oak Ridge,TN
+NCCS.GOV,Federal Agency,Department of Energy,Oak Ridge,TN
+NCRC.GOV,Federal Agency,Department of Energy,Oak Ridge,TN
+NERSC.GOV,Federal Agency,Department of Energy,Berkeley,CA
+NEUP.GOV,Federal Agency,Department of Energy,Washington,DC
+NREL.GOV,Federal Agency,Department of Energy,Golden,CO
+NRELHUB.GOV,Federal Agency,Department of Energy,Golden,CO
+NTRC.GOV,Federal Agency,Department of Energy,Knoxville,TN
+NUCLEAR.GOV,Federal Agency,Department of Energy,Washington,DC
+ORAU.GOV,Federal Agency,Department of Energy,Oak Ridge,TN
+ORNL.GOV,Federal Agency,Department of Energy,Oak Ridge,TN
+OSTI.GOV,Federal Agency,Department of Energy,Oak Ridge,TN
+PNL.GOV,Federal Agency,Department of Energy,Richland,WA
+PNNL.GOV,Federal Agency,Department of Energy,Richland,WA
+RL.GOV,Federal Agency,Department of Energy,Richland,WA
+SALMONRECOVERY.GOV,Federal Agency,Department of Energy,Portland,OR
+SANDIA.GOV,Federal Agency,Department of Energy,Albuquerque,NM
+SCIDAC.GOV,Federal Agency,Department of Energy,Oak Ridge,TN
+SCIENCE.GOV,Federal Agency,Department of Energy,Oak Ridge,TN
+SCIENCEACCELERATOR.GOV,Federal Agency,Department of Energy,Oak Ridge,TN
+SCIENCEEDUCATION.GOV,Federal Agency,Department of Energy,Oak Ridge,TN
+SMARTGRID.GOV,Federal Agency,Department of Energy,Washington,DC
+SNS.GOV,Federal Agency,Department of Energy,Oak Ridge,TN
+SOLARDECATHLON.GOV,Federal Agency,Department of Energy,Golden,CO
+SRS.GOV,Federal Agency,Department of Energy,Aiken,SC
+SWPA.GOV,Federal Agency,Department of Energy,Tulsa,OK
+UNNPP.GOV,Federal Agency,Department of Energy,West Mifflin,PA
+UNRPNET.GOV,Federal Agency,Department of Energy,Washington,DC
+WAPA.GOV,Federal Agency,Department of Energy,Lakewood,CO
+WINDPOWERINGAMERICA.GOV,Federal Agency,Department of Energy,Golden,CO
+YMP.GOV,Federal Agency,Department of Energy,Las Vegas,NV
+ACF.GOV,Federal Agency,Department of Health And Human Services,Washington,DC
+ACL.GOV,Federal Agency,Department of Health And Human Services,Washington,DC
+AFTERSCHOOL.GOV,Federal Agency,Department of Health And Human Services,Washington,DC
+AGINGSTATS.GOV,Federal Agency,Department of Health And Human Services,Washington,DC
+AHCPR.GOV,Federal Agency,Department of Health And Human Services,Rockville,MD
+AHRQ.GOV,Federal Agency,Department of Health And Human Services,Rockville,MD
+AIDS.GOV,Federal Agency,Department of Health And Human Services,Washington,DC
+ALZHEIMERS.GOV,Federal Agency,Department of Health And Human Services,Washington,DC
+AOA.GOV,Federal Agency,Department of Health And Human Services,Washington,DC
+BAM.GOV,Federal Agency,Department of Health And Human Services,Atlanta,GA
+BESTBONESFOREVER.GOV,Federal Agency,Department of Health And Human Services,Washington,DC
+BETOBACCOFREE.GOV,Federal Agency,Department of Health And Human Services,Washington,DC
+BIOETHICS.GOV,Federal Agency,Department of Health And Human Services,Washington,DC
+BIOSECURITYBOARD.GOV,Federal Agency,Department of Health And Human Services,Washington,DC
+CANCER.GOV,Federal Agency,Department of Health And Human Services,Rockville,MD
+CANCERNET.GOV,Federal Agency,Department of Health And Human Services,Rockville,MD
+CDC.GOV,Federal Agency,Department of Health And Human Services,Atlanta,GA
+CHILDWELFARE.GOV,Federal Agency,Department of Health And Human Services,Washington,DC
+CLINICALTRIAL.GOV,Federal Agency,Department of Health And Human Services,Bethesda,MD
+CLINICALTRIALS.GOV,Federal Agency,Department of Health And Human Services,Bethesda,MD
+CLUBDRUGS.GOV,Federal Agency,Department of Health And Human Services,Bethesda,MD
+CMS.GOV,Federal Agency,Department of Health And Human Services,Baltimore,MD
+COLLEGEDRINKINGPREVENTION.GOV,Federal Agency,Department of Health And Human Services,Bethesda,MD
+CUIDADODESALUD.GOV,Federal Agency,Department of Health And Human Services,Baltimore,MD
+DHHS.GOV,Federal Agency,Department of Health And Human Services,Washington,DC
+DIABETESCOMMITTEE.GOV,Federal Agency,Department of Health And Human Services,Washington,DC
+DOCLINE.GOV,Federal Agency,Department of Health And Human Services,Bethesda,MD
+DRUGABUSE.GOV,Federal Agency,Department of Health And Human Services,Baltimore,MD
+DRUGFREEWORKPLACE.GOV,Federal Agency,Department of Health And Human Services,Rockville,MD
+EDISON.GOV,Federal Agency,Department of Health And Human Services,Bethesda,MD
+ELDERCARE.GOV,Federal Agency,Department of Health And Human Services,Washington,DC
+ENDINGTHEDOCUMENTGAME.GOV,Federal Agency,Department of Health And Human Services,Washington,DC
+ERRP.GOV,Federal Agency,Department of Health And Human Services,Baltimore,MD
+FATHERHOOD.GOV,Federal Agency,Department of Health And Human Services,Washington,DC
+FDA.GOV,Federal Agency,Department of Health And Human Services,Rockville,MD
+FINDYOUTHINFO.GOV,Federal Agency,Department of Health And Human Services,Rockville,MD
+FITNESS.GOV,Federal Agency,Department of Health And Human Services,Washington,DC
+FLU.GOV,Federal Agency,Department of Health And Human Services,Washington ,DC
+FOODSAFETY.GOV,Federal Agency,Department of Health And Human Services,Washington,DC
+FRUITSANDVEGGIESMATTER.GOV,Federal Agency,Department of Health And Human Services,Washington,DC
+GENBANK.GOV,Federal Agency,Department of Health And Human Services,Bethesda,MD
+GENOME.GOV,Federal Agency,Department of Health And Human Services,Bethesda,MD
+GIRLSHEALTH.GOV,Federal Agency,Department of Health And Human Services,Washington,DC
+GLOBALHEALTH.GOV,Federal Agency,Department of Health And Human Services,Rockville,MD
+GRANTS.GOV,Federal Agency,Department of Health And Human Services,Washington,DC
+GRANTSOLUTIONS.GOV,Federal Agency,Department of Health And Human Services,Washington,DC
+GUIDELINE.GOV,Federal Agency,Department of Health And Human Services,Rockville,MD
+GUIDELINES.GOV,Federal Agency,Department of Health And Human Services,Rockville,MD
+HCQUALITYCOMMISSION.GOV,Federal Agency,Department of Health And Human Services,Rockville,MD
+HEALTH.GOV,Federal Agency,Department of Health And Human Services,Washington,DC
+HEALTHCARE.GOV,Federal Agency,Department of Health And Human Services,Baltimore,MD
+HEALTHDATA.GOV,Federal Agency,Department of Health And Human Services,Washington,DC
+HEALTHFINDER.GOV,Federal Agency,Department of Health And Human Services,Washington,DC
+HEALTHINDICATORS.GOV,Federal Agency,Department of Health And Human Services,Washington,DC
+HEALTHIT.GOV,Federal Agency,Department of Health And Human Services,Washington,DC
+HEALTHREFORM.GOV,Federal Agency,Department of Health And Human Services,Washington,DC
+HEALTHYPEOPLE.GOV,Federal Agency,Department of Health And Human Services,Washington,DC
+HEARTTRUTH.GOV,Federal Agency,Department of Health And Human Services,Bethesda,MD
+HHS.GOV,Federal Agency,Department of Health And Human Services,Washington,DC
+HHSOIG.GOV,Federal Agency,Department of Health And Human Services,Washington,DC
+HHSOPS.GOV,Federal Agency,Department of Health And Human Services,Rockville,MD
+HIV.GOV,Federal Agency,Department of Health And Human Services,Washington,DC
+HRSA.GOV,Federal Agency,Department of Health And Human Services,Rockville,MD
+IEDISON.GOV,Federal Agency,Department of Health And Human Services,Bethesda,MD
+IHS.GOV,Federal Agency,Department of Health And Human Services,Albuquerque,NM
+INSUREKIDSNOW.GOV,Federal Agency,Department of Health And Human Services,Baltimore,MD
+LOCATORPLUS.GOV,Federal Agency,Department of Health And Human Services,Bethesda,MD
+LONGTERMCARE.GOV,Federal Agency,Department of Health And Human Services,Washington,DC
+MEDICAID.GOV,Federal Agency,Department of Health And Human Services,Baltimore,MD
+MEDICALCOUNTERMEASURES.GOV,Federal Agency,Department of Health And Human Services,Washington,DC
+MEDICALRESERVECORPS.GOV,Federal Agency,Department of Health And Human Services,Washington,DC
+MEDICARE.GOV,Federal Agency,Department of Health And Human Services,Baltimore,MD
+MEDLINE.GOV,Federal Agency,Department of Health And Human Services,Bethesda,MD
+MEDLINEPLUS.GOV,Federal Agency,Department of Health And Human Services,Bethesda,MD
+MENTALHEALTH.GOV,Federal Agency,Department of Health And Human Services,Bethesda,MD
+MESH.GOV,Federal Agency,Department of Health And Human Services,Bethesda,MD
+MIMEDICARE.GOV,Federal Agency,Department of Health And Human Services,Baltimore,MD
+MYMEDICARE.GOV,Federal Agency,Department of Health And Human Services,Baltimore,MD
+NATIONALCHILDRENSSTUDY.GOV,Federal Agency,Department of Health And Human Services,Bethesda,MD
+NCIFCRF.GOV,Federal Agency,Department of Health And Human Services,Frederick,MD
+NGC.GOV,Federal Agency,Department of Health And Human Services,Rockville,MD
+NIH.GOV,Federal Agency,Department of Health And Human Services,Bethesda,MD
+NIHSENIORHEALTH.GOV,Federal Agency,Department of Health And Human Services,Bethesda,MD
+NIOSH.GOV,Federal Agency,Department of Health And Human Services,Atlanta,GA
+NLM.GOV,Federal Agency,Department of Health And Human Services,Bethesda,MD
+NNLM.GOV,Federal Agency,Department of Health And Human Services,Bethesda,MD
+ORGANDONOR.GOV,Federal Agency,Department of Health And Human Services,Rockville,MD
+PANDEMICFLU.GOV,Federal Agency,Department of Health And Human Services,Washington,DC
+PAPERWORKREDUCTION.GOV,Federal Agency,Department of Health And Human Services,Washington,DC
+PCIP.GOV,Federal Agency,Department of Health And Human Services,New Orleans,LA
+PHE.GOV,Federal Agency,Department of Health And Human Services,Washington,DC
+PSC.GOV,Federal Agency,Department of Health And Human Services,Rockville,MD
+PUBMED.GOV,Federal Agency,Department of Health And Human Services,Bethesda,MD
+PUBMEDCENTRAL.GOV,Federal Agency,Department of Health And Human Services,Bethesda,MD
+QUIC.GOV,Federal Agency,Department of Health And Human Services,Rockville,MD
+QUICK.GOV,Federal Agency,Department of Health And Human Services,Rockville,MD
+RECOVERYMONTH.GOV,Federal Agency,Department of Health And Human Services,Rockville,MD
+SAFEYOUTH.GOV,Federal Agency,Department of Health And Human Services,Atlanta,GA
+SAMHSA.GOV,Federal Agency,Department of Health And Human Services,Rockville,MD
+SELECTAGENTS.GOV,Federal Agency,Department of Health And Human Services,Washington,DC
+SMOKEFREE.GOV,Federal Agency,Department of Health And Human Services,Rockville,MD
+STEROIDABUSE.GOV,Federal Agency,Department of Health And Human Services,Bethesda,MD
+STOPALCOHOLABUSE.GOV,Federal Agency,Department of Health And Human Services,Washington,DC
+STOPBULLYING.GOV,Federal Agency,Department of Health And Human Services,Washington,DC
+STOPMEDICAREFRAUD.GOV,Federal Agency,Department of Health And Human Services,Washington,DC
+SURGEONGENERAL.GOV,Federal Agency,Department of Health And Human Services,Washington,DC
+THECOOLSPOT.GOV,Federal Agency,Department of Health And Human Services,Rockville,MD
+THEREALCOST.GOV,Federal Agency,Department of Health And Human Services,Washington,DC
+TISSUEENGINEERING.GOV,Federal Agency,Department of Health And Human Services,Bethesda,MD
+TOBACCO.GOV,Federal Agency,Department of Health And Human Services,Washington,DC
+USABILITY.GOV,Federal Agency,Department of Health And Human Services,Washington,DC
+USBM.GOV,Federal Agency,Department of Health And Human Services,Atlanta,GA
+USPHS.GOV,Federal Agency,Department of Health And Human Services,Rockville,MD
+VACCINES.GOV,Federal Agency,Department of Health And Human Services,Washington,DC
+WHAGING.GOV,Federal Agency,Department of Health And Human Services,Washington,DC
+WHITEHOUSECONFERENCEONAGING.GOV,Federal Agency,Department of Health And Human Services,Washington,DC
+WOMENSHEALTH.GOV,Federal Agency,Department of Health And Human Services,Washington,DC
+BIOMETRICS.GOV,Federal Agency,Department of Homeland Security,Arlington,VA
+CITIZENCORPS.GOV,Federal Agency,Department of Homeland Security,Washington,DC
+CPNIREPORTING.GOV,Federal Agency,Department of Homeland Security,Washington,DC
+DHS.GOV,Federal Agency,Department of Homeland Security,Washington,DC
+DISASTERASSISTANCE.GOV,Federal Agency,Department of Homeland Security,Bluemont,VA
+FEMA.GOV,Federal Agency,Department of Homeland Security,Washington,DC
+FERO.GOV,Federal Agency,Department of Homeland Security,Washington,DC
+FIRSTRESPONDER.GOV,Federal Agency,Department of Homeland Security,Washington,DC
+FIRSTRESPONDERTRAINING.GOV,Federal Agency,Department of Homeland Security,Washington,DC
+FLETA.GOV,Federal Agency,Department of Homeland Security,Glynco,GA
+FLETC.GOV,Federal Agency,Department of Homeland Security,Glynco,GA
+FLIGHTSCHOOLCANDIDATES.GOV,Federal Agency,Department of Homeland Security,Rockville,MD
+FLOODSMART.GOV,Federal Agency,Department of Homeland Security,Bluemont,VA
+HOMELANDSECURITY.GOV,Federal Agency,Department of Homeland Security,Washington,DC
+ICE.GOV,Federal Agency,Department of Homeland Security,Washington,DC
+LISTO.GOV,Federal Agency,Department of Homeland Security,Washington,DC
+LLIS.GOV,Federal Agency,Department of Homeland Security,Washington,DC
+NMSC.GOV,Federal Agency,Department of Homeland Security,St Augustine,FL
+READY.GOV,Federal Agency,Department of Homeland Security,Washington,DC
+READYBUSINESS.GOV,Federal Agency,Department of Homeland Security,Washington,DC
+SAFECOMPROGRAM.GOV,Federal Agency,Department of Homeland Security,Washington,DC
+SAFETYACT.GOV,Federal Agency,Department of Homeland Security,Washington,DC
+SECRETSERVICE.GOV,Federal Agency,Department of Homeland Security,Washington D.C.,DC
+TSA.GOV,Federal Agency,Department of Homeland Security,Arlington,VA
+US-CERT.GOV,Federal Agency,Department of Homeland Security,Washington,DC
+USCG.GOV,Federal Agency,Department of Homeland Security,Alexandria,VA
+USCIS.GOV,Federal Agency,Department of Homeland Security,Washington,DC
+USSS.GOV,Federal Agency,Department of Homeland Security,Washington,DC
+DISASTERHOUSING.GOV,Federal Agency,Department of Housing And Urban Development,Washington,DC
+FHA.GOV,Federal Agency,Department of Housing And Urban Development,Washington,DC
+GINNIEMAE.GOV,Federal Agency,Department of Housing And Urban Development,Washington,DC
+HOMESALES.GOV,Federal Agency,Department of Housing And Urban Development,Washington,DC
+HUD.GOV,Federal Agency,Department of Housing And Urban Development,Washington,DC
+HUDOIG.GOV,Federal Agency,Department of Housing And Urban Development,Washington,DC
+NATIONALHOUSING.GOV,Federal Agency,Department of Housing And Urban Development,Washington,DC
+NATIONALHOUSINGLOCATOR.GOV,Federal Agency,Department of Housing And Urban Development,Washington,DC
+NHL.GOV,Federal Agency,Department of Housing And Urban Development,Washington,DC
+NLS.GOV,Federal Agency,Department of Housing And Urban Development,Washington,DC
+ADA.GOV,Federal Agency,Department of Justice,Rockville,MD
+ADR.GOV,Federal Agency,Department of Justice,Rockville,MD
+AMBERALERT.GOV,Federal Agency,Department of Justice,Potomac,MD
+ATF.GOV,Federal Agency,Department of Justice,Washington,DC
+BIOMETRICCOE.GOV,Federal Agency,Department of Justice,Clarksburg,WV
+BJA.GOV,Federal Agency,Department of Justice,Washington ,DC
+BJS.GOV,Federal Agency,Department of Justice,Washington,DC
+BOP.GOV,Federal Agency,Department of Justice,Washington,DC
+CRIMESOLUTIONS.GOV,Federal Agency,Department of Justice,Washinton ,DC
+CRIMEVICTIMS.GOV,Federal Agency,Department of Justice,Potomac,MD
+CYBERCRIME.GOV,Federal Agency,Department of Justice,Washington,DC
+DEA.GOV,Federal Agency,Department of Justice,Rockville,MD
+DEADIVERSION.GOV,Federal Agency,Department of Justice,Potomac,MD
+DEALS.GOV,Federal Agency,Department of Justice,Washington,DC
+DNA.GOV,Federal Agency,Department of Justice,Potomac,MD
+DSAC.GOV,Federal Agency,Department of Justice,Potomac,MD
+ESPANOLFORLAWENFORCEMENT.GOV,Federal Agency,Department of Justice,Potomac,MD
+FARA.GOV,Federal Agency,Department of Justice,potomac,MD
+FBI.GOV,Federal Agency,Department of Justice,Washington,DC
+FBIJOBS.GOV,Federal Agency,Department of Justice,Washington,DC
+FIRSTFREEDOM.GOV,Federal Agency,Department of Justice,Potomac,MD
+FOIA.GOV,Federal Agency,Department of Justice,Washington,DC
+FORFEITURE.GOV,Federal Agency,Department of Justice,Potomac,MD
+GETSMARTABOUTDRUGS.GOV,Federal Agency,Department of Justice,Potomac,MD
+HELPINGAMERICASYOUTH.GOV,Federal Agency,Department of Justice,Potomac,MD
+IC3.GOV,Federal Agency,Department of Justice,Fairmont,WV
+INTERPOL.GOV,Federal Agency,Department of Justice,Potomac,MD
+IPRCENTER.GOV,Federal Agency,Department of Justice,Washington,DC
+JUSTICE.GOV,Federal Agency,Department of Justice,Rockville,MD
+JUSTTHINKTWICE.GOV,Federal Agency,Department of Justice,Potomac,MD
+JUVENILECOUNCIL.GOV,Federal Agency,Department of Justice,Potomac,MD
+LEP.GOV,Federal Agency,Department of Justice,Rockville,MD
+LOOKSTOOGOODTOBETRUE.GOV,Federal Agency,Department of Justice,Fairmont,WV
+MALWAREINVESTIGATOR.GOV,Federal Agency,Department of Justice,Washington,DC
+MEDALOFVALOR.GOV,Federal Agency,Department of Justice,Potomac,MD
+NAMUS.GOV,Federal Agency,Department of Justice,Potomac,MD
+NATIONALGANGCENTER.GOV,Federal Agency,Department of Justice,Tallahassee,FL
+NCIRC.GOV,Federal Agency,Department of Justice,Tallahassee,FL
+NCJRS.GOV,Federal Agency,Department of Justice,Potomac,MD
+NIBIN.GOV,Federal Agency,Department of Justice,Washington,DC
+NICIC.GOV,Federal Agency,Department of Justice,Washington,DC
+NIEM.GOV,Federal Agency,Department of Justice,Tallahassee,FL
+NIJ.GOV,Federal Agency,Department of Justice,Washington,DC
+NMVTIS.GOV,Federal Agency,Department of Justice,Washington,DC
+NSOPW.GOV,Federal Agency,Department of Justice,Washington,DC
+NVTC.GOV,Federal Agency,Department of Justice,Washington,DC
+OJJDP.GOV,Federal Agency,Department of Justice,Potomac,MD
+OJP.GOV,Federal Agency,Department of Justice,Washington,DC
+OVC.GOV,Federal Agency,Department of Justice,Potomac,MD
+OVCTTAC.GOV,Federal Agency,Department of Justice,Potomac,MD
+PROJECTSAFECHILDHOOD.GOV,Federal Agency,Department of Justice,Potomac,MD
+PROJECTSAFENEIGHBORHOODS.GOV,Federal Agency,Department of Justice,Rockville,MD
+PSOB.GOV,Federal Agency,Department of Justice,Potomac,MD
+RCFL.GOV,Federal Agency,Department of Justice,McLean,VA
+REENTRY.GOV,Federal Agency,Department of Justice,Potomac,MD
+SCRA.GOV,Federal Agency,Department of Justice,Potomac,MD
+SERVICEMEMBERS.GOV,Federal Agency,Department of Justice,Potomac,MD
+SMART.GOV,Federal Agency,Department of Justice,Washington,DC
+STOPFRAUD.GOV,Federal Agency,Department of Justice,Rockville,MD
+TRIBALJUSTICEANDSAFETY.GOV,Federal Agency,Department of Justice,Potomac,MD
+UCRDATATOOL.GOV,Federal Agency,Department of Justice,Washington,DC
+UNICOR.GOV,Federal Agency,Department of Justice,Washington,DC
+USDOJ.GOV,Federal Agency,Department of Justice,Rockville,MD
+USERRA.GOV,Federal Agency,Department of Justice,Potpmac,MD
+USMARSHALS.GOV,Federal Agency,Department of Justice,Rockville,MD
+VCF.GOV,Federal Agency,Department of Justice,Washington,DC
+VEHICLEHISTORY.GOV,Federal Agency,Department of Justice,Potomac,MD
+AMERICASHEROESATWORK.GOV,Federal Agency,Department of Labor,Washington,DC
+AUTOCOMMUNITIES.GOV,Federal Agency,Department of Labor,Washington,DC
+BENEFITS.GOV,Federal Agency,Department of Labor,Washington,DC
+BLS.GOV,Federal Agency,Department of Labor,Washington,DC
+DISABILITY.GOV,Federal Agency,Department of Labor,Washington,DC
+DOL-ESA.GOV,Federal Agency,Department of Labor,Washington,DC
+DOL.GOV,Federal Agency,Department of Labor,Washington,DC
+DOLETA.GOV,Federal Agency,Department of Labor,Washington,DC
+GOVBENEFITS.GOV,Federal Agency,Department of Labor,Washington,DC
+GOVLOANS.GOV,Federal Agency,Department of Labor,Washington,DC
+JOBCORPS.GOV,Federal Agency,Department of Labor,Austin,TX
+LABOR.GOV,Federal Agency,Department of Labor,Washington,DC
+MSHA.GOV,Federal Agency,Department of Labor,Arlington,VA
+MYNEXTMOVE.GOV,Federal Agency,Department of Labor,Washington,DC
+OSHA.GOV,Federal Agency,Department of Labor,Washington,DC
+UNIONREPORTS.GOV,Federal Agency,Department of Labor,Washington,DC
+VETERANS.GOV,Federal Agency,Department of Labor,Washington,DC
+WHISTLEBLOWERS.GOV,Federal Agency,Department of Labor,Washington,DC
+WRP.GOV,Federal Agency,Department of Labor,Washington,DC
+YOUTHRULES.GOV,Federal Agency,Department of Labor,Washington,DC
+AMERICA.GOV,Federal Agency,Department of State,Washington,DC
+CIVILIANRESPONSECORPS.GOV,Federal Agency,Department of State,Washington,DC
+CONTINENTALSHELF.GOV,Federal Agency,Department of State,Washington,DC
+CWC.GOV,Federal Agency,Department of State,Washington,DC
+ECOPARTNERSHIPS.GOV,Federal Agency,Department of State,Washington,DC
+FAN.GOV,Federal Agency,Department of State,Washington,DC
+FOREIGNASSISTANCE.GOV,Federal Agency,Department of State,Washington,DC
+FSGB.GOV,Federal Agency,Department of State,Washington,DC
+GHI.GOV,Federal Agency,Department of State,Washington,DC
+HUMANRIGHTS.GOV,Federal Agency,Department of State,Washington ,DC
+IAWG.GOV,Federal Agency,Department of State,Washington,DC
+IBWC.GOV,Federal Agency,Department of State,El Paso,TX
+ICASS.GOV,Federal Agency,Department of State,Washington,DC
+OSAC.GOV,Federal Agency,Department of State,Washington,DC
+PEPFAR.GOV,Federal Agency,Department of State,Washington,DC
+STATE.GOV,Federal Agency,Department of State,Washington,DC
+USCONSULATE.GOV,Federal Agency,Department of State,Washington,DC
+USEMBASSY-MEXICO.GOV,Federal Agency,Department of State,Mexico City,11
+USEMBASSY.GOV,Federal Agency,Department of State,Washington,DC
+USINT.GOV,Federal Agency,Department of State,Washington,DC
+USMISSION.GOV,Federal Agency,Department of State,Washington,DC
+USVPP.GOV,Federal Agency,Department of State,Washington,DC
+ABANDONEDMINES.GOV,Federal Agency,Department of the Interior,Washington,DC
+ACWI.GOV,Federal Agency,Department of the Interior,Reston,VA
+ALASKACENTERS.GOV,Federal Agency,Department of the Interior,Washington,DC
+AMERICANLATINOMUSEUM.GOV,Federal Agency,Department of the Interior,Washington,WV
+AMERICASGREATOUTDOORS.GOV,Federal Agency,Department of the Interior,Washington,DC
+ANSTASKFORCE.GOV,Federal Agency,Department of the Interior,Arlington,VA
+BIA.GOV,Federal Agency,Department of the Interior,Reston,VA
+BIOECO.GOV,Federal Agency,Department of the Interior,Denver,CO
+BLM.GOV,Federal Agency,Department of the Interior,Denver,CO
+BLMNTL.GOV,Federal Agency,Department of the Interior,Denver,CO
+BOEM.GOV,Federal Agency,Department of the Interior,Herndon,VA
+BOEMRE.GOV,Federal Agency,Department of the Interior,Herndon,VA
+BOR.GOV,Federal Agency,Department of the Interior,Denver,CO
+BSEE.GOV,Federal Agency,Department of the Interior,Herndon,VA
+C3.GOV,Federal Agency,Department of the Interior,POrtland,OR
+COAST2050.GOV,Federal Agency,Department of the Interior,Lafayette,LA
+CONSERVATION.GOV,Federal Agency,Department of the Interior,Washington ,DC
+CORALREEF.GOV,Federal Agency,Department of the Interior,Denver,CO
+CUPCAO.GOV,Federal Agency,Department of the Interior,Denver,CO
+DOI.GOV,Federal Agency,Department of the Interior,Washington,DC
+DOIOIG.GOV,Federal Agency,Department of the Interior,RESTON,VA
+EARTHQUAKE.GOV,Federal Agency,Department of the Interior,Menlo Park,CA
+EVERGLADESRESTORATION.GOV,Federal Agency,Department of the Interior,Davie,FL
+FCG.GOV,Federal Agency,Department of the Interior,Denver,CO
+FGDC.GOV,Federal Agency,Department of the Interior,Reston,VA
+FIRECODE.GOV,Federal Agency,Department of the Interior,Boise,ID
+FIRELEADERSHIP.GOV,Federal Agency,Department of the Interior,Boise,ID
+FIRENET.GOV,Federal Agency,Department of the Interior,Boise,ID
+FIRESCIENCE.GOV,Federal Agency,Department of the Interior,Boise,ID
+FRCC.GOV,Federal Agency,Department of the Interior,Sioux Falls,SD
+FWS.GOV,Federal Agency,Department of the Interior,Lakewood,CO
+GCDAMP.GOV,Federal Agency,Department of the Interior,Denver,CO
+GCMRC.GOV,Federal Agency,Department of the Interior,Flagstaff,AZ
+GEOCOMMUNICATOR.GOV,Federal Agency,Department of the Interior,Denver,CO
+GEOMAC.GOV,Federal Agency,Department of the Interior,Denver,CO
+GEOPLATFORM.GOV,Federal Agency,Department of the Interior,Washington,DC
+IAT.GOV,Federal Agency,Department of the Interior,Boise,ID
+INDIANAFFAIRS.GOV,Federal Agency,Department of the Interior,Reston,VA
+INTERIOR.GOV,Federal Agency,Department of the Interior,Washington,DC
+INVASIVESPECIES.GOV,Federal Agency,Department of the Interior,Washington,DC
+JEM.GOV,Federal Agency,Department of the Interior,Lafayett,LA
+KLAMATHRESTORATION.GOV,Federal Agency,Department of the Interior,Yreka,CA
+LACOAST.GOV,Federal Agency,Department of the Interior,Lafayette,LA
+LANDFIRE.GOV,Federal Agency,Department of the Interior,Sioux Falls,SD
+LANDIMAGING.GOV,Federal Agency,Department of the Interior,Reston,VA
+LCA.GOV,Federal Agency,Department of the Interior,Lafayette,LA
+LCRMSCP.GOV,Federal Agency,Department of the Interior,Denver,CO
+LMVSCI.GOV,Federal Agency,Department of the Interior,Lafayette,LA
+LOWERMISSISSIPPIVALLEYSCIENCE.GOV,Federal Agency,Department of the Interior,Lafayette,LA
+MAPAPLANET.GOV,Federal Agency,Department of the Interior,Flagstaff,AZ
+MARINE.GOV,Federal Agency,Department of the Interior,Camarillo,CA
+MITIGATIONCOMMISSION.GOV,Federal Agency,Department of the Interior,Denver,CO
+MMS.GOV,Federal Agency,Department of the Interior,Herndon,VA
+MRGO.GOV,Federal Agency,Department of the Interior,Lafayette,LA
+MRLC.GOV,Federal Agency,Department of the Interior,Sioux Falls,SD
+NATIONALATLAS.GOV,Federal Agency,Department of the Interior,Reston,VA
+NATIONALMAP.GOV,Federal Agency,Department of the Interior,Reston,VA
+NBC.GOV,Federal Agency,Department of the Interior,Denver,CO
+NDEP.GOV,Federal Agency,Department of the Interior,Reston,VA
+NDOP.GOV,Federal Agency,Department of the Interior,Reston,VA
+NEMI.GOV,Federal Agency,Department of the Interior,Middleton,WI
+NFPORS.GOV,Federal Agency,Department of the Interior,Washington,DC
+NIFC.GOV,Federal Agency,Department of the Interior,Boise,ID
+NIFTT.GOV,Federal Agency,Department of the Interior,Boise,ID
+NOLAENVIRONMENTAL.GOV,Federal Agency,Department of the Interior,Lafayette,LA
+NPS.GOV,Federal Agency,Department of the Interior,WASHINGTON DC,DC
+ONHIR.GOV,Federal Agency,Department of the Interior,Flagstaff,AZ
+ONRR.GOV,Federal Agency,Department of the Interior,Herndon,VA
+OSM.GOV,Federal Agency,Department of the Interior,Washington,DC
+OSMRE.GOV,Federal Agency,Department of the Interior,Washington,DC
+PIEDRASBLANCAS.GOV,Federal Agency,Department of the Interior,Sacramento,CA
+REPORTBAND.GOV,Federal Agency,Department of the Interior,Laurel,MD
+RIVERS.GOV,Federal Agency,Department of the Interior,Burbank,WA
+SAFECOM.GOV,Federal Agency,Department of the Interior,Boise,ID
+SCIENCEBASE.GOV,Federal Agency,Department of the Interior,Denver,CO
+SIERRAWILD.GOV,Federal Agency,Department of the Interior,Yosemite,CA
+SNAP.GOV,Federal Agency,Department of the Interior,Washington,DC
+USBR.GOV,Federal Agency,Department of the Interior,Denver,CO
+USGS.GOV,Federal Agency,Department of the Interior,Reston,VA
+UTAHFIREINFO.GOV,Federal Agency,Department of the Interior,Denver,CO
+VOLCANO.GOV,Federal Agency,Department of the Interior,Anchorage,AK
+VOLUNTEER.GOV,Federal Agency,Department of the Interior,Reston,VA
+WATERMONITOR.GOV,Federal Agency,Department of the Interior,Reston,VA
+WILDLIFEADAPTATIONSTRATEGY.GOV,Federal Agency,Department of the Interior,Arlington,VA
+WLCI.GOV,Federal Agency,Department of the Interior,Denver,CO
+YOUTHGO.GOV,Federal Agency,Department of the Interior,Shepherdstown,WV
+AMA.GOV,Federal Agency,Department of the Treasury,Washington,DC
+AMERICATHEBEAUTIFULQUARTERS.GOV,Federal Agency,Department of the Treasury,Washington,DC
+ASAP.GOV,Federal Agency,Department of the Treasury,Washington,DC
+AYUDACONMIBANCO.GOV,Federal Agency,Department of the Treasury,Washington,DC
+BANKANSWERS.GOV,Federal Agency,Department of the Treasury,Washington,DC
+BANKCUSTOMER.GOV,Federal Agency,Department of the Treasury,Washington,DC
+BANKCUSTOMERASSISTANCE.GOV,Federal Agency,Department of the Treasury,Washington,DC
+BANKHELP.GOV,Federal Agency,Department of the Treasury,Washington,DC
+BANKNET.GOV,Federal Agency,Department of the Treasury,Washington,DC
+BEP.GOV,Federal Agency,Department of the Treasury,Washington,DC
+BFEM.GOV,Federal Agency,Department of the Treasury,Washington,DC
+BONDPRO.GOV,Federal Agency,Department of the Treasury,Washington,DC
+CCAC.GOV,Federal Agency,Department of the Treasury,Washington,DC
+CDFIFUND.GOV,Federal Agency,Department of the Treasury,Washington,DC
+COMPLAINTREFERRALEXPRESS.GOV,Federal Agency,Department of the Treasury,Washington,DC
+COMPTROLLEROFTHECURRENCY.GOV,Federal Agency,Department of the Treasury,Washington,DC
+DIRECTOASUCUENTA.GOV,Federal Agency,Department of the Treasury,Washington,DC
+EFTPS.GOV,Federal Agency,Department of the Treasury,Washington,DC
+ETA-FIND.GOV,Federal Agency,Department of the Treasury,DALLAS,TX
+ETHICSBURG.GOV,Federal Agency,Department of the Treasury,Parkersburg,WV
+EYENOTE.GOV,Federal Agency,Department of the Treasury,Washington,DC
+FEDERALINVESTMENTS.GOV,Federal Agency,Department of the Treasury,Pakersburg,WV
+FEDINVEST.GOV,Federal Agency,Department of the Treasury,Parkersburg,WV
+FINANCIALRESEARCH.GOV,Federal Agency,Department of the Treasury,Washington,DC
+FINANCIALSTABILITY.GOV,Federal Agency,Department of the Treasury,Washington,DC
+FINCEN.GOV,Federal Agency,Department of the Treasury,Vienna,VA
+FSOC.GOV,Federal Agency,Department of the Treasury,Washington,DC
+FTTESTTWAI.GOV,Federal Agency,Department of the Treasury,Hyattsville,MD
+GODIRECT.GOV,Federal Agency,Department of the Treasury,Washington,DC
+GWA.GOV,Federal Agency,Department of the Treasury,Hyattsville,MD
+HELPWITHMYBANK.GOV,Federal Agency,Department of the Treasury,Washington,DC
+HELPWITHMYCHECKINGACCOUNT.GOV,Federal Agency,Department of the Treasury,Washington,DC
+HELPWITHMYCREDITCARD.GOV,Federal Agency,Department of the Treasury,Washington,DC
+HELPWITHMYCREDITCARDBANK.GOV,Federal Agency,Department of the Treasury,Washington,DC
+HELPWITHMYMORTGAGE.GOV,Federal Agency,Department of the Treasury,Washington,DC
+HELPWITHMYMORTGAGEBANK.GOV,Federal Agency,Department of the Treasury,Washington,DC
+IPAC.GOV,Federal Agency,Department of the Treasury,Boston,MA
+IPP.GOV,Federal Agency,Department of the Treasury,McLean,VA
+IRS.GOV,Federal Agency,Department of the Treasury,McLean,VA
+IRSAUCTIONS.GOV,Federal Agency,Department of the Treasury,McLean,VA
+IRSNET.GOV,Federal Agency,Department of the Treasury,McLean,VA
+IRSSALES.GOV,Federal Agency,Department of the Treasury,McLean,VA
+IRSVIDEOS.GOV,Federal Agency,Department of the Treasury,Washington,DC
+ITS.GOV,Federal Agency,Department of the Treasury,McLean,VA
+MAKINGHOMEAFFORDABLE.GOV,Federal Agency,Department of the Treasury,Washington,DC
+MHA.GOV,Federal Agency,Department of the Treasury,Washington,DC
+MONEYFACTORY.GOV,Federal Agency,Department of the Treasury,Washington,DC
+MONEYFACTORYSTORE.GOV,Federal Agency,Department of the Treasury,Washington,DC
+MSB.GOV,Federal Agency,Department of the Treasury,Vienna,VA
+MYMONEY.GOV,Federal Agency,Department of the Treasury,Washington,DC
+MYRA.GOV,Federal Agency,Department of the Treasury,Washington,DC
+NATIONALBANK.GOV,Federal Agency,Department of the Treasury,McLean,VA
+NATIONALBANKHELP.GOV,Federal Agency,Department of the Treasury,Washington,DC
+NATIONALBANKNET.GOV,Federal Agency,Department of the Treasury,Washington,DC
+NAVYCASH.GOV,Federal Agency,Department of the Treasury,McLean,VA
+OCC.GOV,Federal Agency,Department of the Treasury,Washington,DC
+OCCHELPS.GOV,Federal Agency,Department of the Treasury,Washington,DC
+OCCNET.GOV,Federal Agency,Department of the Treasury,Landover,MD
+OTS.GOV,Federal Agency,Department of the Treasury,McLean,VA
+PATRIOTBONDS.GOV,Federal Agency,Department of the Treasury,Parkersburg,WV
+PAY.GOV,Federal Agency,Department of the Treasury,Washington,DC
+PRACOMMENT.GOV,Federal Agency,Department of the Treasury,Washington,DC
+QATESTTWAI.GOV,Federal Agency,Department of the Treasury,Hyattsville,MD
+SAVINGSBOND.GOV,Federal Agency,Department of the Treasury,Mclean,VA
+SAVINGSBONDS.GOV,Federal Agency,Department of the Treasury,McLean,VA
+SAVINGSBONDWIZARD.GOV,Federal Agency,Department of the Treasury,Mclean,VA
+SIGTARP.GOV,Federal Agency,Department of the Treasury,Washington,DC
+SLGS.GOV,Federal Agency,Department of the Treasury,Mclean,VA
+TAAPS.GOV,Federal Agency,Department of the Treasury,Mclean,VA
+TAX.GOV,Federal Agency,Department of the Treasury,McLean,VA
+TCIS.GOV,Federal Agency,Department of the Treasury,Washington,DC
+TIGTA.GOV,Federal Agency,Department of the Treasury,Washington,DC
+TIGTANET.GOV,Federal Agency,Department of the Treasury,McLean,VA
+TREAS.GOV,Federal Agency,Department of the Treasury,Washington,DC
+TREASLOCKBOX.GOV,Federal Agency,Department of the Treasury,Washington,DC
+TREASURY.FED.US,Federal Agency,Department of the Treasury,Washington,DC
+TREASURY.GOV,Federal Agency,Department of the Treasury,Washington,DC
+TREASURYAUCTION.GOV,Federal Agency,Department of the Treasury,Parkersburg,WV
+TREASURYAUCTIONS.GOV,Federal Agency,Department of the Treasury,Mclean,VA
+TREASURYDIRECT.GOV,Federal Agency,Department of the Treasury,McLean,VA
+TREASURYECM.GOV,Federal Agency,Department of the Treasury,Washington,DC
+TREASURYHUNT.GOV,Federal Agency,Department of the Treasury,Parkersburg,WV
+TREASURYSCAMS.GOV,Federal Agency,Department of the Treasury,Mclean,VA
+TRS.GOV,Federal Agency,Department of the Treasury,Washington,DC
+TTB.GOV,Federal Agency,Department of the Treasury,Washington,DC
+TTBONLINE.GOV,Federal Agency,Department of the Treasury,McLean,VA
+TTLPLUS.GOV,Federal Agency,Department of the Treasury,St. Louis,MO
+TWAI.GOV,Federal Agency,Department of the Treasury,Washington,DC
+USASPENDING.GOV,Federal Agency,Department of the Treasury,Washington,DC
+USDEBITCARD.GOV,Federal Agency,Department of the Treasury,Mclean,VA
+USMINT.GOV,Federal Agency,Department of the Treasury,Washington,DC
+USTREAS.GOV,Federal Agency,Department of the Treasury,McLean,VA
+VERIFYPAYMENT.GOV,Federal Agency,Department of the Treasury,Parkersburg,WV
+WIZARD.GOV,Federal Agency,Department of the Treasury,Mclean,VA
+WORKPLACE.GOV,Federal Agency,Department of the Treasury,Washington,DC
+911.GOV,Federal Agency,Department of Transportation,Washington,DC
+BTS.GOV,Federal Agency,Department of Transportation,Washington,DC
+CFLHD.GOV,Federal Agency,Department of Transportation,Lakewood,CO
+DISTRACTEDDRIVING.GOV,Federal Agency,Department of Transportation,Washington,DC
+DISTRACTION.GOV,Federal Agency,Department of Transportation,Washington,DC
+DOT.GOV,Federal Agency,Department of Transportation,Washington,DC
+DOTIDEAHUB.GOV,Federal Agency,Department of Transportation,Washington,DC
+DOTTRAFFICRECORDS.GOV,Federal Agency,Department of Transportation,Room 2202,DC
+DOTTRCC.GOV,Federal Agency,Department of Transportation,Washington,DC
+EMS.GOV,Federal Agency,Department of Transportation,Washington,DC
+ESC.GOV,Federal Agency,Department of Transportation,Oklahoma City,OK
+FAA.GOV,Federal Agency,Department of Transportation,Washington,DC
+FAASAFETY.GOV,Federal Agency,Department of Transportation,Washington,DC
+FDR.GOV,Federal Agency,Department of Transportation,Washington,DC
+FMIP.GOV,Federal Agency,Department of Transportation,Washington,DC
+ITALLADDSUP.GOV,Federal Agency,Department of Transportation,Washington,DC
+JCCBI.GOV,Federal Agency,Department of Transportation,Oklahoma City,OK
+MARVIEW.GOV,Federal Agency,Department of Transportation,Washington,DC
+MDA.GOV,Federal Agency,Department of Transportation,Washington,DC
+NHTSA.GOV,Federal Agency,Department of Transportation,Washington,DC
+NTDPROGRAM.GOV,Federal Agency,Department of Transportation,Washington,DC
+PLAINLANGUAGE.GOV,Federal Agency,Department of Transportation,Washington,DC
+PROTECTYOURMOVE.GOV,Federal Agency,Department of Transportation,Washington,DC
+SAFERCAR.GOV,Federal Agency,Department of Transportation,Washington,DC
+SAFERTRUCK.GOV,Federal Agency,Department of Transportation,Washington,DC
+SHARETHEROADSAFELY.GOV,Federal Agency,Department of Transportation,Washington,DC
+STRONGPORTS.GOV,Federal Agency,Department of Transportation,Washington,DC
+SUSTAINABLECOMMUNITIES.GOV,Federal Agency,Department of Transportation,Washington,DC
+TFHRC.GOV,Federal Agency,Department of Transportation,Mclean,VA
+TRAFFICSAFETYMARKETING.GOV,Federal Agency,Department of Transportation,Washington,DC
+TRANSPORTATION.GOV,Federal Agency,Department of Transportation,Washington,DC
+TRANSPORTATIONRESEARCH.GOV,Federal Agency,Department of Transportation,Washington,DC
+UNITEDWERIDE.GOV,Federal Agency,Department of Transportation,Washington,DC
+CDCO.GOV,Federal Agency,Department of Veterans Affairs,Austin,TX
+LASEGUNDACOSA.GOV,Federal Agency,Department of Veterans Affairs,Washington,DC
+NATIONALRESOURCEDIRECTORY.GOV,Federal Agency,Department of Veterans Affairs,Washington,DC
+NRD.GOV,Federal Agency,Department of Veterans Affairs,Washington,DC
+THESECONDTHING.GOV,Federal Agency,Department of Veterans Affairs,Washington,DC
+VA.GOV,Federal Agency,Department of Veterans Affairs,Washington,DC
+VET-BIZ.GOV,Federal Agency,Department of Veterans Affairs,Washington,DC
+VETBIZ.GOV,Federal Agency,Department of Veterans Affairs,Washington,DC
+VETSUCCESS.GOV,Federal Agency,Department of Veterans Affairs,Washington,DC
+BTO.GOV,Federal Agency,Director of National Intelligence,McLean,VA
+COUNTERWMD.GOV,Federal Agency,Director of National Intelligence,Washington,DC
+DNI.GOV,Federal Agency,Director of National Intelligence,McLean,VA
+IARPA-IDEAS.GOV,Federal Agency,Director of National Intelligence,Washington,DC
+IARPA.GOV,Federal Agency,Director of National Intelligence,College Park,MD
+ICJOINTDUTY.GOV,Federal Agency,Director of National Intelligence,Washington,DC
+INTELINK.GOV,Federal Agency,Director of National Intelligence,Ft. George G. Meade,MD
+INTELLIGENCE.GOV,Federal Agency,Director of National Intelligence,Washington,DC
+ISE.GOV,Federal Agency,Director of National Intelligence,Washington ,DC
+NCIX.GOV,Federal Agency,Director of National Intelligence,Washington,DC
+NMIC.GOV,Federal Agency,Director of National Intelligence,Washington,DC
+ODNI.GOV,Federal Agency,Director of National Intelligence,Washington,DC
+OSIS.GOV,Federal Agency,Director of National Intelligence,Fort George G. Meade,MD
+PIX.GOV,Federal Agency,Director of National Intelligence,Washington,DC
+UGOV.GOV,Federal Agency,Director of National Intelligence,Fort George G Meade,MD
+AIRNOW.GOV,Federal Agency,Environmental Protection Agency,Durham,NC
+AQI.GOV,Federal Agency,Environmental Protection Agency,Durham,NC
+CBI-EPA.GOV,Federal Agency,Environmental Protection Agency,Durham,NC
+ENERGYSTAR.GOV,Federal Agency,Environmental Protection Agency,Washington,DC
+EPA-ECHO.GOV,Federal Agency,Environmental Protection Agency,Washington,DC
+EPA-OTIS.GOV,Federal Agency,Environmental Protection Agency,Washington,DC
+EPA.GOV,Federal Agency,Environmental Protection Agency,Research Triangle Park,NC
+FDMS.GOV,Federal Agency,Environmental Protection Agency,Washington,DC
+FEDCENTER.GOV,Federal Agency,Environmental Protection Agency,Champaign,IL
+FRTR.GOV,Federal Agency,Environmental Protection Agency,Omaha,NE
+GREENGOV.GOV,Federal Agency,Environmental Protection Agency, Washington,DC
+OFEE.GOV,Federal Agency,Environmental Protection Agency,Washington,DC
+REGULATION.GOV,Federal Agency,Environmental Protection Agency,Washington,DC
+REGULATIONS.GOV,Federal Agency,Environmental Protection Agency,Washington,DC
+RELOCATEFEDS.GOV,Federal Agency,Environmental Protection Agency,Cincinnati,OH
+SUSTAINABILITY.GOV,Federal Agency,Environmental Protection Agency,Washington,DC
+URBANWATERS.GOV,Federal Agency,Environmental Protection Agency,Washington,DC
+EEOC.GOV,Federal Agency,Equal Employment Opportunity Commission,Washington,DC
+ASTRONGMIDDLECLASS.GOV,Federal Agency,Executive Office of the President,Washington,DC
+BUDGET.GOV,Federal Agency,Executive Office of the President,Washington,DC
+CHANGE.GOV,Federal Agency,Executive Office of the President,Arlington,VA
+EARMARKS.GOV,Federal Agency,Executive Office of the President,Washington,DC
+EGOV.GOV,Federal Agency,Executive Office of the President,Washington,DC
+EOP.GOV,Federal Agency,Executive Office of the President,Washington,DC
+ETHICS.GOV,Federal Agency,Executive Office of the President,Washington ,DC
+EXRWH.GOV,Federal Agency,Executive Office of the President,Washington,DC
+FISCALCOMMISSION.GOV,Federal Agency,Executive Office of the President,Washington,DC
+HC.GOV,Federal Agency,Executive Office of the President,Washington,DC
+ITDASHBOARD.GOV,Federal Agency,Executive Office of the President,Washington,DC
+JOININGFORCES.GOV,Federal Agency,Executive Office of the President,Washington,DC
+LETSMOVE.GOV,Federal Agency,Executive Office of the President,Washington,DC
+MAX.GOV,Federal Agency,Executive Office of the President,NW,WA
+NEPA.GOV,Federal Agency,Executive Office of the President,Washington,DC
+NOTALONE.GOV,Federal Agency,Executive Office of the President,Washington,DC
+NSTIC.GOV,Federal Agency,Executive Office of the President,Gaithersburg,MD
+OMB.GOV,Federal Agency,Executive Office of the President,Washington,DC
+OMBLOG.GOV,Federal Agency,Executive Office of the President,Washington,DC
+ONDCP.GOV,Federal Agency,Executive Office of the President,Washington,DC
+OSTP.GOV,Federal Agency,Executive Office of the President,Washington,DC
+PAYMENTACCURACY.GOV,Federal Agency,Executive Office of the President,Washington,DC
+PCI.GOV,Federal Agency,Executive Office of the President,Washington,DC
+PRESIDIO.GOV,Federal Agency,Executive Office of the President,San Francisco,CA
+PRESIDIOTRUST.GOV,Federal Agency,Executive Office of the President,San Francisco,CA
+REACHHIGHER.GOV,Federal Agency,Executive Office of the President,Washington,DC
+SAVE.GOV,Federal Agency,Executive Office of the President,Washington,DC
+SAVEAWARD.GOV,Federal Agency,Executive Office of the President,Washington,DC
+STRONGMIDDLECLASS.GOV,Federal Agency,Executive Office of the President,Washington,DC
+USTR.GOV,Federal Agency,Executive Office of the President,Washington,DC
+WH.GOV,Federal Agency,Executive Office of the President,Washington,DC
+WHITEHOUSE.GOV,Federal Agency,Executive Office of the President,Washington,DC
+WHITEHOUSEDRUGPOLICY.GOV,Federal Agency,Executive Office of the President,Washington,DC
+EXIM.GOV,Federal Agency,Export/Import Bank of the U.S.,Washington,DC
+EXIMCOOP.GOV,Federal Agency,Export/Import Bank of the U.S.,Washington,DC
+FCA.GOV,Federal Agency,Farm Credit Administration,McLean,VA
+FCSIC.GOV,Federal Agency,Farm Credit Administration,McLean,VA
+BROADBAND.GOV,Federal Agency,Federal Communications Commission,Washington,DC
+BROADBANDMAP.GOV,Federal Agency,Federal Communications Commission,Washington,DC
+DTV.GOV,Federal Agency,Federal Communications Commission,Washington,DC
+FCC.GOV,Federal Agency,Federal Communications Commission,Washington,DC
+FCCUNIVERSITY.GOV,Federal Agency,Federal Communications Commission,Washington,DC
+LIFELINE.GOV,Federal Agency,Federal Communications Commission,Washington,DC
+NBM.GOV,Federal Agency,Federal Communications Commission,Washington,DC
+OPENINTERNET.GOV,Federal Agency,Federal Communications Commission,Washington,DC
+ECONOMICINCLUSION.GOV,Federal Agency,Federal Deposit Insurance Corporation,Arlington,VA
+FDIC.GOV,Federal Agency,Federal Deposit Insurance Corporation,Arlington,VA
+FDICBETS.GOV,Federal Agency,Federal Deposit Insurance Corporation,Arlington,VA
+FDICCONNECT.GOV,Federal Agency,Federal Deposit Insurance Corporation,Arlington,VA
+FDICIG.GOV,Federal Agency,Federal Deposit Insurance Corporation,Arlington,VA
+FDICOIG.GOV,Federal Agency,Federal Deposit Insurance Corporation,Washington,DC
+FDICSALES.GOV,Federal Agency,Federal Deposit Insurance Corporation,Arlington,VA
+FDICSEGURO.GOV,Federal Agency,Federal Deposit Insurance Corporation,Arlington,VA
+MYFDIC.GOV,Federal Agency,Federal Deposit Insurance Corporation,Arlington,VA
+MYFDICINSURANCE.GOV,Federal Agency,Federal Deposit Insurance Corporation,Arlington,VA
+FEC.GOV,Federal Agency,Federal Elections Commission,Washington,DC
+FERC.GOV,Federal Agency,Federal Energy Regulatory Commission,Washington,DC
+FERCALT.GOV,Federal Agency,Federal Energy Regulatory Commission,Washington,DC
+FHFA.GOV,Federal Agency,Federal Housing Finance Agency,Washington,DC
+FHFB.GOV,Federal Agency,Federal Housing Finance Agency,Washington,DC
+HARP.GOV,Federal Agency,Federal Housing Finance Agency,Washington,DC
+OFHEO.GOV,Federal Agency,Federal Housing Finance Agency,Washington,DC
+FHFAOIG.GOV,Federal Agency,Federal Housing Finance Agency Office of Inspector General,Washington,DC
+FLRA.GOV,Federal Agency,Federal Labor Relations Authority,Washington,DC
+FMC.GOV,Federal Agency,Federal Maritime Commission,Washington,DC
+FMCS.GOV,Federal Agency,Federal Mediation and Conciliation Service,Washington,DC
+FBIIC.GOV,Federal Agency,Federal Reserve System,Washington,DC
+FEDCENTENNIAL.GOV,Federal Agency,Federal Reserve System,Washington,DC
+FEDERALRESERVE.GOV,Federal Agency,Federal Reserve System,Washington,DC
+FEDERALRESERVE100.GOV,Federal Agency,Federal Reserve System,Washington ,DC
+FEDERALRESERVE2013.GOV,Federal Agency,Federal Reserve System,Washington,DC
+FEDERALRESERVECENTENNIAL.GOV,Federal Agency,Federal Reserve System,Washington ,DC
+FEDERALRESERVECENTENNIALCELEBRATION.GOV,Federal Agency,Federal Reserve System,Washington,DC
+FEDERALRESERVECONSUMERHELP.GOV,Federal Agency,Federal Reserve System,Washington,DC
+FEDPARTNERSHIP.GOV,Federal Agency,Federal Reserve System,Washington,DC
+FFIEC.GOV,Federal Agency,Federal Reserve System,Washington,DC
+FRB.FED.US,Federal Agency,Federal Reserve System,Washington,DC
+FRB.GOV,Federal Agency,Federal Reserve System,Washington,DC
+FRS.GOV,Federal Agency,Federal Reserve System,Washington,DC
+NEWMONEY.GOV,Federal Agency,Federal Reserve System,Washington,DC
+EXPLORETSP.GOV,Federal Agency,Federal Retirement Thrift Investment Board,Washington,DC
+FRTIB.GOV,Federal Agency,Federal Retirement Thrift Investment Board,Washington,DC
+FRTIBTEST.GOV,Federal Agency,Federal Retirement Thrift Investment Board,Washigton,DC
+TSP.GOV,Federal Agency,Federal Retirement Thrift Investment Board,Washington,DC
+TSPTEST.GOV,Federal Agency,Federal Retirement Thrift Investment Board,Washington,DC
+ADMONGO.GOV,Federal Agency,Federal Trade Commission,Washington,DC
+ALERTAENLINEA.GOV,Federal Agency,Federal Trade Commission,Washington,DC
+ANNUALCREDITREPORT.GOV,Federal Agency,Federal Trade Commission,Washington,DC
+CONSUMER.GOV,Federal Agency,Federal Trade Commission,Washington,DC
+CONSUMERSENTINEL.GOV,Federal Agency,Federal Trade Commission,Washington,DC
+CONSUMERSENTINELNETWORK.GOV,Federal Agency,Federal Trade Commission,Washington,DC
+CONSUMIDOR.GOV,Federal Agency,Federal Trade Commission,Washington,DC
+DONOTCALL.GOV,Federal Agency,Federal Trade Commission,Washington,DC
+DONTSERVETEENS.GOV,Federal Agency,Federal Trade Commission,Washington,DC
+ECONSUMER.GOV,Federal Agency,Federal Trade Commission,Washington,DC
+FREECREDITREPORT.GOV,Federal Agency,Federal Trade Commission,Washington,DC
+FTC.GOV,Federal Agency,Federal Trade Commission,Washington,DC
+FTCCOMPLAINTASSISTANT.GOV,Federal Agency,Federal Trade Commission,Washington,DC
+FTCEFILE.GOV,Federal Agency,Federal Trade Commission,Washington,DC
+HSR.GOV,Federal Agency,Federal Trade Commission,Washington,DC
+IDENTITYTHEFT.GOV,Federal Agency,Federal Trade Commission,Washington,DC
+IDTHEFT.GOV,Federal Agency,Federal Trade Commission,Washington,DC
+NCPW.GOV,Federal Agency,Federal Trade Commission,Washington,DC
+ONGUARDONLINE.GOV,Federal Agency,Federal Trade Commission,Washington,DC
+ONLINEONGUARD.GOV,Federal Agency,Federal Trade Commission,Washington,DC
+PROTECCIONDELCONSUMIDOR.GOV,Federal Agency,Federal Trade Commission,Washington,DC
+SENTINEL.GOV,Federal Agency,Federal Trade Commission,Washington,DC
+UCE.GOV,Federal Agency,Federal Trade Commission,Washington,DC
+USICN.GOV,Federal Agency,Federal Trade Commission,Washington,DC
+ACQUISITION.GOV,Federal Agency,General Services Administration,Arlington,VA
+ADVANTAGE.GOV,Federal Agency,General Services Administration,Washington,DC
+AFADVANTAGE.GOV,Federal Agency,General Services Administration,Washington,DC
+AMERICANJOBCENTER.GOV,Federal Agency,General Services Administration,Washington,DC
+APPS.GOV,Federal Agency,General Services Administration,Washington,DC
+BUSINESSUSA.GOV,Federal Agency,General Services Administration,Washington,DC
+BUYACCESSIBLE.GOV,Federal Agency,General Services Administration,Washington,DC
+CAO.GOV,Federal Agency,General Services Administration,Washington,DC
+CBCA.GOV,Federal Agency,General Services Administration,Washington,DC
+CCR.GOV,Federal Agency,General Services Administration,Battle Creek,MI
+CFDA.GOV,Federal Agency,General Services Administration,Washington,DC
+CFO.GOV,Federal Agency,General Services Administration,Washington,DC
+CHALLENGE.GOV,Federal Agency,General Services Administration,Washington,DC
+CHALLENGES.GOV,Federal Agency,General Services Administration,Washington,DC
+CIO.GOV,Federal Agency,General Services Administration,Washington,DC
+COMPUTERS4LEARNING.GOV,Federal Agency,General Services Administration,Arlington,VA
+COMPUTERSFORLEARNING.GOV,Federal Agency,General Services Administration,Arlington,VA
+CONNECT.GOV,Federal Agency,General Services Administration,Washington,DC
+CONSUMERACTION.GOV,Federal Agency,General Services Administration,Washington,DC
+CONTRACTDIRECTORY.GOV,Federal Agency,General Services Administration,Arlington,VA
+CPARS.GOV,Federal Agency,General Services Administration,Washington,DC
+DATA.GOV,Federal Agency,General Services Administration,Washington,DC
+DIGITALGOV.GOV,Federal Agency,General Services Administration,Washington,DC
+DOTGOV.GOV,Federal Agency,General Services Administration,Fairfax,VA
+EAC.GOV,Federal Agency,General Services Administration,Washington,DC
+ECPIC.GOV,Federal Agency,General Services Administration,Washington,DC
+EFACA.GOV,Federal Agency,General Services Administration,Washington,DC
+EFORMS.GOV,Federal Agency,General Services Administration,Washington,DC
+EISENHOWERMEMORIAL.GOV,Federal Agency,General Services Administration,Washington,DC
+EPLS.GOV,Federal Agency,General Services Administration,Arlington,VA
+ESPANOL.GOV,Federal Agency,General Services Administration,Washington,DC
+ESRS.GOV,Federal Agency,General Services Administration,arlington,VA
+FACA.GOV,Federal Agency,General Services Administration,Washington,DC
+FACADATABASE.GOV,Federal Agency,General Services Administration,Washington,DC
+FAI.GOV,Federal Agency,General Services Administration,Washington,DC
+FAPIIS.GOV,Federal Agency,General Services Administration,Washington,DC
+FAQ.GOV,Federal Agency,General Services Administration,Washington,DC
+FBO.GOV,Federal Agency,General Services Administration,Arlington,VA
+FED.US,Federal Agency,General Services Administration,Washington,DC
+FEDBIZOPPS.GOV,Federal Agency,General Services Administration,Arlington,VA
+FEDFORMS.GOV,Federal Agency,General Services Administration,Washington,DC
+FEDIDCARD.GOV,Federal Agency,General Services Administration,Washington,DC
+FEDINFO.GOV,Federal Agency,General Services Administration,Washington,DC
+FEDRAMP.GOV,Federal Agency,General Services Administration,Washington,DC
+FEDREALESTATE.GOV,Federal Agency,General Services Administration,San Francisco,CA
+FEDROOMS.GOV,Federal Agency,General Services Administration,Arlington,VA
+FIDO.GOV,Federal Agency,General Services Administration,Washington,DC
+FIRSTGOV.GOV,Federal Agency,General Services Administration,Washington,DC
+FMI.GOV,Federal Agency,General Services Administration,Washington,DC
+FORMS.GOV,Federal Agency,General Services Administration,Washington,DC
+FPDS.GOV,Federal Agency,General Services Administration,Arlington,VA
+FPKI-LAB.GOV,Federal Agency,General Services Administration,Washington,DC
+FPKI.GOV,Federal Agency,General Services Administration,Washington,DC
+FRPP-PA.GOV,Federal Agency,General Services Administration,WASHINGTON,DC
+FSD.GOV,Federal Agency,General Services Administration,Arlington,VA
+FSRS.GOV,Federal Agency,General Services Administration,Crystal City,VA
+GOBIERNO.GOV,Federal Agency,General Services Administration,Washington,DC
+GOBIERNOUSA.GOV,Federal Agency,General Services Administration,Washington,DC
+GOVSALES.GOV,Federal Agency,General Services Administration,Arlington,VA
+GSA.GOV,Federal Agency,General Services Administration,Washington,DC
+GSAADVANTAGE.GOV,Federal Agency,General Services Administration,Washington,DC
+GSAAUCTIONS.GOV,Federal Agency,General Services Administration,Washington,DC
+GSADVANTAGE.GOV,Federal Agency,General Services Administration,Washington,DC
+GSAIG.GOV,Federal Agency,General Services Administration,Washington,DC
+GSAXCESS.GOV,Federal Agency,General Services Administration,Arlington,VA
+HOWTO.GOV,Federal Agency,General Services Administration,Washington,DC
+IDMANAGEMENT.GOV,Federal Agency,General Services Administration,Washington,DC
+INFO.GOV,Federal Agency,General Services Administration,Washington,DC
+JOBCENTER.GOV,Federal Agency,General Services Administration,Washington,DC
+KIDS.GOV,Federal Agency,General Services Administration,Washington,DC
+LEARNPERFORMANCE.GOV,Federal Agency,General Services Administration,Washington,DC
+MYUSA.GOV,Federal Agency,General Services Administration,Washington,DC
+NBRC.GOV,Federal Agency,General Services Administration,Bangor,ME
+NETWORX.GOV,Federal Agency,General Services Administration,Fairfax,VA
+NIC.GOV,Federal Agency,General Services Administration,Fairfax,VA
+NONPROFIT.GOV,Federal Agency,General Services Administration,Washington,DC
+PARTNER4SOLUTIONS.GOV,Federal Agency,General Services Administration,Washington,DC
+PCLOB.GOV,Federal Agency,General Services Administration,Washington,DC
+PERFORMANCE.GOV,Federal Agency,General Services Administration,Washington,DC
+PIC.GOV,Federal Agency,General Services Administration,Washington,DC
+PPIRS.GOV,Federal Agency,General Services Administration,Washington,DC
+PTT.GOV,Federal Agency,General Services Administration,Washington D.C.,DC
+REALESTATESALES.GOV,Federal Agency,General Services Administration,Washington,DC
+REALPROPERTYPROFILE.GOV,Federal Agency,General Services Administration,Washington,DC
+REGINFO.GOV,Federal Agency,General Services Administration,Washington,DC
+ROCIS.GOV,Federal Agency,General Services Administration,Washington,DC
+SAM.GOV,Federal Agency,General Services Administration,Arlington,VA
+SANDBOX.GOV,Federal Agency,General Services Administration,Washinton,DC
+SECTION508.GOV,Federal Agency,General Services Administration,Washington,DC
+SENIORS.GOV,Federal Agency,General Services Administration,Washington,DC
+SFTOOL.GOV,Federal Agency,General Services Administration,Chicago,IL
+STRATEGICSOURCING.GOV,Federal Agency,General Services Administration,Arlington,VA
+SUPPORTTHEVOTER.GOV,Federal Agency,General Services Administration,WASHINGTON,DC
+TRANSPARENCY.GOV,Federal Agency,General Services Administration,Washington,DC
+UNITEDSTATES.GOV,Federal Agency,General Services Administration,Washington,DC
+US.GOV,Federal Agency,General Services Administration,Washington,DC
+USA.GOV,Federal Agency,General Services Administration,Washington,DC
+USAGOV.GOV,Federal Agency,General Services Administration,Washington,DC
+USAPERFORMANCE.GOV,Federal Agency,General Services Administration,Washington,DC
+USCIRF.GOV,Federal Agency,General Services Administration,Washington,DC
+USGOVERNMENT.GOV,Federal Agency,General Services Administration,Washington,DC
+USIP.GOV,Federal Agency,General Services Administration,Washington,DC
+VEF.GOV,Federal Agency,General Services Administration,Arlington,VA
+VITM.GOV,Federal Agency,General Services Administration,Arlington,VA
+BROWSETOPICS.GOV,Federal Agency,Government Printing Office,Washington,DC
+CONGRESSIONALDIRECTORY.GOV,Federal Agency,Government Printing Office,Washington,DC
+CONGRESSIONALRECORD.GOV,Federal Agency,Government Printing Office,Washington,DC
+ECFR.GOV,Federal Agency,Government Printing Office,Washington,DC
+FDLP.GOV,Federal Agency,Government Printing Office,Washington,DC
+FDSYS.GOV,Federal Agency,Government Printing Office,Washington,DC
+FEDERALREGISTER.GOV,Federal Agency,Government Printing Office,Washington,DC
+FEDREG.GOV,Federal Agency,Government Printing Office,Washington,DC
+FMSHRC.GOV,Federal Agency,Government Printing Office,Washington,DC
+GOVINFO.GOV,Federal Agency,Government Printing Office,Washington,DC
+GPO.GOV,Federal Agency,Government Printing Office,Washington,DC
+GPOACCESS.GOV,Federal Agency,Government Printing Office,Washington,DC
+HOUSECALENDAR.GOV,Federal Agency,Government Printing Office,Washington,DC
+OFR.GOV,Federal Agency,Government Printing Office,Washington,DC
+OPENWORLD.GOV,Federal Agency,Government Printing Office,Washington,DC
+PRESIDENTIALDOCUMENTS.GOV,Federal Agency,Government Printing Office,Washington,DC
+SENATECALENDAR.GOV,Federal Agency,Government Printing Office,Washington,DC
+STOPFAKES.GOV,Federal Agency,Government Printing Office,Washington,DC
+USCAPITOLPOLICE.GOV,Federal Agency,Government Printing Office,Washington,DC
+USCC.GOV,Federal Agency,Government Printing Office,Washington,DC
+USCCR.GOV,Federal Agency,Government Printing Office,Washington,DC
+USCODE.GOV,Federal Agency,Government Printing Office,Washington,DC
+USGOVERNMENTMANUAL.GOV,Federal Agency,Government Printing Office,College Park,MD
+WELCOMETOUSA.GOV,Federal Agency,Government Printing Office,Washington,DC
+TRUMAN.GOV,Federal Agency,Harry S. Truman Scholarship Foundation,Washington,DC
+IMLS.GOV,Federal Agency,Institute of Museum and Library Services,Washington,DC
+IAF.GOV,Federal Agency,Inter-American Foundation,Washington,DC
+BBG.GOV,Federal Agency,International Broadcasting Bureau,Washington,DC
+IBB.GOV,Federal Agency,International Broadcasting Bureau,Washington,DC
+VOA.GOV,Federal Agency,International Broadcasting Bureau,Washington,DC
+JAMESMADISON.GOV,Federal Agency,James Madison Memorial Fellowship Foundation,Alexandria,VA
+LSC.GOV,Federal Agency,Legal Services Corporation,Washington,DC
+AFRICANAMERICANHISTORYMONTH.GOV,Federal Agency,Library of Congress,Washington,DC
+AMERICANMEMORY.GOV,Federal Agency,Library of Congress,Washington,DC
+AMERICASLIBRARY.GOV,Federal Agency,Library of Congress,Washington,DC
+AMERICASSTORY.GOV,Federal Agency,Library of Congress,Washington,DC
+AMERICASTORY.GOV,Federal Agency,Library of Congress,Washington,DC
+ASIANPACIFICHERITAGE.GOV,Federal Agency,Library of Congress,Washington,DC
+CAPITOLHILL.GOV,Federal Agency,Library of Congress,Washington,DC
+COMMISSION.GOV,Federal Agency,Library of Congress,Washington,DC
+CONGRESS.GOV,Federal Agency,Library of Congress,Washington,DC
+COPYRIGHT.GOV,Federal Agency,Library of Congress,Washington,DC
+CRS.GOV,Federal Agency,Library of Congress,Washington,DC
+DIGITALPRESERVATION.GOV,Federal Agency,Library of Congress,Washington,DC
+DIGITALSTEWARDSHIP.GOV,Federal Agency,Library of Congress,Washington,DC
+DIGITIZATIONGUIDELINES.GOV,Federal Agency,Library of Congress,Washington,DC
+HILL.GOV,Federal Agency,Library of Congress,Washington,DC
+HISPANICHERITAGEMONTH.GOV,Federal Agency,Library of Congress,Washington,DC
+JEWISHHERITAGE.GOV,Federal Agency,Library of Congress,Washington,DC
+JEWISHHERITAGEMONTH.GOV,Federal Agency,Library of Congress,Washington,DC
+LAW.GOV,Federal Agency,Library of Congress,Washington,DC
+LCTL.GOV,Federal Agency,Library of Congress,Washington,DC
+LEGISLATIVE.GOV,Federal Agency,Library of Congress,Washington,DC
+LEGISLATIVEBRANCH.GOV,Federal Agency,Library of Congress,Washington,DC
+LIBRARY-OF-CONGRESS.GOV,Federal Agency,Library of Congress,Washington,DC
+LIBRARYOFCONGRESS.GOV,Federal Agency,Library of Congress,Washington,DC
+LIS.GOV,Federal Agency,Library of Congress,Washington,DC
+LITERACY.GOV,Federal Agency,Library of Congress,Washington,DC
+LOC.GOV,Federal Agency,Library of Congress,Washington,DC
+LOCIMAGES.GOV,Federal Agency,Library of Congress,Washington,DC
+LOCSTORE.GOV,Federal Agency,Library of Congress,Washington,DC
+LOCTPS.GOV,Federal Agency,Library of Congress,Washington,DC
+MYLOC.GOV,Federal Agency,Library of Congress,Washington,DC
+NATIVEAMERICANHERITAGEMONTH.GOV,Federal Agency,Library of Congress,Washington,DC
+NDSA.GOV,Federal Agency,Library of Congress,Washington,DC
+PRIMARYSOURCES.GOV,Federal Agency,Library of Congress,Washington,DC
+READ.GOV,Federal Agency,Library of Congress,Washington,DC
+SECTION108.GOV,Federal Agency,Library of Congress,Washington,DC
+TEACHINGPRIMARYSOURCES.GOV,Federal Agency,Library of Congress,Washington,DC
+TEACHINGWITHPRIMARYSOURCES.GOV,Federal Agency,Library of Congress,Washington,DC
+THOMAS.GOV,Federal Agency,Library of Congress,Washington,DC
+TPS.GOV,Federal Agency,Library of Congress,Washington,DC
+UNITEDSTATESCONGRESS.GOV,Federal Agency,Library of Congress,Washington,DC
+USCONGRESS.GOV,Federal Agency,Library of Congress,Washington,DC
+WDL.GOV,Federal Agency,Library of Congress,Washington,DC
+WOMENSHISTORYMONTH.GOV,Federal Agency,Library of Congress,Washington,DC
+WORLDDIGITALLIBRARY.GOV,Federal Agency,Library of Congress,Washington,DC
+MMC.GOV,Federal Agency,Marine Mammal Commission,Bethesda,MD
+MACPAC.GOV,Federal Agency,Medicaid and CHIP Payment and Access Commission,Washington,DC
+MEDPAC.GOV,Federal Agency,Medical Payment Advisory Commission,Washington,DC
+MSPB.GOV,Federal Agency,Merit Systems Protection Board,Washington,DC
+MCC.GOV,Federal Agency,Millennium Challenge Corporation,Washington,DC
+ECR.GOV,Federal Agency,Morris K. Udall Foundation,Tucson,AZ
+UDALL.GOV,Federal Agency,Morris K. Udall Foundation,Tucson,AZ
+GLOBE.GOV,Federal Agency,National Aeronautics and Space Administration,Greenbelt,MD
+NASA.GOV,Federal Agency,National Aeronautics and Space Administration,MSFC,AL
+NSWP.GOV,Federal Agency,National Aeronautics and Space Administration,MSFC,AL
+SCIJINKS.GOV,Federal Agency,National Aeronautics and Space Administration,MSFC,AL
+USGEO.GOV,Federal Agency,National Aeronautics and Space Administration,MSFC,AL
+9-11COMMISSION.GOV,Federal Agency,National Archives and Records Administration,College Park,MD
+911COMMISSION.GOV,Federal Agency,National Archives and Records Administration,College Park,MD
+ARCHIVES.GOV,Federal Agency,National Archives and Records Administration,College Park,MD
+CLINTONLIBRARY.GOV,Federal Agency,National Archives and Records Administration,Little Rock,AR
+EMERGENCY-FEDERAL-REGISTER.GOV,Federal Agency,National Archives and Records Administration,College Park,MD
+FCIC.GOV,Federal Agency,National Archives and Records Administration,College Park,MD
+FORDLIBRARYMUSEUM.GOV,Federal Agency,National Archives and Records Administration,College Park,MD
+FRC.GOV,Federal Agency,National Archives and Records Administration,College Park,MD
+GEORGEWBUSHLIBRARY.GOV,Federal Agency,National Archives and Records Administration,College Park,MD
+HISTORY.GOV,Federal Agency,National Archives and Records Administration,College Park,MD
+JIMMYCARTERLIBRARY.GOV,Federal Agency,National Archives and Records Administration,College,MD
+NARA-AT-WORK.GOV,Federal Agency,National Archives and Records Administration,College Park,MD
+NARA.GOV,Federal Agency,National Archives and Records Administration,College Park,MD
+NIXONLIBRARY.GOV,Federal Agency,National Archives and Records Administration,College Park,MD
+OGIS.GOV,Federal Agency,National Archives and Records Administration,College Park,MD
+OURDOCUMENTS.GOV,Federal Agency,National Archives and Records Administration,College Park,MD
+REAGANLIBRARY.GOV,Federal Agency,National Archives and Records Administration,College Park,MD
+RECORDSMANAGEMENT.GOV,Federal Agency,National Archives and Records Administration,College Park,MD
+WARTIMECONTRACTING.GOV,Federal Agency,National Archives and Records Administration,College Park,MD
+WEBHARVEST.GOV,Federal Agency,National Archives and Records Administration,College Park,MD
+NCPC.GOV,Federal Agency,National Capital Planning Commission,Washington,DC
+NCD.GOV,Federal Agency,National Council on Disability,Washington,DC
+MYCREDITUNION.GOV,Federal Agency,National Credit Union Administration,Alexandria,VA
+NCUA.GOV,Federal Agency,National Credit Union Administration,Alexandria,VA
+ARTS.GOV,Federal Agency,National Endowment for the Arts,Washington,DC
+NEA.GOV,Federal Agency,National Endowment for the Arts,Washington,DC
+HUMANITIES.GOV,Federal Agency,National Endowment for the Humanities,Washington,DC
+NEH.GOV,Federal Agency,National Endowment for the Humanities,Washington,DC
+PCAH.GOV,Federal Agency,National Endowment for the Humanities,Washington,DC
+WETHEPEOPLE.GOV,Federal Agency,National Endowment for the Humanities,Washington,DC
+NGA.GOV,Federal Agency,National Gallery of Art,Washington,DC
+NIGC.GOV,Federal Agency,National Indian Gaming Commission,Washington,DC
+NLRB.GOV,Federal Agency,National Labor Relations Board,Washington,DC
+NMB.GOV,Federal Agency,National Mediation Board,Washington,DC
+NANO.GOV,Federal Agency,National Nanotechnology Coordination Office,Arlington,VA
+ARCTIC.GOV,Federal Agency,National Science Foundation,Arlington,VA
+ARCTICGAS.GOV,Federal Agency,National Science Foundation,Washington,DC
+NSF.GOV,Federal Agency,National Science Foundation,Arlington,VA
+RESEARCH.GOV,Federal Agency,National Science Foundation,Arlington,VA
+SAC.GOV,Federal Agency,National Science Foundation,Arlington,VA
+SBIR.GOV,Federal Agency,National Science Foundation,Arlington,VA
+SCIENCE360.GOV,Federal Agency,National Science Foundation,Arlington,VA
+USAP.GOV,Federal Agency,National Science Foundation,Arlington,VA
+LPS.GOV,Federal Agency,National Security Agency,College Park,MD
+NTSB.GOV,Federal Agency,National Transportation Safety Board,Washington,DC
+ITRD.GOV,Federal Agency,Networking Information Technology Research and Development (NITRD),Arlington,VA
+NITRD.GOV,Federal Agency,Networking Information Technology Research and Development (NITRD),Arlington,VA
+HERITAGEABROAD.GOV,Federal Agency,Non-Federal Agency,Washington,DC
+IAB.GOV,Federal Agency,Non-Federal Agency,Quantico,VA
+JUSFC.GOV,Federal Agency,Non-Federal Agency,Washington,DC
+NWTRB.GOV,Federal Agency,Non-Federal Agency,Arlington,VA
+PPPL.GOV,Federal Agency,Non-Federal Agency,Princeton,NJ
+SERVEINDIANA.GOV,Federal Agency,Non-Federal Agency,Indianapolis,IN
+SJI.GOV,Federal Agency,Non-Federal Agency,Reston,VA
+WMATC.GOV,Federal Agency,Non-Federal Agency,Silver Spring,MD
+NRC-GATEWAY.GOV,Federal Agency,Nuclear Regulatory Commission,Rockville,MD
+NRC.GOV,Federal Agency,Nuclear Regulatory Commission,Rockville,MD
+OSHRC.GOV,Federal Agency,Occupational Safety & Health Review Commission,Washington,DC
+INTEGRITY.GOV,Federal Agency,Office of Government Ethics,Washington,DC
+APPLICATIONMANAGER.GOV,Federal Agency,Office of Personnel Management,Macon,GA
+CHCOC.GOV,Federal Agency,Office of Personnel Management,Washington,DC
+E-QIP.GOV,Federal Agency,Office of Personnel Management,Washington,DC
+EMPLOYEEEXPRESS.GOV,Federal Agency,Office of Personnel Management,Macon,GA
+FEB.GOV,Federal Agency,Office of Personnel Management,Washington,DC
+FEDERALJOBS.GOV,Federal Agency,Office of Personnel Management,Macon,GA
+FEDJOBS.GOV,Federal Agency,Office of Personnel Management,Macon,GA
+FEDSHIREVETS.GOV,Federal Agency,Office of Personnel Management,Washington,DC
+FEGLI.GOV,Federal Agency,Office of Personnel Management,Washington,DC
+FSAFEDS.GOV,Federal Agency,Office of Personnel Management,Washington,DC
+GOLEARN.GOV,Federal Agency,Office of Personnel Management,Washington,DC
+GOVERNMENTJOBS.GOV,Federal Agency,Office of Personnel Management,Macon,GA
+HRU.GOV,Federal Agency,Office of Personnel Management,Washington,DC
+LMRCOUNCIL.GOV,Federal Agency,Office of Personnel Management,Washington,DC
+OPM.GOV,Federal Agency,Office of Personnel Management,Macon,GA
+PAC.GOV,Federal Agency,Office of Personnel Management,Washington,DC
+PMF.GOV,Federal Agency,Office of Personnel Management,Washington,DC
+TELEWORK.GOV,Federal Agency,Office of Personnel Management,Washington,DC
+UNLOCKTALENT.GOV,Federal Agency,Office of Personnel Management,Washington,DC
+USAJOBS.GOV,Federal Agency,Office of Personnel Management,Washington,DC
+USALEARNING.GOV,Federal Agency,Office of Personnel Management,Washington,DC
+USASTAFFING.GOV,Federal Agency,Office of Personnel Management,Macon,GA
+OPIC.GOV,Federal Agency,Overseas Private Investment Corporation,Washington,DC
+PBGC.GOV,Federal Agency,Pension Benefit Guaranty Corporation,Washington,DC
+PRC.GOV,Federal Agency,Postal Rate Commission,Washington,DC
+RRB.GOV,Federal Agency,Railroad Retirement Board,Chicago,IL
+EDUCATIONJOBSFUND.GOV,Federal Agency,Recovery Accountability and Transparency Board,Washington,DC
+FEDERALACCOUNTABILITY.GOV,Federal Agency,Recovery Accountability and Transparency Board,Washington,DC
+FEDERALREPORTING.GOV,Federal Agency,Recovery Accountability and Transparency Board,Washington,DC
+FEDERALTRANSPARENCY.GOV,Federal Agency,Recovery Accountability and Transparency Board,Washington ,DC
+RATB.GOV,Federal Agency,Recovery Accountability and Transparency Board,WASHINGTON,DC
+RECOVERY.GOV,Federal Agency,Recovery Accountability and Transparency Board,Washington,DC
+404.GOV,Federal Agency,Securities and Exchange Commission,Alexandria,VA
+INVESTOR.GOV,Federal Agency,Securities and Exchange Commission,Alexandria,VA
+SEC.GOV,Federal Agency,Securities and Exchange Commission,Alexandria,VA
+SSS.GOV,Federal Agency,Selective Service System,Arlington,VA
+BUSINESS.GOV,Federal Agency,Small Business Administration,Washington,DC
+DISASTERCONTRACTINGASSISTANCE.GOV,Federal Agency,Small Business Administration,Washington,DC
+HSA.GOV,Federal Agency,Small Business Administration,Washington,DC
+NWBC.GOV,Federal Agency,Small Business Administration,Washington,DC
+ONLINEWBC.GOV,Federal Agency,Small Business Administration,Washington,DC
+SBA.GOV,Federal Agency,Small Business Administration,Washington,DC
+SMALLBUSINESS.GOV,Federal Agency,Small Business Administration,Washington,DC
+WOMENBIZ.GOV,Federal Agency,Small Business Administration,Washington,DC
+ITIS.GOV,Federal Agency,Smithsonian Institution,Washington,DC
+SEGUROSOCIAL.GOV,Federal Agency,Social Security Administration,Baltimore,MD
+SOCIALSECURITY.GOV,Federal Agency,Social Security Administration,Baltimore,MD
+SSA.GOV,Federal Agency,Social Security Administration,Baltimore,MD
+SOCIALSECURITYADVISORYBOARD.GOV,Federal Agency,Social Security Advisory Board,Washington,DC
+SSAB.GOV,Federal Agency,Social Security Advisory Board,WASHINGTON,DC
+STENNIS.GOV,Federal Agency,Stennis Center for Public Service,Starkville,MS
+TVA.GOV,Federal Agency,Tennessee Valley Authority,Knoxville,TN
+TVAOIG.GOV,Federal Agency,Tennessee Valley Authority,Knoxville,TN
+TSC.GOV,Federal Agency,Terrorist Screening Center,Washington,DC
+PTF.GOV,Federal Agency,The Intelligence Community,Washington,DC
+BANKRUPTCY.GOV,Federal Agency,The Judicial Branch (Courts),Washington,DC
+CAVC.GOV,Federal Agency,The Judicial Branch (Courts),Washington,DC
+DCSC.GOV,Federal Agency,The Judicial Branch (Courts),Washington,DC
+FEDCIR.GOV,Federal Agency,The Judicial Branch (Courts),Washington,DC
+FEDERALCOURTS.GOV,Federal Agency,The Judicial Branch (Courts),Washington,DC
+FEDERALPROBATION.GOV,Federal Agency,The Judicial Branch (Courts),Washington,DC
+FEDERALRULES.GOV,Federal Agency,The Judicial Branch (Courts),Washington,DC
+FJC.GOV,Federal Agency,The Judicial Branch (Courts),Washington,DC
+JUDICIALCONFERENCE.GOV,Federal Agency,The Judicial Branch (Courts),Washington,DC
+NMCOURT.FED.US,Federal Agency,The Judicial Branch (Courts),Albuquerque,NM
+PACER.GOV,Federal Agency,The Judicial Branch (Courts),Washington,DC
+SC-US.GOV,Federal Agency,The Judicial Branch (Courts),Washington,DC
+SCINET-TEST.GOV,Federal Agency,The Judicial Branch (Courts),Washington,DC
+SCINET.GOV,Federal Agency,The Judicial Branch (Courts),Washington,DC
+SCUS.GOV,Federal Agency,The Judicial Branch (Courts),WASHINGTON,DC
+SUPREME-COURT.GOV,Federal Agency,The Judicial Branch (Courts),Washington,DC
+SUPREMECOURT.GOV,Federal Agency,The Judicial Branch (Courts),Washington,DC
+SUPREMECOURTUS.GOV,Federal Agency,The Judicial Branch (Courts),Washington,DC
+USBANKRUPTCY.GOV,Federal Agency,The Judicial Branch (Courts),Washington,DC
+USC.GOV,Federal Agency,The Judicial Branch (Courts),Washington,DC
+USCAVC.GOV,Federal Agency,The Judicial Branch (Courts),Washington,DC
+USCOURTS.GOV,Federal Agency,The Judicial Branch (Courts),Washington,DC
+USCVA.GOV,Federal Agency,The Judicial Branch (Courts),Washington,DC
+USPROBATION.GOV,Federal Agency,The Judicial Branch (Courts),Washington,DC
+USSC.GOV,Federal Agency,The Judicial Branch (Courts),Washington,DC
+USTAXCOURT.GOV,Federal Agency,The Judicial Branch (Courts),Washington,DC
+VETAPP.GOV,Federal Agency,The Judicial Branch (Courts),Washington,DC
+AOC.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC
+CAPITAL.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC
+CAPITOL.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC
+CAPITOLFLAGS.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC
+CBO.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC
+CBONEWS.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC
+CECC.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC
+CHINA-COMMISSION.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC
+CHINACOMMISSION.GOV,Federal Agency,The Legislative Branch (Congress),Washington,MD
+CITIZENCOSPONSORS.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC
+CITIZENS.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC
+COSPONSOR.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC
+CSCE.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC
+DEMOCRATICLEADER.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC
+DEMOCRATICWHIP.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC
+DEMOCRATS.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC
+DEMS.GOV,Federal Agency,The Legislative Branch (Congress),Washington DC,DC
+ESECLAB.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC
+FASAB.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC
+GAO.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC
+GAONET.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC
+GOP.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC
+GOPCONFERENCE.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC
+GOPLEADER.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC
+HOUSE.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC
+HOUSECOMMUNICATIONS.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC
+HOUSEDEMOCRATS.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC
+HOUSEDEMS.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC
+HOUSELIVE.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC
+HOUSENEWSLETTERS.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC
+JCT.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC
+LISTENSTOYOU.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC
+MAJORITYLEADER.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC
+MAJORITYWHIP.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC
+PDBCECC.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC
+PPDCECC.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC
+REPUBLICANS.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC
+SENATE.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC
+SENATERESTAURANTS.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC
+SPEAKER.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC
+TAXREFORM.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC
+USBG.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC
+USCAPITAL.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC
+USCAPITOL.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC
+USCAPITOLVISITORCENTER.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC
+USCVC.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC
+VISITTHECAPITAL.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC
+VISITTHECAPITOL.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC
+WORLDWAR1CENTENNIAL.GOV,Federal Agency,The United States World War One Centennial Commission,Washington,DC
+ACCESS-BOARD-MEMBERS.GOV,Federal Agency,U. S. Access Board,Washington,DC
+ACCESS-BOARD.GOV,Federal Agency,U. S. Access Board,Washington,DC
+USHMM.GOV,Federal Agency,U. S. Holocaust Memorial Museum,Washington,DC
+USITC.GOV,Federal Agency,U. S. International Trade Commission,Washington,DC
+OSC.GOV,Federal Agency,U. S. Office of Special Counsel,Washington,DC
+OSCNET.GOV,Federal Agency,U. S. Office of Special Counsel,Washington,DC
+PEACECORE.GOV,Federal Agency,U. S. Peace Corps,Washington,DC
+PEACECORP.GOV,Federal Agency,U. S. Peace Corps,Washington,DC
+PEACECORPS.GOV,Federal Agency,U. S. Peace Corps,Washington,DC
+MAIL.GOV,Federal Agency,U. S. Postal Service,Raleigh,NC
+POSTOFFICE.GOV,Federal Agency,U. S. Postal Service,Raleigh,NC
+PURCHASING.GOV,Federal Agency,U. S. Postal Service,Raleigh,NC
+USPIS.GOV,Federal Agency,U. S. Postal Service,Arlington,VA
+USPS.GOV,Federal Agency,U. S. Postal Service,Raleigh,NC
+CHILDRENINADVERSITY.GOV,Federal Agency,U.S. Agency for International Development,Washington,DC
+DFAFACTS.GOV,Federal Agency,U.S. Agency for International Development,Washington,DC
+FEEDTHEFUTURE.GOV,Federal Agency,U.S. Agency for International Development,Washington,DC
+FIGHTINGMALARIA.GOV,Federal Agency,U.S. Agency for International Development,Washington,DC
+JMC.GOV,Federal Agency,U.S. Agency for International Development,Washington,DC
+NEGLECTEDDISEASES.GOV,Federal Agency,U.S. Agency for International Development,Washington,DC
+OFDA.GOV,Federal Agency,U.S. Agency for International Development,Washington,DC
+OTI.GOV,Federal Agency,U.S. Agency for International Development,Washington,DC
+PMI.GOV,Federal Agency,U.S. Agency for International Development,Washington,DC
+USAID.GOV,Federal Agency,U.S. Agency for International Development,Washington,DC
+USAIDALLNET.GOV,Federal Agency,U.S. Agency for International Development,Arlington,VA
+VOLUNTEERSFORPROSPERITY.GOV,Federal Agency,U.S. Agency for International Development,Washington,DC
+USCP.GOV,Federal Agency,U.S. Capitol Police,Washington,DC
+CHEMSAFETY.GOV,Federal Agency,U.S. Chemical Safety and Hazard Investigation Board,Washington,DC
+CSB.GOV,Federal Agency,U.S. Chemical Safety and Hazard Investigation Board,Washington,DC
+SAFETYVIDEOS.GOV,Federal Agency,U.S. Chemical Safety and Hazard Investigation Board,Washington,DC
+CFA.GOV,Federal Agency,U.S. Commission of Fine Arts,Washington,DC
+PEACECORPSOIG.GOV,Federal Agency,"U.S. Postal Service, Office of Inspector General",Washington,DC
+USPSOIG.GOV,Federal Agency,"U.S. Postal Service, Office of Inspector General",Arlington,VA
+TDA.GOV,Federal Agency,U.S. Trade and Development Agency,Arlington,VA
+USTDA.GOV,Federal Agency,U.S. Trade and Development Agency,Arlington,VA
+CARBONCYCLESCIENCE.GOV,Federal Agency,United Stated Global Change Research Program,Washington,DC
+GLOBALCHANGE.GOV,Federal Agency,United Stated Global Change Research Program,Washington,DC
+IPCC-WG2.GOV,Federal Agency,United Stated Global Change Research Program,Stanford,CA
+USGCRP.GOV,Federal Agency,United Stated Global Change Research Program,Washington,DC
+OGE.GOV,Federal Agency,United States Office of Government Ethics,Washington,DC
+USOGE.GOV,Federal Agency,United States Office of Government Ethics,Washington,DC
+ICH.GOV,Federal Agency,US Interagency Council on Homelessness,washington,DC
+USICH.GOV,Federal Agency,US Interagency Council on Homelessness,Washington,DC

--- a/pages/analytics/domains.html
+++ b/pages/analytics/domains.html
@@ -22,7 +22,7 @@ description: "Which federal government domains are participating in the Digital 
         <tr>
           <th class="all">Domain</th>
           <th class="never">Canonical</th>
-          <th class="never">Agency</th>
+          <th class="all">Agency</th>
           <th class="min-tablet">Participates in DAP?</th>
         </tr>
       </thead>


### PR DESCRIPTION
This adds permalink support for search filters, and uses this feature to add support for filtering domains by agency.

![image](https://cloud.githubusercontent.com/assets/4592/7872914/14ec7312-056a-11e5-84c5-8f4a8a2fcc05.png)

Clicking the HHS domain number will take you to `/https/domains/#q=Department%20of%20Health%20And%20Human%20Services`, which shows the list of domains filtered to those owned by HHS.

Fixes #101, and #118.