### PR TITLE
Full data re-scan and update

### DIFF
--- a/assets/data/analytics.csv
+++ b/assets/data/analytics.csv
@@ -1,3 +1,3 @@
 status,value
-active,46
-inactive,54
+active,43
+inactive,57

--- a/assets/data/analytics.csv
+++ b/assets/data/analytics.csv
@@ -1,3 +1,3 @@
 status,value
-active,33
-inactive,67
+active,46
+inactive,54

--- a/assets/data/tables/analytics/agencies.json
+++ b/assets/data/tables/analytics/agencies.json
@@ -16,6 +16,11 @@
       "Participates in DAP?": 0
     },
     {
+      "Agency": "African Development Foundation",
+      "Number of Domains": 2,
+      "Participates in DAP?": 0
+    },
+    {
       "Agency": "American Battle Monuments Commission",
       "Number of Domains": 1,
       "Participates in DAP?": 0
@@ -43,16 +48,11 @@
     {
       "Agency": "Christopher Columbus Fellowship Foundation",
       "Number of Domains": 1,
-      "Participates in DAP?": 0
+      "Participates in DAP?": 100
     },
     {
       "Agency": "Civil Air Patrol",
       "Number of Domains": 1,
-      "Participates in DAP?": 0
-    },
-    {
-      "Agency": "Comm for People Who Are Blind/Severly Disabled",
-      "Number of Domains": 2,
       "Participates in DAP?": 0
     },
     {
@@ -63,16 +63,16 @@
     {
       "Agency": "Consumer Financial Protection Bureau",
       "Number of Domains": 1,
-      "Participates in DAP?": 0
+      "Participates in DAP?": 100
     },
     {
       "Agency": "Consumer Product Safety Commission",
       "Number of Domains": 4,
-      "Participates in DAP?": 0
+      "Participates in DAP?": 75
     },
     {
       "Agency": "Corporation for National & Community Service",
-      "Number of Domains": 6,
+      "Number of Domains": 7,
       "Participates in DAP?": 0
     },
     {
@@ -103,62 +103,62 @@
     {
       "Agency": "Department of Agriculture",
       "Number of Domains": 33,
-      "Participates in DAP?": 9
+      "Participates in DAP?": 18
     },
     {
       "Agency": "Department of Commerce",
-      "Number of Domains": 41,
-      "Participates in DAP?": 49
+      "Number of Domains": 39,
+      "Participates in DAP?": 69
     },
     {
       "Agency": "Department of Defense",
       "Number of Domains": 22,
-      "Participates in DAP?": 36
+      "Participates in DAP?": 45
     },
     {
       "Agency": "Department of Education",
       "Number of Domains": 10,
-      "Participates in DAP?": 70
+      "Participates in DAP?": 80
     },
     {
       "Agency": "Department of Energy",
-      "Number of Domains": 44,
-      "Participates in DAP?": 2
+      "Number of Domains": 43,
+      "Participates in DAP?": 9
     },
     {
       "Agency": "Department of Health And Human Services",
-      "Number of Domains": 73,
-      "Participates in DAP?": 26
+      "Number of Domains": 71,
+      "Participates in DAP?": 37
     },
     {
       "Agency": "Department of Homeland Security",
-      "Number of Domains": 18,
-      "Participates in DAP?": 50
+      "Number of Domains": 19,
+      "Participates in DAP?": 63
     },
     {
       "Agency": "Department of Housing And Urban Development",
       "Number of Domains": 9,
-      "Participates in DAP?": 11
+      "Participates in DAP?": 33
     },
     {
       "Agency": "Department of Justice",
-      "Number of Domains": 46,
-      "Participates in DAP?": 85
+      "Number of Domains": 50,
+      "Participates in DAP?": 76
     },
     {
       "Agency": "Department of Labor",
       "Number of Domains": 14,
-      "Participates in DAP?": 57
+      "Participates in DAP?": 71
     },
     {
       "Agency": "Department of State",
-      "Number of Domains": 19,
-      "Participates in DAP?": 32
+      "Number of Domains": 18,
+      "Participates in DAP?": 61
     },
     {
       "Agency": "Department of Transportation",
       "Number of Domains": 25,
-      "Participates in DAP?": 48
+      "Participates in DAP?": 72
     },
     {
       "Agency": "Department of Veterans Affairs",
@@ -167,23 +167,23 @@
     },
     {
       "Agency": "Department of the Interior",
-      "Number of Domains": 74,
-      "Participates in DAP?": 23
+      "Number of Domains": 73,
+      "Participates in DAP?": 40
     },
     {
       "Agency": "Department of the Treasury",
       "Number of Domains": 71,
-      "Participates in DAP?": 38
+      "Participates in DAP?": 65
     },
     {
       "Agency": "Director of National Intelligence",
-      "Number of Domains": 11,
+      "Number of Domains": 10,
       "Participates in DAP?": 0
     },
     {
       "Agency": "Environmental Protection Agency",
       "Number of Domains": 12,
-      "Participates in DAP?": 42
+      "Participates in DAP?": 50
     },
     {
       "Agency": "Equal Employment Opportunity Commission",
@@ -193,7 +193,7 @@
     {
       "Agency": "Executive Office of the President",
       "Number of Domains": 10,
-      "Participates in DAP?": 30
+      "Participates in DAP?": 40
     },
     {
       "Agency": "Export/Import Bank of the U.S.",
@@ -262,13 +262,13 @@
     },
     {
       "Agency": "Federal Trade Commission",
-      "Number of Domains": 15,
-      "Participates in DAP?": 47
+      "Number of Domains": 16,
+      "Participates in DAP?": 62
     },
     {
       "Agency": "General Services Administration",
-      "Number of Domains": 64,
-      "Participates in DAP?": 56
+      "Number of Domains": 62,
+      "Participates in DAP?": 76
     },
     {
       "Agency": "Harry S. Truman Scholarship Foundation",
@@ -323,7 +323,7 @@
     {
       "Agency": "Millennium Challenge Corporation",
       "Number of Domains": 1,
-      "Participates in DAP?": 0
+      "Participates in DAP?": 100
     },
     {
       "Agency": "Morris K. Udall Foundation",
@@ -427,8 +427,8 @@
     },
     {
       "Agency": "Office of Personnel Management",
-      "Number of Domains": 13,
-      "Participates in DAP?": 92
+      "Number of Domains": 14,
+      "Participates in DAP?": 93
     },
     {
       "Agency": "Overseas Private Investment Corporation",
@@ -458,7 +458,7 @@
     {
       "Agency": "Securities and Exchange Commission",
       "Number of Domains": 3,
-      "Participates in DAP?": 0
+      "Participates in DAP?": 33
     },
     {
       "Agency": "Selective Service System",
@@ -473,12 +473,12 @@
     {
       "Agency": "Smithsonian Institution",
       "Number of Domains": 1,
-      "Participates in DAP?": 0
+      "Participates in DAP?": 100
     },
     {
       "Agency": "Social Security Administration",
       "Number of Domains": 3,
-      "Participates in DAP?": 100
+      "Participates in DAP?": 67
     },
     {
       "Agency": "Social Security Advisory Board",
@@ -492,7 +492,7 @@
     },
     {
       "Agency": "Tennessee Valley Authority",
-      "Number of Domains": 1,
+      "Number of Domains": 2,
       "Participates in DAP?": 0
     },
     {
@@ -518,7 +518,7 @@
     {
       "Agency": "U. S. Peace Corps",
       "Number of Domains": 3,
-      "Participates in DAP?": 0
+      "Participates in DAP?": 33
     },
     {
       "Agency": "U. S. Postal Service",
@@ -527,8 +527,8 @@
     },
     {
       "Agency": "U.S. Agency for International Development",
-      "Number of Domains": 9,
-      "Participates in DAP?": 11
+      "Number of Domains": 8,
+      "Participates in DAP?": 50
     },
     {
       "Agency": "U.S. Chemical Safety and Hazard Investigation Board",
@@ -557,7 +557,7 @@
     },
     {
       "Agency": "United Stated Global Change Research Program",
-      "Number of Domains": 3,
+      "Number of Domains": 2,
       "Participates in DAP?": 0
     },
     {

--- a/assets/data/tables/analytics/agencies.json
+++ b/assets/data/tables/analytics/agencies.json
@@ -68,7 +68,7 @@
     {
       "Agency": "Consumer Financial Protection Bureau",
       "Number of Domains": 1,
-      "Participates in DAP?": 100
+      "Participates in DAP?": 0
     },
     {
       "Agency": "Consumer Product Safety Commission",
@@ -93,7 +93,7 @@
     {
       "Agency": "Defense Nuclear Facilities Safety Board",
       "Number of Domains": 1,
-      "Participates in DAP?": 100
+      "Participates in DAP?": 0
     },
     {
       "Agency": "Delta Regional Authority",
@@ -108,12 +108,12 @@
     {
       "Agency": "Department of Agriculture",
       "Number of Domains": 33,
-      "Participates in DAP?": 18
+      "Participates in DAP?": 21
     },
     {
       "Agency": "Department of Commerce",
       "Number of Domains": 39,
-      "Participates in DAP?": 69
+      "Participates in DAP?": 64
     },
     {
       "Agency": "Department of Defense",
@@ -128,12 +128,12 @@
     {
       "Agency": "Department of Energy",
       "Number of Domains": 43,
-      "Participates in DAP?": 9
+      "Participates in DAP?": 5
     },
     {
       "Agency": "Department of Health And Human Services",
       "Number of Domains": 71,
-      "Participates in DAP?": 37
+      "Participates in DAP?": 34
     },
     {
       "Agency": "Department of Homeland Security",
@@ -143,12 +143,12 @@
     {
       "Agency": "Department of Housing And Urban Development",
       "Number of Domains": 9,
-      "Participates in DAP?": 33
+      "Participates in DAP?": 22
     },
     {
       "Agency": "Department of Justice",
       "Number of Domains": 50,
-      "Participates in DAP?": 76
+      "Participates in DAP?": 72
     },
     {
       "Agency": "Department of Labor",
@@ -158,12 +158,12 @@
     {
       "Agency": "Department of State",
       "Number of Domains": 18,
-      "Participates in DAP?": 61
+      "Participates in DAP?": 50
     },
     {
       "Agency": "Department of Transportation",
       "Number of Domains": 25,
-      "Participates in DAP?": 72
+      "Participates in DAP?": 68
     },
     {
       "Agency": "Department of Veterans Affairs",
@@ -173,7 +173,7 @@
     {
       "Agency": "Department of the Interior",
       "Number of Domains": 73,
-      "Participates in DAP?": 40
+      "Participates in DAP?": 36
     },
     {
       "Agency": "Department of the Treasury",
@@ -188,7 +188,7 @@
     {
       "Agency": "Environmental Protection Agency",
       "Number of Domains": 12,
-      "Participates in DAP?": 50
+      "Participates in DAP?": 42
     },
     {
       "Agency": "Equal Employment Opportunity Commission",
@@ -273,7 +273,7 @@
     {
       "Agency": "General Services Administration",
       "Number of Domains": 62,
-      "Participates in DAP?": 76
+      "Participates in DAP?": 71
     },
     {
       "Agency": "Harry S. Truman Scholarship Foundation",
@@ -463,7 +463,7 @@
     {
       "Agency": "Securities and Exchange Commission",
       "Number of Domains": 3,
-      "Participates in DAP?": 33
+      "Participates in DAP?": 0
     },
     {
       "Agency": "Selective Service System",
@@ -523,7 +523,7 @@
     {
       "Agency": "U. S. Peace Corps",
       "Number of Domains": 3,
-      "Participates in DAP?": 33
+      "Participates in DAP?": 0
     },
     {
       "Agency": "U. S. Postal Service",

--- a/assets/data/tables/analytics/agencies.json
+++ b/assets/data/tables/analytics/agencies.json
@@ -56,6 +56,11 @@
       "Participates in DAP?": 0
     },
     {
+      "Agency": "Comm for People Who Are Blind/Severly Disabled",
+      "Number of Domains": 1,
+      "Participates in DAP?": 0
+    },
+    {
       "Agency": "Commodity Futures Trading Commission",
       "Number of Domains": 2,
       "Participates in DAP?": 0

--- a/assets/data/tables/analytics/domains.json
+++ b/assets/data/tables/analytics/domains.json
@@ -31,6 +31,12 @@
       "Participates in DAP?": 0
     },
     {
+      "Agency": "Comm for People Who Are Blind/Severly Disabled",
+      "Canonical": "http://abilityone.gov",
+      "Domain": "abilityone.gov",
+      "Participates in DAP?": 0
+    },
+    {
       "Agency": "American Battle Monuments Commission",
       "Canonical": "http://abmc.gov",
       "Domain": "abmc.gov",

--- a/assets/data/tables/analytics/domains.json
+++ b/assets/data/tables/analytics/domains.json
@@ -424,7 +424,7 @@
       "Agency": "Department of Justice",
       "Canonical": "http://bjs.gov",
       "Domain": "bjs.gov",
-      "Participates in DAP?": 1
+      "Participates in DAP?": 0
     },
     {
       "Agency": "Department of Commerce",
@@ -658,7 +658,7 @@
       "Agency": "Department of Health And Human Services",
       "Canonical": "https://childwelfare.gov",
       "Domain": "childwelfare.gov",
-      "Participates in DAP?": 1
+      "Participates in DAP?": 0
     },
     {
       "Agency": "Department of Agriculture",
@@ -796,7 +796,7 @@
       "Agency": "Consumer Financial Protection Bureau",
       "Canonical": "http://www.consumerfinance.gov",
       "Domain": "consumerfinance.gov",
-      "Participates in DAP?": 1
+      "Participates in DAP?": 0
     },
     {
       "Agency": "Federal Trade Commission",
@@ -1006,7 +1006,7 @@
       "Agency": "Defense Nuclear Facilities Safety Board",
       "Canonical": "http://www.dnfsb.gov",
       "Domain": "dnfsb.gov",
-      "Participates in DAP?": 1
+      "Participates in DAP?": 0
     },
     {
       "Agency": "Director of National Intelligence",
@@ -1192,7 +1192,7 @@
       "Agency": "Department of Energy",
       "Canonical": "http://www.eia.gov",
       "Domain": "eia.gov",
-      "Participates in DAP?": 1
+      "Participates in DAP?": 0
     },
     {
       "Agency": "General Services Administration",
@@ -1270,7 +1270,7 @@
       "Agency": "Department of Transportation",
       "Canonical": "http://www.esc.gov",
       "Domain": "esc.gov",
-      "Participates in DAP?": 1
+      "Participates in DAP?": 0
     },
     {
       "Agency": "Department of Justice",
@@ -1678,7 +1678,7 @@
       "Agency": "Department of Commerce",
       "Canonical": "http://www.fishwatch.gov",
       "Domain": "fishwatch.gov",
-      "Participates in DAP?": 1
+      "Participates in DAP?": 0
     },
     {
       "Agency": "Department of Health And Human Services",
@@ -1882,7 +1882,7 @@
       "Agency": "Department of the Interior",
       "Canonical": "http://www.fws.gov",
       "Domain": "fws.gov",
-      "Participates in DAP?": 1
+      "Participates in DAP?": 0
     },
     {
       "Agency": "Department of Education",
@@ -2044,7 +2044,7 @@
       "Agency": "General Services Administration",
       "Canonical": "http://www.gsadvantage.gov",
       "Domain": "gsadvantage.gov",
-      "Participates in DAP?": 1
+      "Participates in DAP?": 0
     },
     {
       "Agency": "General Services Administration",
@@ -2140,13 +2140,13 @@
       "Agency": "Department of the Treasury",
       "Canonical": "http://helpwithmycreditcard.gov",
       "Domain": "helpwithmycreditcard.gov",
-      "Participates in DAP?": 0
+      "Participates in DAP?": 1
     },
     {
       "Agency": "Department of the Treasury",
       "Canonical": "http://helpwithmycreditcardbank.gov",
       "Domain": "helpwithmycreditcardbank.gov",
-      "Participates in DAP?": 0
+      "Participates in DAP?": 1
     },
     {
       "Agency": "Department of the Treasury",
@@ -2212,7 +2212,7 @@
       "Agency": "Department of Housing And Urban Development",
       "Canonical": "http://hud.gov",
       "Domain": "hud.gov",
-      "Participates in DAP?": 1
+      "Participates in DAP?": 0
     },
     {
       "Agency": "Department of Housing And Urban Development",
@@ -2224,7 +2224,7 @@
       "Agency": "Department of State",
       "Canonical": "http://www.humanrights.gov",
       "Domain": "humanrights.gov",
-      "Participates in DAP?": 1
+      "Participates in DAP?": 0
     },
     {
       "Agency": "Department of Energy",
@@ -2518,7 +2518,7 @@
       "Agency": "Department of the Interior",
       "Canonical": "http://jem.gov",
       "Domain": "jem.gov",
-      "Participates in DAP?": 1
+      "Participates in DAP?": 0
     },
     {
       "Agency": "National Archives and Records Administration",
@@ -2602,7 +2602,7 @@
       "Agency": "Department of Agriculture",
       "Canonical": "http://www.lcacommons.gov",
       "Domain": "lcacommons.gov",
-      "Participates in DAP?": 0
+      "Participates in DAP?": 1
     },
     {
       "Agency": "Department of the Interior",
@@ -2662,7 +2662,7 @@
       "Agency": "Department of the Interior",
       "Canonical": "http://www.lowermississippivalleyscience.gov",
       "Domain": "lowermississippivalleyscience.gov",
-      "Participates in DAP?": 1
+      "Participates in DAP?": 0
     },
     {
       "Agency": "National Security Agency",
@@ -2782,7 +2782,7 @@
       "Agency": "Department of Health And Human Services",
       "Canonical": "http://medicare.gov",
       "Domain": "medicare.gov",
-      "Participates in DAP?": 1
+      "Participates in DAP?": 0
     },
     {
       "Agency": "Medical Payment Advisory Commission",
@@ -3502,7 +3502,7 @@
       "Agency": "Department of Justice",
       "Canonical": "https://www.ovcttac.gov",
       "Domain": "ovcttac.gov",
-      "Participates in DAP?": 1
+      "Participates in DAP?": 0
     },
     {
       "Agency": "Department of Commerce",
@@ -3526,7 +3526,7 @@
       "Agency": "Department of the Treasury",
       "Canonical": "https://pay.gov",
       "Domain": "pay.gov",
-      "Participates in DAP?": 1
+      "Participates in DAP?": 0
     },
     {
       "Agency": "Executive Office of the President",
@@ -3568,7 +3568,7 @@
       "Agency": "U. S. Peace Corps",
       "Canonical": "http://www.peacecorps.gov",
       "Domain": "peacecorps.gov",
-      "Participates in DAP?": 1
+      "Participates in DAP?": 0
     },
     {
       "Agency": "Department of State",
@@ -3592,7 +3592,7 @@
       "Agency": "General Services Administration",
       "Canonical": "http://pic.gov",
       "Domain": "pic.gov",
-      "Participates in DAP?": 1
+      "Participates in DAP?": 0
     },
     {
       "Agency": "Department of Transportation",
@@ -3772,7 +3772,7 @@
       "Agency": "Environmental Protection Agency",
       "Canonical": "http://www.regulations.gov",
       "Domain": "regulations.gov",
-      "Participates in DAP?": 1
+      "Participates in DAP?": 0
     },
     {
       "Agency": "Environmental Protection Agency",
@@ -3934,7 +3934,7 @@
       "Agency": "Securities and Exchange Commission",
       "Canonical": "http://www.sec.gov",
       "Domain": "sec.gov",
-      "Participates in DAP?": 1
+      "Participates in DAP?": 0
     },
     {
       "Agency": "Department of Homeland Security",
@@ -4120,7 +4120,7 @@
       "Agency": "General Services Administration",
       "Canonical": "https://strategicsourcing.gov",
       "Domain": "strategicsourcing.gov",
-      "Participates in DAP?": 1
+      "Participates in DAP?": 0
     },
     {
       "Agency": "Department of Education",
@@ -4198,7 +4198,7 @@
       "Agency": "Department of Commerce",
       "Canonical": "http://time.gov",
       "Domain": "time.gov",
-      "Participates in DAP?": 1
+      "Participates in DAP?": 0
     },
     {
       "Agency": "Department of Health And Human Services",
@@ -4420,7 +4420,7 @@
       "Agency": "Department of the Treasury",
       "Canonical": "https://www.usaspending.gov",
       "Domain": "usaspending.gov",
-      "Participates in DAP?": 1
+      "Participates in DAP?": 0
     },
     {
       "Agency": "Office of Personnel Management",
@@ -4468,7 +4468,7 @@
       "Agency": "Department of State",
       "Canonical": "http://www.usembassy.gov",
       "Domain": "usembassy.gov",
-      "Participates in DAP?": 1
+      "Participates in DAP?": 0
     },
     {
       "Agency": "Department of the Interior",
@@ -4618,7 +4618,7 @@
       "Agency": "Department of Energy",
       "Canonical": "http://www.wapa.gov",
       "Domain": "wapa.gov",
-      "Participates in DAP?": 1
+      "Participates in DAP?": 0
     },
     {
       "Agency": "Department of the Interior",

--- a/assets/data/tables/analytics/domains.json
+++ b/assets/data/tables/analytics/domains.json
@@ -31,12 +31,6 @@
       "Participates in DAP?": 0
     },
     {
-      "Agency": "Comm for People Who Are Blind/Severly Disabled",
-      "Canonical": "http://abilityone.gov",
-      "Domain": "abilityone.gov",
-      "Participates in DAP?": 0
-    },
-    {
       "Agency": "American Battle Monuments Commission",
       "Canonical": "http://abmc.gov",
       "Domain": "abmc.gov",
@@ -76,7 +70,7 @@
       "Agency": "Department of the Interior",
       "Canonical": "http://acwi.gov",
       "Domain": "acwi.gov",
-      "Participates in DAP?": 0
+      "Participates in DAP?": 1
     },
     {
       "Agency": "Department of Justice",
@@ -85,10 +79,16 @@
       "Participates in DAP?": 1
     },
     {
+      "Agency": "African Development Foundation",
+      "Canonical": "http://adf.gov",
+      "Domain": "adf.gov",
+      "Participates in DAP?": 0
+    },
+    {
       "Agency": "Department of Defense",
       "Canonical": "http://adlnet.gov",
       "Domain": "adlnet.gov",
-      "Participates in DAP?": 0
+      "Participates in DAP?": 1
     },
     {
       "Agency": "Federal Trade Commission",
@@ -136,7 +136,7 @@
       "Agency": "Department of Health And Human Services",
       "Canonical": "http://www.ahrq.gov",
       "Domain": "ahrq.gov",
-      "Participates in DAP?": 0
+      "Participates in DAP?": 1
     },
     {
       "Agency": "Department of Health And Human Services",
@@ -154,7 +154,7 @@
       "Agency": "Department of the Interior",
       "Canonical": "http://alaskacenters.gov",
       "Domain": "alaskacenters.gov",
-      "Participates in DAP?": 0
+      "Participates in DAP?": 1
     },
     {
       "Agency": "Federal Trade Commission",
@@ -166,7 +166,7 @@
       "Agency": "Department of Defense",
       "Canonical": "http://www.altusandc.gov",
       "Domain": "altusandc.gov",
-      "Participates in DAP?": 0
+      "Participates in DAP?": 1
     },
     {
       "Agency": "Department of Health And Human Services",
@@ -196,6 +196,12 @@
       "Agency": "Department of the Treasury",
       "Canonical": "http://www.americathebeautifulquarters.gov",
       "Domain": "americathebeautifulquarters.gov",
+      "Participates in DAP?": 1
+    },
+    {
+      "Agency": "Corporation for National & Community Service",
+      "Canonical": "http://americorpsweek.gov",
+      "Domain": "americorpsweek.gov",
       "Participates in DAP?": 0
     },
     {
@@ -206,7 +212,7 @@
     },
     {
       "Agency": "AMTRAK",
-      "Canonical": "http://amtrakoig.gov",
+      "Canonical": "https://amtrakoig.gov",
       "Domain": "amtrakoig.gov",
       "Participates in DAP?": 0
     },
@@ -284,7 +290,7 @@
     },
     {
       "Agency": "Department of Justice",
-      "Canonical": "http://www.atf.gov",
+      "Canonical": "https://www.atf.gov",
       "Domain": "atf.gov",
       "Participates in DAP?": 1
     },
@@ -292,7 +298,7 @@
       "Agency": "Department of Labor",
       "Canonical": "http://www.autocommunities.gov",
       "Domain": "autocommunities.gov",
-      "Participates in DAP?": 0
+      "Participates in DAP?": 1
     },
     {
       "Agency": "Department of Commerce",
@@ -304,19 +310,13 @@
       "Agency": "Department of the Treasury",
       "Canonical": "http://ayudaconmibanco.gov",
       "Domain": "ayudaconmibanco.gov",
-      "Participates in DAP?": 0
-    },
-    {
-      "Agency": "Department of Health And Human Services",
-      "Canonical": "http://www.bam.gov",
-      "Domain": "bam.gov",
-      "Participates in DAP?": 0
+      "Participates in DAP?": 1
     },
     {
       "Agency": "Department of the Treasury",
       "Canonical": "http://bankanswers.gov",
       "Domain": "bankanswers.gov",
-      "Participates in DAP?": 0
+      "Participates in DAP?": 1
     },
     {
       "Agency": "Department of the Treasury",
@@ -328,7 +328,7 @@
       "Agency": "Department of the Treasury",
       "Canonical": "http://bankcustomerassistance.gov",
       "Domain": "bankcustomerassistance.gov",
-      "Participates in DAP?": 0
+      "Participates in DAP?": 1
     },
     {
       "Agency": "Department of the Treasury",
@@ -418,19 +418,19 @@
       "Agency": "Department of Justice",
       "Canonical": "http://bjs.gov",
       "Domain": "bjs.gov",
-      "Participates in DAP?": 0
+      "Participates in DAP?": 1
     },
     {
       "Agency": "Department of Commerce",
       "Canonical": "http://www.bldrdoc.gov",
       "Domain": "bldrdoc.gov",
-      "Participates in DAP?": 0
+      "Participates in DAP?": 1
     },
     {
       "Agency": "Department of the Interior",
       "Canonical": "http://www.blm.gov",
       "Domain": "blm.gov",
-      "Participates in DAP?": 0
+      "Participates in DAP?": 1
     },
     {
       "Agency": "Department of Labor",
@@ -460,7 +460,7 @@
       "Agency": "Department of the Treasury",
       "Canonical": "http://bondpro.gov",
       "Domain": "bondpro.gov",
-      "Participates in DAP?": 0
+      "Participates in DAP?": 1
     },
     {
       "Agency": "Department of Justice",
@@ -530,14 +530,8 @@
     },
     {
       "Agency": "Civil Air Patrol",
-      "Canonical": "http://www.capnhq.gov",
-      "Domain": "capnhq.gov",
-      "Participates in DAP?": 0
-    },
-    {
-      "Agency": "United Stated Global Change Research Program",
-      "Canonical": "http://www.carboncyclescience.gov",
-      "Domain": "carboncyclescience.gov",
+      "Canonical": "http://www.cap.gov",
+      "Domain": "cap.gov",
       "Participates in DAP?": 0
     },
     {
@@ -592,7 +586,7 @@
       "Agency": "Department of Commerce",
       "Canonical": "http://census.gov",
       "Domain": "census.gov",
-      "Participates in DAP?": 0
+      "Participates in DAP?": 1
     },
     {
       "Agency": "U.S. Commission of Fine Arts",
@@ -658,7 +652,7 @@
       "Agency": "Department of Health And Human Services",
       "Canonical": "https://childwelfare.gov",
       "Domain": "childwelfare.gov",
-      "Participates in DAP?": 0
+      "Participates in DAP?": 1
     },
     {
       "Agency": "Department of Agriculture",
@@ -670,7 +664,7 @@
       "Agency": "Christopher Columbus Fellowship Foundation",
       "Canonical": "http://www.christophercolumbusfoundation.gov",
       "Domain": "christophercolumbusfoundation.gov",
-      "Participates in DAP?": 0
+      "Participates in DAP?": 1
     },
     {
       "Agency": "Central Intelligence Agency",
@@ -688,7 +682,7 @@
       "Agency": "Department of State",
       "Canonical": "http://civilianresponsecorps.gov",
       "Domain": "civilianresponsecorps.gov",
-      "Participates in DAP?": 0
+      "Participates in DAP?": 1
     },
     {
       "Agency": "Department of Commerce",
@@ -734,7 +728,7 @@
     },
     {
       "Agency": "Corporation for National & Community Service",
-      "Canonical": "http://cncsoig.gov",
+      "Canonical": "http://www.cncsoig.gov",
       "Domain": "cncsoig.gov",
       "Participates in DAP?": 0
     },
@@ -748,13 +742,13 @@
       "Agency": "Department of the Interior",
       "Canonical": "http://coast2050.gov",
       "Domain": "coast2050.gov",
-      "Participates in DAP?": 0
+      "Participates in DAP?": 1
     },
     {
       "Agency": "Department of Agriculture",
       "Canonical": "http://coastalamerica.gov",
       "Domain": "coastalamerica.gov",
-      "Participates in DAP?": 0
+      "Participates in DAP?": 1
     },
     {
       "Agency": "Department of Health And Human Services",
@@ -784,7 +778,7 @@
       "Agency": "General Services Administration",
       "Canonical": "http://www.connect.gov",
       "Domain": "connect.gov",
-      "Participates in DAP?": 0
+      "Participates in DAP?": 1
     },
     {
       "Agency": "Federal Trade Commission",
@@ -796,7 +790,7 @@
       "Agency": "Consumer Financial Protection Bureau",
       "Canonical": "http://www.consumerfinance.gov",
       "Domain": "consumerfinance.gov",
-      "Participates in DAP?": 0
+      "Participates in DAP?": 1
     },
     {
       "Agency": "Federal Trade Commission",
@@ -826,7 +820,7 @@
       "Agency": "Department of the Interior",
       "Canonical": "http://www.coralreef.gov",
       "Domain": "coralreef.gov",
-      "Participates in DAP?": 0
+      "Participates in DAP?": 1
     },
     {
       "Agency": "Director of National Intelligence",
@@ -850,7 +844,7 @@
       "Agency": "Consumer Product Safety Commission",
       "Canonical": "http://www.cpsc.gov",
       "Domain": "cpsc.gov",
-      "Participates in DAP?": 0
+      "Participates in DAP?": 1
     },
     {
       "Agency": "Department of Justice",
@@ -910,7 +904,7 @@
       "Agency": "Department of State",
       "Canonical": "http://cwc.gov",
       "Domain": "cwc.gov",
-      "Participates in DAP?": 0
+      "Participates in DAP?": 1
     },
     {
       "Agency": "General Services Administration",
@@ -964,7 +958,7 @@
       "Agency": "Department of Commerce",
       "Canonical": "http://www.digitalliteracy.gov",
       "Domain": "digitalliteracy.gov",
-      "Participates in DAP?": 0
+      "Participates in DAP?": 1
     },
     {
       "Agency": "Department of the Treasury",
@@ -994,7 +988,7 @@
       "Agency": "Department of Transportation",
       "Canonical": "http://distracteddriving.gov",
       "Domain": "distracteddriving.gov",
-      "Participates in DAP?": 0
+      "Participates in DAP?": 1
     },
     {
       "Agency": "Department of Transportation",
@@ -1033,12 +1027,6 @@
       "Participates in DAP?": 0
     },
     {
-      "Agency": "Department of Energy",
-      "Canonical": "http://www.doeal.gov",
-      "Domain": "doeal.gov",
-      "Participates in DAP?": 0
-    },
-    {
       "Agency": "Department of the Interior",
       "Canonical": "http://www.doi.gov",
       "Domain": "doi.gov",
@@ -1072,7 +1060,7 @@
       "Agency": "Federal Trade Commission",
       "Canonical": "https://donotcall.gov",
       "Domain": "donotcall.gov",
-      "Participates in DAP?": 0
+      "Participates in DAP?": 1
     },
     {
       "Agency": "Department of Transportation",
@@ -1084,7 +1072,7 @@
       "Agency": "General Services Administration",
       "Canonical": "https://www.dotgov.gov",
       "Domain": "dotgov.gov",
-      "Participates in DAP?": 0
+      "Participates in DAP?": 1
     },
     {
       "Agency": "Department of Transportation",
@@ -1114,7 +1102,7 @@
       "Agency": "Department of Health And Human Services",
       "Canonical": "http://www.drugabuse.gov",
       "Domain": "drugabuse.gov",
-      "Participates in DAP?": 0
+      "Participates in DAP?": 1
     },
     {
       "Agency": "Department of Justice",
@@ -1126,7 +1114,7 @@
       "Agency": "Department of Commerce",
       "Canonical": "http://e3.gov",
       "Domain": "e3.gov",
-      "Participates in DAP?": 0
+      "Participates in DAP?": 1
     },
     {
       "Agency": "General Services Administration",
@@ -1150,7 +1138,7 @@
       "Agency": "Department of State",
       "Canonical": "http://ecopartnerships.gov",
       "Domain": "ecopartnerships.gov",
-      "Participates in DAP?": 0
+      "Participates in DAP?": 1
     },
     {
       "Agency": "General Services Administration",
@@ -1178,7 +1166,7 @@
     },
     {
       "Agency": "Department of Education",
-      "Canonical": "http://www.education.gov",
+      "Canonical": "http://education.gov",
       "Domain": "education.gov",
       "Participates in DAP?": 1
     },
@@ -1198,7 +1186,7 @@
       "Agency": "Department of Energy",
       "Canonical": "http://www.eia.gov",
       "Domain": "eia.gov",
-      "Participates in DAP?": 0
+      "Participates in DAP?": 1
     },
     {
       "Agency": "General Services Administration",
@@ -1270,13 +1258,13 @@
       "Agency": "Department of Commerce",
       "Canonical": "http://esa.gov",
       "Domain": "esa.gov",
-      "Participates in DAP?": 1
+      "Participates in DAP?": 0
     },
     {
       "Agency": "Department of Transportation",
       "Canonical": "http://www.esc.gov",
       "Domain": "esc.gov",
-      "Participates in DAP?": 0
+      "Participates in DAP?": 1
     },
     {
       "Agency": "Department of Justice",
@@ -1316,7 +1304,7 @@
     },
     {
       "Agency": "Export/Import Bank of the U.S.",
-      "Canonical": "http://www.exim.gov",
+      "Canonical": "http://exim.gov",
       "Domain": "exim.gov",
       "Participates in DAP?": 0
     },
@@ -1346,12 +1334,6 @@
     },
     {
       "Agency": "General Services Administration",
-      "Canonical": "http://faca.gov",
-      "Domain": "faca.gov",
-      "Participates in DAP?": 0
-    },
-    {
-      "Agency": "General Services Administration",
       "Canonical": "http://facadatabase.gov",
       "Domain": "facadatabase.gov",
       "Participates in DAP?": 1
@@ -1366,7 +1348,7 @@
       "Agency": "General Services Administration",
       "Canonical": "http://www.fai.gov",
       "Domain": "fai.gov",
-      "Participates in DAP?": 0
+      "Participates in DAP?": 1
     },
     {
       "Agency": "Department of State",
@@ -1378,7 +1360,7 @@
       "Agency": "General Services Administration",
       "Canonical": "https://fapiis.gov",
       "Domain": "fapiis.gov",
-      "Participates in DAP?": 0
+      "Participates in DAP?": 1
     },
     {
       "Agency": "Department of Justice",
@@ -1430,7 +1412,7 @@
     },
     {
       "Agency": "Federal Communications Commission",
-      "Canonical": "http://www.fcc.gov",
+      "Canonical": "https://www.fcc.gov",
       "Domain": "fcc.gov",
       "Participates in DAP?": 0
     },
@@ -1444,12 +1426,6 @@
       "Agency": "Farm Credit Administration",
       "Canonical": "http://fcsic.gov",
       "Domain": "fcsic.gov",
-      "Participates in DAP?": 0
-    },
-    {
-      "Agency": "Department of Commerce",
-      "Canonical": "http://fcsm.gov",
-      "Domain": "fcsm.gov",
       "Participates in DAP?": 0
     },
     {
@@ -1490,7 +1466,7 @@
     },
     {
       "Agency": "Environmental Protection Agency",
-      "Canonical": "http://www.fdms.gov",
+      "Canonical": "https://www.fdms.gov",
       "Domain": "fdms.gov",
       "Participates in DAP?": 0
     },
@@ -1528,11 +1504,11 @@
       "Agency": "Department of the Treasury",
       "Canonical": "http://federalinvestments.gov",
       "Domain": "federalinvestments.gov",
-      "Participates in DAP?": 0
+      "Participates in DAP?": 1
     },
     {
       "Agency": "Federal Reserve System",
-      "Canonical": "http://federalreserve.gov",
+      "Canonical": "http://www.federalreserve.gov",
       "Domain": "federalreserve.gov",
       "Participates in DAP?": 0
     },
@@ -1552,7 +1528,7 @@
       "Agency": "Department of the Treasury",
       "Canonical": "http://fedinvest.gov",
       "Domain": "fedinvest.gov",
-      "Participates in DAP?": 0
+      "Participates in DAP?": 1
     },
     {
       "Agency": "Federal Reserve System",
@@ -1564,13 +1540,7 @@
       "Agency": "General Services Administration",
       "Canonical": "http://www.fedramp.gov",
       "Domain": "fedramp.gov",
-      "Participates in DAP?": 0
-    },
-    {
-      "Agency": "General Services Administration",
-      "Canonical": "http://fedrealestate.gov",
-      "Domain": "fedrealestate.gov",
-      "Participates in DAP?": 0
+      "Participates in DAP?": 1
     },
     {
       "Agency": "General Services Administration",
@@ -1585,16 +1555,10 @@
       "Participates in DAP?": 1
     },
     {
-      "Agency": "Department of Commerce",
-      "Canonical": "http://fedstats.gov",
-      "Domain": "fedstats.gov",
-      "Participates in DAP?": 0
-    },
-    {
       "Agency": "U.S. Agency for International Development",
       "Canonical": "http://feedthefuture.gov",
       "Domain": "feedthefuture.gov",
-      "Participates in DAP?": 0
+      "Participates in DAP?": 1
     },
     {
       "Agency": "Department of Homeland Security",
@@ -1651,28 +1615,16 @@
       "Participates in DAP?": 1
     },
     {
-      "Agency": "U.S. Agency for International Development",
-      "Canonical": "http://fightingmalaria.gov",
-      "Domain": "fightingmalaria.gov",
-      "Participates in DAP?": 0
-    },
-    {
       "Agency": "Department of the Treasury",
       "Canonical": "http://financialresearch.gov",
       "Domain": "financialresearch.gov",
-      "Participates in DAP?": 0
+      "Participates in DAP?": 1
     },
     {
       "Agency": "Department of the Treasury",
       "Canonical": "http://fincen.gov",
       "Domain": "fincen.gov",
       "Participates in DAP?": 1
-    },
-    {
-      "Agency": "Department of Health And Human Services",
-      "Canonical": "http://findyouthinfo.gov",
-      "Domain": "findyouthinfo.gov",
-      "Participates in DAP?": 0
     },
     {
       "Agency": "Department of the Interior",
@@ -1696,7 +1648,7 @@
       "Agency": "Department of Commerce",
       "Canonical": "http://firstnet.gov",
       "Domain": "firstnet.gov",
-      "Participates in DAP?": 0
+      "Participates in DAP?": 1
     },
     {
       "Agency": "Department of Homeland Security",
@@ -1720,25 +1672,25 @@
       "Agency": "Department of Commerce",
       "Canonical": "http://www.fishwatch.gov",
       "Domain": "fishwatch.gov",
-      "Participates in DAP?": 0
+      "Participates in DAP?": 1
     },
     {
       "Agency": "Department of Health And Human Services",
       "Canonical": "http://fitness.gov",
       "Domain": "fitness.gov",
-      "Participates in DAP?": 0
+      "Participates in DAP?": 1
     },
     {
       "Agency": "Department of Homeland Security",
       "Canonical": "https://www.fleta.gov",
       "Domain": "fleta.gov",
-      "Participates in DAP?": 0
+      "Participates in DAP?": 1
     },
     {
       "Agency": "Department of Homeland Security",
       "Canonical": "https://www.fletc.gov",
       "Domain": "fletc.gov",
-      "Participates in DAP?": 0
+      "Participates in DAP?": 1
     },
     {
       "Agency": "Department of Homeland Security",
@@ -1856,7 +1808,7 @@
     },
     {
       "Agency": "Department of Agriculture",
-      "Canonical": "http://www.fs.fed.us",
+      "Canonical": "http://fs.fed.us",
       "Domain": "fs.fed.us",
       "Participates in DAP?": 0
     },
@@ -1912,7 +1864,7 @@
       "Agency": "Department of Energy",
       "Canonical": "http://fueleconomy.gov",
       "Domain": "fueleconomy.gov",
-      "Participates in DAP?": 0
+      "Participates in DAP?": 1
     },
     {
       "Agency": "Department of Defense",
@@ -1924,7 +1876,7 @@
       "Agency": "Department of the Interior",
       "Canonical": "http://www.fws.gov",
       "Domain": "fws.gov",
-      "Participates in DAP?": 0
+      "Participates in DAP?": 1
     },
     {
       "Agency": "Department of Education",
@@ -1942,7 +1894,7 @@
       "Agency": "Department of the Interior",
       "Canonical": "http://www.gcmrc.gov",
       "Domain": "gcmrc.gov",
-      "Participates in DAP?": 0
+      "Participates in DAP?": 1
     },
     {
       "Agency": "Department of Health And Human Services",
@@ -1969,16 +1921,22 @@
       "Participates in DAP?": 0
     },
     {
+      "Agency": "Department of Justice",
+      "Canonical": "http://getsmartaboutdrugs.gov",
+      "Domain": "getsmartaboutdrugs.gov",
+      "Participates in DAP?": 0
+    },
+    {
       "Agency": "Department of State",
       "Canonical": "http://ghi.gov",
       "Domain": "ghi.gov",
-      "Participates in DAP?": 0
+      "Participates in DAP?": 1
     },
     {
       "Agency": "Department of Housing And Urban Development",
       "Canonical": "http://www.ginniemae.gov",
       "Domain": "ginniemae.gov",
-      "Participates in DAP?": 0
+      "Participates in DAP?": 1
     },
     {
       "Agency": "Department of Health And Human Services",
@@ -2026,7 +1984,7 @@
       "Agency": "Department of Labor",
       "Canonical": "http://www.govloans.gov",
       "Domain": "govloans.gov",
-      "Participates in DAP?": 0
+      "Participates in DAP?": 1
     },
     {
       "Agency": "General Services Administration",
@@ -2080,7 +2038,7 @@
       "Agency": "General Services Administration",
       "Canonical": "http://www.gsadvantage.gov",
       "Domain": "gsadvantage.gov",
-      "Participates in DAP?": 0
+      "Participates in DAP?": 1
     },
     {
       "Agency": "General Services Administration",
@@ -2132,7 +2090,7 @@
     },
     {
       "Agency": "Department of Health And Human Services",
-      "Canonical": "http://www.healthdata.gov",
+      "Canonical": "http://healthdata.gov",
       "Domain": "healthdata.gov",
       "Participates in DAP?": 0
     },
@@ -2176,13 +2134,13 @@
       "Agency": "Department of the Treasury",
       "Canonical": "http://helpwithmycreditcard.gov",
       "Domain": "helpwithmycreditcard.gov",
-      "Participates in DAP?": 1
+      "Participates in DAP?": 0
     },
     {
       "Agency": "Department of the Treasury",
       "Canonical": "http://helpwithmycreditcardbank.gov",
       "Domain": "helpwithmycreditcardbank.gov",
-      "Participates in DAP?": 1
+      "Participates in DAP?": 0
     },
     {
       "Agency": "Department of the Treasury",
@@ -2207,6 +2165,12 @@
       "Canonical": "https://www.hispanicfarmerclaims.gov",
       "Domain": "hispanicfarmerclaims.gov",
       "Participates in DAP?": 0
+    },
+    {
+      "Agency": "Department of Health And Human Services",
+      "Canonical": "http://hiv.gov",
+      "Domain": "hiv.gov",
+      "Participates in DAP?": 1
     },
     {
       "Agency": "Department of Housing And Urban Development",
@@ -2246,9 +2210,9 @@
     },
     {
       "Agency": "Department of Housing And Urban Development",
-      "Canonical": "http://www.hudoig.gov",
+      "Canonical": "https://www.hudoig.gov",
       "Domain": "hudoig.gov",
-      "Participates in DAP?": 0
+      "Participates in DAP?": 1
     },
     {
       "Agency": "Department of State",
@@ -2335,6 +2299,12 @@
       "Participates in DAP?": 0
     },
     {
+      "Agency": "Federal Trade Commission",
+      "Canonical": "https://www.identitytheft.gov",
+      "Domain": "identitytheft.gov",
+      "Participates in DAP?": 1
+    },
+    {
       "Agency": "General Services Administration",
       "Canonical": "http://idmanagement.gov",
       "Domain": "idmanagement.gov",
@@ -2350,7 +2320,7 @@
       "Agency": "Department of Health And Human Services",
       "Canonical": "http://www.ihs.gov",
       "Domain": "ihs.gov",
-      "Participates in DAP?": 0
+      "Participates in DAP?": 1
     },
     {
       "Agency": "Department of Agriculture",
@@ -2410,7 +2380,7 @@
       "Agency": "Department of the Interior",
       "Canonical": "http://www.interior.gov",
       "Domain": "interior.gov",
-      "Participates in DAP?": 0
+      "Participates in DAP?": 1
     },
     {
       "Agency": "Department of the Interior",
@@ -2494,13 +2464,13 @@
       "Agency": "Department of Transportation",
       "Canonical": "http://www.italladdsup.gov",
       "Domain": "italladdsup.gov",
-      "Participates in DAP?": 0
+      "Participates in DAP?": 1
     },
     {
       "Agency": "Department of Agriculture",
       "Canonical": "http://www.itap.gov",
       "Domain": "itap.gov",
-      "Participates in DAP?": 0
+      "Participates in DAP?": 1
     },
     {
       "Agency": "Executive Office of the President",
@@ -2518,7 +2488,7 @@
       "Agency": "Smithsonian Institution",
       "Canonical": "http://www.itis.gov",
       "Domain": "itis.gov",
-      "Participates in DAP?": 0
+      "Participates in DAP?": 1
     },
     {
       "Agency": "Department of the Treasury",
@@ -2564,15 +2534,15 @@
     },
     {
       "Agency": "Department of Justice",
+      "Canonical": "http://justthinktwice.gov",
+      "Domain": "justthinktwice.gov",
+      "Participates in DAP?": 0
+    },
+    {
+      "Agency": "Department of Justice",
       "Canonical": "http://juvenilecouncil.gov",
       "Domain": "juvenilecouncil.gov",
       "Participates in DAP?": 1
-    },
-    {
-      "Agency": "Comm for People Who Are Blind/Severly Disabled",
-      "Canonical": "http://jwod.gov",
-      "Domain": "jwod.gov",
-      "Participates in DAP?": 0
     },
     {
       "Agency": "Department of the Interior",
@@ -2596,7 +2566,7 @@
       "Agency": "Department of the Interior",
       "Canonical": "http://www.landimaging.gov",
       "Domain": "landimaging.gov",
-      "Participates in DAP?": 0
+      "Participates in DAP?": 1
     },
     {
       "Agency": "Department of Energy",
@@ -2638,7 +2608,7 @@
       "Agency": "General Services Administration",
       "Canonical": "https://www.learnperformance.gov",
       "Domain": "learnperformance.gov",
-      "Participates in DAP?": 0
+      "Participates in DAP?": 1
     },
     {
       "Agency": "Department of Justice",
@@ -2650,7 +2620,7 @@
       "Agency": "Executive Office of the President",
       "Canonical": "http://www.letsmove.gov",
       "Domain": "letsmove.gov",
-      "Participates in DAP?": 0
+      "Participates in DAP?": 1
     },
     {
       "Agency": "Department of Energy",
@@ -2686,7 +2656,7 @@
       "Agency": "Department of the Interior",
       "Canonical": "http://www.lowermississippivalleyscience.gov",
       "Domain": "lowermississippivalleyscience.gov",
-      "Participates in DAP?": 0
+      "Participates in DAP?": 1
     },
     {
       "Agency": "National Security Agency",
@@ -2728,7 +2698,7 @@
       "Agency": "Department of the Interior",
       "Canonical": "http://www.mapaplanet.gov",
       "Domain": "mapaplanet.gov",
-      "Participates in DAP?": 0
+      "Participates in DAP?": 1
     },
     {
       "Agency": "Department of the Interior",
@@ -2740,7 +2710,7 @@
       "Agency": "Department of Commerce",
       "Canonical": "http://marinecadastre.gov",
       "Domain": "marinecadastre.gov",
-      "Participates in DAP?": 0
+      "Participates in DAP?": 1
     },
     {
       "Agency": "Department of Transportation",
@@ -2764,7 +2734,7 @@
       "Agency": "Millennium Challenge Corporation",
       "Canonical": "https://mcc.gov",
       "Domain": "mcc.gov",
-      "Participates in DAP?": 0
+      "Participates in DAP?": 1
     },
     {
       "Agency": "Department of Defense",
@@ -2776,6 +2746,12 @@
       "Agency": "Department of Transportation",
       "Canonical": "http://mda.gov",
       "Domain": "mda.gov",
+      "Participates in DAP?": 0
+    },
+    {
+      "Agency": "Department of Justice",
+      "Canonical": "https://www.medalofvalor.gov",
+      "Domain": "medalofvalor.gov",
       "Participates in DAP?": 0
     },
     {
@@ -2800,7 +2776,7 @@
       "Agency": "Department of Health And Human Services",
       "Canonical": "http://medicare.gov",
       "Domain": "medicare.gov",
-      "Participates in DAP?": 0
+      "Participates in DAP?": 1
     },
     {
       "Agency": "Medical Payment Advisory Commission",
@@ -2854,7 +2830,7 @@
       "Agency": "Department of the Treasury",
       "Canonical": "http://msb.gov",
       "Domain": "msb.gov",
-      "Participates in DAP?": 0
+      "Participates in DAP?": 1
     },
     {
       "Agency": "Department of Labor",
@@ -2908,7 +2884,7 @@
       "Agency": "Department of Education",
       "Canonical": "http://nagb.gov",
       "Domain": "nagb.gov",
-      "Participates in DAP?": 0
+      "Participates in DAP?": 1
     },
     {
       "Agency": "Department of Justice",
@@ -3001,14 +2977,8 @@
       "Participates in DAP?": 1
     },
     {
-      "Agency": "Director of National Intelligence",
-      "Canonical": "http://ncix.gov",
-      "Domain": "ncix.gov",
-      "Participates in DAP?": 0
-    },
-    {
       "Agency": "Department of Justice",
-      "Canonical": "https://ncjrs.gov",
+      "Canonical": "https://www.ncjrs.gov",
       "Domain": "ncjrs.gov",
       "Participates in DAP?": 1
     },
@@ -3056,9 +3026,9 @@
     },
     {
       "Agency": "U.S. Agency for International Development",
-      "Canonical": "http://neglecteddiseases.gov",
+      "Canonical": "http://www.neglecteddiseases.gov",
       "Domain": "neglecteddiseases.gov",
-      "Participates in DAP?": 0
+      "Participates in DAP?": 1
     },
     {
       "Agency": "National Endowment for the Humanities",
@@ -3170,15 +3140,9 @@
     },
     {
       "Agency": "Department of Justice",
-      "Canonical": "http://www.nij.gov",
+      "Canonical": "http://nij.gov",
       "Domain": "nij.gov",
       "Participates in DAP?": 1
-    },
-    {
-      "Agency": "Department of Health And Human Services",
-      "Canonical": "http://www.niosh.gov",
-      "Domain": "niosh.gov",
-      "Participates in DAP?": 0
     },
     {
       "Agency": "Department of Commerce",
@@ -3220,6 +3184,12 @@
       "Agency": "Director of National Intelligence",
       "Canonical": "http://www.nmic.gov",
       "Domain": "nmic.gov",
+      "Participates in DAP?": 0
+    },
+    {
+      "Agency": "Department of Homeland Security",
+      "Canonical": "http://nmsc.gov",
+      "Domain": "nmsc.gov",
       "Participates in DAP?": 0
     },
     {
@@ -3290,7 +3260,7 @@
     },
     {
       "Agency": "National Science Foundation",
-      "Canonical": "http://www.nsf.gov",
+      "Canonical": "http://nsf.gov",
       "Domain": "nsf.gov",
       "Participates in DAP?": 1
     },
@@ -3310,7 +3280,7 @@
       "Agency": "Department of Transportation",
       "Canonical": "http://www.ntdprogram.gov",
       "Domain": "ntdprogram.gov",
-      "Participates in DAP?": 0
+      "Participates in DAP?": 1
     },
     {
       "Agency": "Department of Commerce",
@@ -3328,7 +3298,7 @@
       "Agency": "Department of Agriculture",
       "Canonical": "http://www.nutrition.gov",
       "Domain": "nutrition.gov",
-      "Participates in DAP?": 0
+      "Participates in DAP?": 1
     },
     {
       "Agency": "Small Business Administration",
@@ -3392,7 +3362,7 @@
     },
     {
       "Agency": "Department of Justice",
-      "Canonical": "http://ojjdp.gov",
+      "Canonical": "http://www.ojjdp.gov",
       "Domain": "ojjdp.gov",
       "Participates in DAP?": 1
     },
@@ -3508,7 +3478,7 @@
       "Agency": "Department of the Treasury",
       "Canonical": "http://ots.gov",
       "Domain": "ots.gov",
-      "Participates in DAP?": 0
+      "Participates in DAP?": 1
     },
     {
       "Agency": "National Archives and Records Administration",
@@ -3538,19 +3508,19 @@
       "Agency": "General Services Administration",
       "Canonical": "http://www.partner4solutions.gov",
       "Domain": "partner4solutions.gov",
-      "Participates in DAP?": 0
+      "Participates in DAP?": 1
     },
     {
       "Agency": "Department of the Treasury",
       "Canonical": "http://patriotbonds.gov",
       "Domain": "patriotbonds.gov",
-      "Participates in DAP?": 0
+      "Participates in DAP?": 1
     },
     {
       "Agency": "Department of the Treasury",
       "Canonical": "https://pay.gov",
       "Domain": "pay.gov",
-      "Participates in DAP?": 0
+      "Participates in DAP?": 1
     },
     {
       "Agency": "Executive Office of the President",
@@ -3592,7 +3562,7 @@
       "Agency": "U. S. Peace Corps",
       "Canonical": "http://www.peacecorps.gov",
       "Domain": "peacecorps.gov",
-      "Participates in DAP?": 0
+      "Participates in DAP?": 1
     },
     {
       "Agency": "Department of State",
@@ -3614,7 +3584,7 @@
     },
     {
       "Agency": "General Services Administration",
-      "Canonical": "https://pic.gov",
+      "Canonical": "http://pic.gov",
       "Domain": "pic.gov",
       "Participates in DAP?": 1
     },
@@ -3632,9 +3602,9 @@
     },
     {
       "Agency": "U.S. Agency for International Development",
-      "Canonical": "http://pmi.gov",
+      "Canonical": "http://www.pmi.gov",
       "Domain": "pmi.gov",
-      "Participates in DAP?": 0
+      "Participates in DAP?": 1
     },
     {
       "Agency": "Department of Energy",
@@ -3652,7 +3622,7 @@
       "Agency": "Consumer Product Safety Commission",
       "Canonical": "http://www.poolsafely.gov",
       "Domain": "poolsafely.gov",
-      "Participates in DAP?": 0
+      "Participates in DAP?": 1
     },
     {
       "Agency": "General Services Administration",
@@ -3691,10 +3661,16 @@
       "Participates in DAP?": 0
     },
     {
+      "Agency": "Department of Justice",
+      "Canonical": "http://www.projectsafeneighborhoods.gov",
+      "Domain": "projectsafeneighborhoods.gov",
+      "Participates in DAP?": 0
+    },
+    {
       "Agency": "Federal Trade Commission",
       "Canonical": "http://www.protecciondelconsumidor.gov",
       "Domain": "protecciondelconsumidor.gov",
-      "Participates in DAP?": 0
+      "Participates in DAP?": 1
     },
     {
       "Agency": "Court Services and Offender Supervision",
@@ -3710,13 +3686,13 @@
     },
     {
       "Agency": "Department of Commerce",
-      "Canonical": "http://pscr.gov",
+      "Canonical": "http://www.pscr.gov",
       "Domain": "pscr.gov",
       "Participates in DAP?": 0
     },
     {
       "Agency": "Department of Justice",
-      "Canonical": "https://psob.gov",
+      "Canonical": "https://www.psob.gov",
       "Domain": "psob.gov",
       "Participates in DAP?": 1
     },
@@ -3730,7 +3706,7 @@
       "Agency": "Department of Justice",
       "Canonical": "http://www.rcfl.gov",
       "Domain": "rcfl.gov",
-      "Participates in DAP?": 1
+      "Participates in DAP?": 0
     },
     {
       "Agency": "Department of Homeland Security",
@@ -3748,19 +3724,19 @@
       "Agency": "General Services Administration",
       "Canonical": "http://realestatesales.gov",
       "Domain": "realestatesales.gov",
-      "Participates in DAP?": 0
+      "Participates in DAP?": 1
     },
     {
       "Agency": "General Services Administration",
       "Canonical": "https://www.realpropertyprofile.gov",
       "Domain": "realpropertyprofile.gov",
-      "Participates in DAP?": 0
+      "Participates in DAP?": 1
     },
     {
       "Agency": "Consumer Product Safety Commission",
       "Canonical": "http://www.recalls.gov",
       "Domain": "recalls.gov",
-      "Participates in DAP?": 0
+      "Participates in DAP?": 1
     },
     {
       "Agency": "Recovery Accountability and Transparency Board",
@@ -3790,7 +3766,7 @@
       "Agency": "Environmental Protection Agency",
       "Canonical": "http://www.regulations.gov",
       "Domain": "regulations.gov",
-      "Participates in DAP?": 0
+      "Participates in DAP?": 1
     },
     {
       "Agency": "Environmental Protection Agency",
@@ -3841,16 +3817,10 @@
       "Participates in DAP?": 0
     },
     {
-      "Agency": "Department of the Interior",
-      "Canonical": "http://www.safecom.gov",
-      "Domain": "safecom.gov",
-      "Participates in DAP?": 0
-    },
-    {
       "Agency": "Department of Transportation",
       "Canonical": "http://www.safercar.gov",
       "Domain": "safercar.gov",
-      "Participates in DAP?": 0
+      "Participates in DAP?": 1
     },
     {
       "Agency": "Consumer Product Safety Commission",
@@ -3862,11 +3832,11 @@
       "Agency": "Department of Transportation",
       "Canonical": "http://safertruck.gov",
       "Domain": "safertruck.gov",
-      "Participates in DAP?": 0
+      "Participates in DAP?": 1
     },
     {
       "Agency": "Department of Homeland Security",
-      "Canonical": "https://safetyact.gov",
+      "Canonical": "http://www.safetyact.gov",
       "Domain": "safetyact.gov",
       "Participates in DAP?": 0
     },
@@ -3898,19 +3868,19 @@
       "Agency": "Department of the Treasury",
       "Canonical": "http://savingsbond.gov",
       "Domain": "savingsbond.gov",
-      "Participates in DAP?": 0
+      "Participates in DAP?": 1
     },
     {
       "Agency": "Department of the Treasury",
       "Canonical": "http://savingsbonds.gov",
       "Domain": "savingsbonds.gov",
-      "Participates in DAP?": 0
+      "Participates in DAP?": 1
     },
     {
       "Agency": "Department of the Treasury",
       "Canonical": "http://savingsbondwizard.gov",
       "Domain": "savingsbondwizard.gov",
-      "Participates in DAP?": 0
+      "Participates in DAP?": 1
     },
     {
       "Agency": "Small Business Administration",
@@ -3920,7 +3890,7 @@
     },
     {
       "Agency": "National Science Foundation",
-      "Canonical": "http://www.sbir.gov",
+      "Canonical": "https://www.sbir.gov",
       "Domain": "sbir.gov",
       "Participates in DAP?": 0
     },
@@ -3952,13 +3922,13 @@
       "Agency": "Department of Commerce",
       "Canonical": "http://www.sdr.gov",
       "Domain": "sdr.gov",
-      "Participates in DAP?": 0
+      "Participates in DAP?": 1
     },
     {
       "Agency": "Securities and Exchange Commission",
       "Canonical": "http://www.sec.gov",
       "Domain": "sec.gov",
-      "Participates in DAP?": 0
+      "Participates in DAP?": 1
     },
     {
       "Agency": "Department of Homeland Security",
@@ -3976,7 +3946,7 @@
       "Agency": "Social Security Administration",
       "Canonical": "http://segurosocial.gov",
       "Domain": "segurosocial.gov",
-      "Participates in DAP?": 1
+      "Participates in DAP?": 0
     },
     {
       "Agency": "Department of Health And Human Services",
@@ -4024,7 +3994,7 @@
       "Agency": "Department of the Treasury",
       "Canonical": "http://slgs.gov",
       "Domain": "slgs.gov",
-      "Participates in DAP?": 0
+      "Participates in DAP?": 1
     },
     {
       "Agency": "Department of Justice",
@@ -4048,7 +4018,7 @@
       "Agency": "Department of Health And Human Services",
       "Canonical": "http://smokefree.gov",
       "Domain": "smokefree.gov",
-      "Participates in DAP?": 0
+      "Participates in DAP?": 1
     },
     {
       "Agency": "Department of the Interior",
@@ -4112,7 +4082,7 @@
     },
     {
       "Agency": "Stennis Center for Public Service",
-      "Canonical": "http://stennis.gov",
+      "Canonical": "https://stennis.gov",
       "Domain": "stennis.gov",
       "Participates in DAP?": 0
     },
@@ -4144,7 +4114,7 @@
       "Agency": "General Services Administration",
       "Canonical": "https://strategicsourcing.gov",
       "Domain": "strategicsourcing.gov",
-      "Participates in DAP?": 0
+      "Participates in DAP?": 1
     },
     {
       "Agency": "Department of Education",
@@ -4192,7 +4162,7 @@
       "Agency": "Department of the Treasury",
       "Canonical": "http://taaps.gov",
       "Domain": "taaps.gov",
-      "Participates in DAP?": 0
+      "Participates in DAP?": 1
     },
     {
       "Agency": "Department of the Treasury",
@@ -4264,7 +4234,7 @@
       "Agency": "Department of the Treasury",
       "Canonical": "http://treasuryauctions.gov",
       "Domain": "treasuryauctions.gov",
-      "Participates in DAP?": 0
+      "Participates in DAP?": 1
     },
     {
       "Agency": "Department of the Treasury",
@@ -4276,13 +4246,13 @@
       "Agency": "Department of the Treasury",
       "Canonical": "http://treasuryhunt.gov",
       "Domain": "treasuryhunt.gov",
-      "Participates in DAP?": 0
+      "Participates in DAP?": 1
     },
     {
       "Agency": "Department of the Treasury",
       "Canonical": "http://treasuryscams.gov",
       "Domain": "treasuryscams.gov",
-      "Participates in DAP?": 0
+      "Participates in DAP?": 1
     },
     {
       "Agency": "Harry S. Truman Scholarship Foundation",
@@ -4333,10 +4303,16 @@
       "Participates in DAP?": 0
     },
     {
+      "Agency": "Tennessee Valley Authority",
+      "Canonical": "http://tvaoig.gov",
+      "Domain": "tvaoig.gov",
+      "Participates in DAP?": 0
+    },
+    {
       "Agency": "Department of Justice",
       "Canonical": "http://ucrdatatool.gov",
       "Domain": "ucrdatatool.gov",
-      "Participates in DAP?": 1
+      "Participates in DAP?": 0
     },
     {
       "Agency": "Morris K. Udall Foundation",
@@ -4372,7 +4348,7 @@
       "Agency": "Department of Homeland Security",
       "Canonical": "https://www.us-cert.gov",
       "Domain": "us-cert.gov",
-      "Participates in DAP?": 0
+      "Participates in DAP?": 1
     },
     {
       "Agency": "General Services Administration",
@@ -4387,6 +4363,12 @@
       "Participates in DAP?": 1
     },
     {
+      "Agency": "African Development Foundation",
+      "Canonical": "http://usadf.gov",
+      "Domain": "usadf.gov",
+      "Participates in DAP?": 0
+    },
+    {
       "Agency": "U.S. Agency for International Development",
       "Canonical": "http://www.usaid.gov",
       "Domain": "usaid.gov",
@@ -4394,7 +4376,7 @@
     },
     {
       "Agency": "U.S. Agency for International Development",
-      "Canonical": "http://www.usaidallnet.gov",
+      "Canonical": "https://www.usaidallnet.gov",
       "Domain": "usaidallnet.gov",
       "Participates in DAP?": 0
     },
@@ -4408,7 +4390,7 @@
       "Agency": "Office of Personnel Management",
       "Canonical": "https://usalearning.gov",
       "Domain": "usalearning.gov",
-      "Participates in DAP?": 0
+      "Participates in DAP?": 1
     },
     {
       "Agency": "Department of Defense",
@@ -4433,6 +4415,12 @@
       "Canonical": "https://www.usaspending.gov",
       "Domain": "usaspending.gov",
       "Participates in DAP?": 1
+    },
+    {
+      "Agency": "Office of Personnel Management",
+      "Canonical": "https://www.usastaffing.gov",
+      "Domain": "usastaffing.gov",
+      "Participates in DAP?": 0
     },
     {
       "Agency": "Department of the Interior",
@@ -4474,7 +4462,7 @@
       "Agency": "Department of State",
       "Canonical": "http://www.usembassy.gov",
       "Domain": "usembassy.gov",
-      "Participates in DAP?": 0
+      "Participates in DAP?": 1
     },
     {
       "Agency": "Department of the Interior",
@@ -4517,12 +4505,6 @@
       "Canonical": "http://www.usmint.gov",
       "Domain": "usmint.gov",
       "Participates in DAP?": 1
-    },
-    {
-      "Agency": "Department of State",
-      "Canonical": "http://usmission.gov",
-      "Domain": "usmission.gov",
-      "Participates in DAP?": 0
     },
     {
       "Agency": "Department of Health And Human Services",
@@ -4630,7 +4612,7 @@
       "Agency": "Department of Energy",
       "Canonical": "http://www.wapa.gov",
       "Domain": "wapa.gov",
-      "Participates in DAP?": 0
+      "Participates in DAP?": 1
     },
     {
       "Agency": "Department of the Interior",
@@ -4696,13 +4678,13 @@
       "Agency": "Department of the Treasury",
       "Canonical": "http://wizard.gov",
       "Domain": "wizard.gov",
-      "Participates in DAP?": 0
+      "Participates in DAP?": 1
     },
     {
       "Agency": "Department of the Interior",
       "Canonical": "https://www.wlci.gov",
       "Domain": "wlci.gov",
-      "Participates in DAP?": 0
+      "Participates in DAP?": 1
     },
     {
       "Agency": "Department of Agriculture",
@@ -4714,7 +4696,7 @@
       "Agency": "Department of Health And Human Services",
       "Canonical": "http://womenshealth.gov",
       "Domain": "womenshealth.gov",
-      "Participates in DAP?": 1
+      "Participates in DAP?": 0
     },
     {
       "Agency": "Department of the Treasury",

--- a/assets/data/tables/https/agencies.json
+++ b/assets/data/tables/https/agencies.json
@@ -89,6 +89,14 @@
       "Uses HTTPS": 0
     },
     {
+      "Agency": "Comm for People Who Are Blind/Severly Disabled",
+      "Enforces HTTPS": 0,
+      "Number of Domains": 1,
+      "SSL Labs (A- or higher)": 0,
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 0
+    },
+    {
       "Agency": "Commodity Futures Trading Commission",
       "Enforces HTTPS": 0,
       "Number of Domains": 2,

--- a/assets/data/tables/https/agencies.json
+++ b/assets/data/tables/https/agencies.json
@@ -2,7 +2,7 @@
   "data": [
     {
       "Agency": "AMTRAK",
-      "Enforces HTTPS": 0,
+      "Enforces HTTPS": 100,
       "Number of Domains": 1,
       "SSL Labs (A- or higher)": 0,
       "Strict Transport Security (HSTS)": 0,
@@ -18,6 +18,14 @@
     },
     {
       "Agency": "Advisory Council on Historic Preservation",
+      "Enforces HTTPS": 0,
+      "Number of Domains": 2,
+      "SSL Labs (A- or higher)": 0,
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 0
+    },
+    {
+      "Agency": "African Development Foundation",
       "Enforces HTTPS": 0,
       "Number of Domains": 2,
       "SSL Labs (A- or higher)": 0,
@@ -60,7 +68,7 @@
       "Agency": "Central Intelligence Agency",
       "Enforces HTTPS": 67,
       "Number of Domains": 3,
-      "SSL Labs (A- or higher)": 33,
+      "SSL Labs (A- or higher)": 67,
       "Strict Transport Security (HSTS)": 0,
       "Uses HTTPS": 67
     },
@@ -74,14 +82,6 @@
     },
     {
       "Agency": "Civil Air Patrol",
-      "Enforces HTTPS": 0,
-      "Number of Domains": 1,
-      "SSL Labs (A- or higher)": 0,
-      "Strict Transport Security (HSTS)": 0,
-      "Uses HTTPS": 100
-    },
-    {
-      "Agency": "Comm for People Who Are Blind/Severly Disabled",
       "Enforces HTTPS": 0,
       "Number of Domains": 2,
       "SSL Labs (A- or higher)": 0,
@@ -126,7 +126,7 @@
       "Number of Domains": 21,
       "SSL Labs (A- or higher)": 5,
       "Strict Transport Security (HSTS)": 0,
-      "Uses HTTPS": 5
+      "Uses HTTPS": 10
     },
     {
       "Agency": "Council of Inspector General on Integrity and Efficiency",
@@ -142,7 +142,7 @@
       "Number of Domains": 4,
       "SSL Labs (A- or higher)": 0,
       "Strict Transport Security (HSTS)": 0,
-      "Uses HTTPS": 0
+      "Uses HTTPS": 50
     },
     {
       "Agency": "Defense Nuclear Facilities Safety Board",
@@ -166,7 +166,7 @@
       "Number of Domains": 1,
       "SSL Labs (A- or higher)": 0,
       "Strict Transport Security (HSTS)": 0,
-      "Uses HTTPS": 100
+      "Uses HTTPS": 0
     },
     {
       "Agency": "Department of Agriculture",
@@ -179,10 +179,10 @@
     {
       "Agency": "Department of Commerce",
       "Enforces HTTPS": 0,
-      "Number of Domains": 53,
+      "Number of Domains": 49,
       "SSL Labs (A- or higher)": 6,
       "Strict Transport Security (HSTS)": 0,
-      "Uses HTTPS": 19
+      "Uses HTTPS": 18
     },
     {
       "Agency": "Department of Defense",
@@ -194,39 +194,39 @@
     },
     {
       "Agency": "Department of Education",
-      "Enforces HTTPS": 19,
+      "Enforces HTTPS": 12,
       "Number of Domains": 16,
       "SSL Labs (A- or higher)": 6,
       "Strict Transport Security (HSTS)": 6,
-      "Uses HTTPS": 38
+      "Uses HTTPS": 44
     },
     {
       "Agency": "Department of Energy",
-      "Enforces HTTPS": 10,
-      "Number of Domains": 58,
-      "SSL Labs (A- or higher)": 10,
+      "Enforces HTTPS": 11,
+      "Number of Domains": 55,
+      "SSL Labs (A- or higher)": 7,
       "Strict Transport Security (HSTS)": 0,
-      "Uses HTTPS": 36
+      "Uses HTTPS": 40
     },
     {
       "Agency": "Department of Health And Human Services",
       "Enforces HTTPS": 9,
       "Number of Domains": 112,
-      "SSL Labs (A- or higher)": 12,
-      "Strict Transport Security (HSTS)": 3,
-      "Uses HTTPS": 32
+      "SSL Labs (A- or higher)": 11,
+      "Strict Transport Security (HSTS)": 4,
+      "Uses HTTPS": 28
     },
     {
       "Agency": "Department of Homeland Security",
-      "Enforces HTTPS": 25,
-      "Number of Domains": 24,
-      "SSL Labs (A- or higher)": 8,
+      "Enforces HTTPS": 20,
+      "Number of Domains": 25,
+      "SSL Labs (A- or higher)": 4,
       "Strict Transport Security (HSTS)": 0,
-      "Uses HTTPS": 46
+      "Uses HTTPS": 44
     },
     {
       "Agency": "Department of Housing And Urban Development",
-      "Enforces HTTPS": 0,
+      "Enforces HTTPS": 10,
       "Number of Domains": 10,
       "SSL Labs (A- or higher)": 0,
       "Strict Transport Security (HSTS)": 0,
@@ -234,10 +234,10 @@
     },
     {
       "Agency": "Department of Justice",
-      "Enforces HTTPS": 14,
+      "Enforces HTTPS": 15,
       "Number of Domains": 66,
-      "SSL Labs (A- or higher)": 5,
-      "Strict Transport Security (HSTS)": 0,
+      "SSL Labs (A- or higher)": 3,
+      "Strict Transport Security (HSTS)": 2,
       "Uses HTTPS": 18
     },
     {
@@ -246,7 +246,7 @@
       "Number of Domains": 20,
       "SSL Labs (A- or higher)": 0,
       "Strict Transport Security (HSTS)": 0,
-      "Uses HTTPS": 25
+      "Uses HTTPS": 20
     },
     {
       "Agency": "Department of State",
@@ -254,7 +254,7 @@
       "Number of Domains": 22,
       "SSL Labs (A- or higher)": 0,
       "Strict Transport Security (HSTS)": 0,
-      "Uses HTTPS": 45
+      "Uses HTTPS": 50
     },
     {
       "Agency": "Department of Transportation",
@@ -276,17 +276,17 @@
       "Agency": "Department of the Interior",
       "Enforces HTTPS": 5,
       "Number of Domains": 83,
-      "SSL Labs (A- or higher)": 2,
+      "SSL Labs (A- or higher)": 13,
       "Strict Transport Security (HSTS)": 0,
-      "Uses HTTPS": 33
+      "Uses HTTPS": 30
     },
     {
       "Agency": "Department of the Treasury",
       "Enforces HTTPS": 19,
-      "Number of Domains": 85,
+      "Number of Domains": 84,
       "SSL Labs (A- or higher)": 1,
       "Strict Transport Security (HSTS)": 0,
-      "Uses HTTPS": 27
+      "Uses HTTPS": 25
     },
     {
       "Agency": "Director of National Intelligence",
@@ -298,11 +298,11 @@
     },
     {
       "Agency": "Environmental Protection Agency",
-      "Enforces HTTPS": 7,
-      "Number of Domains": 15,
+      "Enforces HTTPS": 8,
+      "Number of Domains": 13,
       "SSL Labs (A- or higher)": 0,
       "Strict Transport Security (HSTS)": 0,
-      "Uses HTTPS": 20
+      "Uses HTTPS": 23
     },
     {
       "Agency": "Equal Employment Opportunity Commission",
@@ -314,11 +314,11 @@
     },
     {
       "Agency": "Executive Office of the President",
-      "Enforces HTTPS": 19,
-      "Number of Domains": 31,
-      "SSL Labs (A- or higher)": 45,
-      "Strict Transport Security (HSTS)": 32,
-      "Uses HTTPS": 74
+      "Enforces HTTPS": 20,
+      "Number of Domains": 30,
+      "SSL Labs (A- or higher)": 47,
+      "Strict Transport Security (HSTS)": 33,
+      "Uses HTTPS": 77
     },
     {
       "Agency": "Export/Import Bank of the U.S.",
@@ -338,11 +338,11 @@
     },
     {
       "Agency": "Federal Communications Commission",
-      "Enforces HTTPS": 0,
+      "Enforces HTTPS": 12,
       "Number of Domains": 8,
       "SSL Labs (A- or higher)": 0,
       "Strict Transport Security (HSTS)": 0,
-      "Uses HTTPS": 12
+      "Uses HTTPS": 25
     },
     {
       "Agency": "Federal Deposit Insurance Corporation",
@@ -414,7 +414,7 @@
       "Number of Domains": 6,
       "SSL Labs (A- or higher)": 0,
       "Strict Transport Security (HSTS)": 0,
-      "Uses HTTPS": 67
+      "Uses HTTPS": 83
     },
     {
       "Agency": "Federal Retirement Thrift Investment Board",
@@ -426,27 +426,27 @@
     },
     {
       "Agency": "Federal Trade Commission",
-      "Enforces HTTPS": 27,
+      "Enforces HTTPS": 32,
       "Number of Domains": 22,
-      "SSL Labs (A- or higher)": 27,
+      "SSL Labs (A- or higher)": 23,
       "Strict Transport Security (HSTS)": 18,
-      "Uses HTTPS": 59
+      "Uses HTTPS": 68
     },
     {
       "Agency": "General Services Administration",
-      "Enforces HTTPS": 27,
-      "Number of Domains": 94,
-      "SSL Labs (A- or higher)": 5,
-      "Strict Transport Security (HSTS)": 6,
-      "Uses HTTPS": 51
+      "Enforces HTTPS": 26,
+      "Number of Domains": 92,
+      "SSL Labs (A- or higher)": 1,
+      "Strict Transport Security (HSTS)": 7,
+      "Uses HTTPS": 53
     },
     {
       "Agency": "Government Printing Office",
-      "Enforces HTTPS": 4,
-      "Number of Domains": 23,
-      "SSL Labs (A- or higher)": 4,
-      "Strict Transport Security (HSTS)": 4,
-      "Uses HTTPS": 13
+      "Enforces HTTPS": 5,
+      "Number of Domains": 22,
+      "SSL Labs (A- or higher)": 0,
+      "Strict Transport Security (HSTS)": 5,
+      "Uses HTTPS": 9
     },
     {
       "Agency": "Harry S. Truman Scholarship Foundation",
@@ -556,14 +556,14 @@
       "Agency": "National Aeronautics and Space Administration",
       "Enforces HTTPS": 0,
       "Number of Domains": 5,
-      "SSL Labs (A- or higher)": 20,
+      "SSL Labs (A- or higher)": 0,
       "Strict Transport Security (HSTS)": 0,
       "Uses HTTPS": 60
     },
     {
       "Agency": "National Archives and Records Administration",
       "Enforces HTTPS": 0,
-      "Number of Domains": 16,
+      "Number of Domains": 15,
       "SSL Labs (A- or higher)": 0,
       "Strict Transport Security (HSTS)": 0,
       "Uses HTTPS": 0
@@ -650,11 +650,11 @@
     },
     {
       "Agency": "National Science Foundation",
-      "Enforces HTTPS": 0,
+      "Enforces HTTPS": 12,
       "Number of Domains": 8,
       "SSL Labs (A- or higher)": 0,
       "Strict Transport Security (HSTS)": 0,
-      "Uses HTTPS": 75
+      "Uses HTTPS": 62
     },
     {
       "Agency": "National Security Agency",
@@ -706,9 +706,9 @@
     },
     {
       "Agency": "Office of Personnel Management",
-      "Enforces HTTPS": 29,
+      "Enforces HTTPS": 33,
       "Number of Domains": 21,
-      "SSL Labs (A- or higher)": 0,
+      "SSL Labs (A- or higher)": 29,
       "Strict Transport Security (HSTS)": 5,
       "Uses HTTPS": 57
     },
@@ -747,7 +747,7 @@
     {
       "Agency": "Recovery Accountability and Transparency Board",
       "Enforces HTTPS": 0,
-      "Number of Domains": 5,
+      "Number of Domains": 4,
       "SSL Labs (A- or higher)": 0,
       "Strict Transport Security (HSTS)": 0,
       "Uses HTTPS": 0
@@ -756,9 +756,9 @@
       "Agency": "Securities and Exchange Commission",
       "Enforces HTTPS": 0,
       "Number of Domains": 3,
-      "SSL Labs (A- or higher)": 0,
+      "SSL Labs (A- or higher)": 33,
       "Strict Transport Security (HSTS)": 0,
-      "Uses HTTPS": 33
+      "Uses HTTPS": 67
     },
     {
       "Agency": "Selective Service System",
@@ -770,11 +770,11 @@
     },
     {
       "Agency": "Small Business Administration",
-      "Enforces HTTPS": 29,
-      "Number of Domains": 7,
+      "Enforces HTTPS": 33,
+      "Number of Domains": 6,
       "SSL Labs (A- or higher)": 0,
       "Strict Transport Security (HSTS)": 0,
-      "Uses HTTPS": 29
+      "Uses HTTPS": 33
     },
     {
       "Agency": "Smithsonian Institution",
@@ -802,16 +802,16 @@
     },
     {
       "Agency": "Stennis Center for Public Service",
-      "Enforces HTTPS": 0,
+      "Enforces HTTPS": 100,
       "Number of Domains": 1,
       "SSL Labs (A- or higher)": 0,
       "Strict Transport Security (HSTS)": 0,
-      "Uses HTTPS": 0
+      "Uses HTTPS": 100
     },
     {
       "Agency": "Tennessee Valley Authority",
       "Enforces HTTPS": 0,
-      "Number of Domains": 1,
+      "Number of Domains": 2,
       "SSL Labs (A- or higher)": 0,
       "Strict Transport Security (HSTS)": 0,
       "Uses HTTPS": 0
@@ -838,15 +838,15 @@
       "Number of Domains": 16,
       "SSL Labs (A- or higher)": 6,
       "Strict Transport Security (HSTS)": 6,
-      "Uses HTTPS": 6
+      "Uses HTTPS": 12
     },
     {
       "Agency": "The Legislative Branch (Congress)",
-      "Enforces HTTPS": 5,
+      "Enforces HTTPS": 7,
       "Number of Domains": 41,
       "SSL Labs (A- or higher)": 2,
       "Strict Transport Security (HSTS)": 0,
-      "Uses HTTPS": 17
+      "Uses HTTPS": 22
     },
     {
       "Agency": "The United States World War One Centennial Commission",
@@ -906,11 +906,11 @@
     },
     {
       "Agency": "U.S. Agency for International Development",
-      "Enforces HTTPS": 9,
-      "Number of Domains": 11,
+      "Enforces HTTPS": 20,
+      "Number of Domains": 10,
       "SSL Labs (A- or higher)": 0,
       "Strict Transport Security (HSTS)": 0,
-      "Uses HTTPS": 18
+      "Uses HTTPS": 30
     },
     {
       "Agency": "U.S. Chemical Safety and Hazard Investigation Board",
@@ -932,7 +932,7 @@
       "Agency": "U.S. Postal Service, Office of Inspector General",
       "Enforces HTTPS": 100,
       "Number of Domains": 1,
-      "SSL Labs (A- or higher)": 100,
+      "SSL Labs (A- or higher)": 0,
       "Strict Transport Security (HSTS)": 100,
       "Uses HTTPS": 100
     },
@@ -942,7 +942,7 @@
       "Number of Domains": 1,
       "SSL Labs (A- or higher)": 0,
       "Strict Transport Security (HSTS)": 0,
-      "Uses HTTPS": 100
+      "Uses HTTPS": 0
     },
     {
       "Agency": "US Interagency Council on Homelessness",
@@ -955,10 +955,10 @@
     {
       "Agency": "United Stated Global Change Research Program",
       "Enforces HTTPS": 0,
-      "Number of Domains": 4,
+      "Number of Domains": 3,
       "SSL Labs (A- or higher)": 0,
       "Strict Transport Security (HSTS)": 0,
-      "Uses HTTPS": 25
+      "Uses HTTPS": 33
     },
     {
       "Agency": "United States Office of Government Ethics",

--- a/assets/data/tables/https/domains.json
+++ b/assets/data/tables/https/domains.json
@@ -71,16 +71,6 @@
       "Uses HTTPS": 2
     },
     {
-      "Agency": "Comm for People Who Are Blind/Severly Disabled",
-      "Canonical": "http://abilityone.gov",
-      "Details": "This domain does not support HTTPS.",
-      "Domain": "abilityone.gov",
-      "Enforces HTTPS": -1,
-      "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": -1
-    },
-    {
       "Agency": "American Battle Monuments Commission",
       "Canonical": "http://abmc.gov",
       "Details": "This domain is offered over valid HTTPS, but uses a certificate chain that may cause issues for some visitors.",
@@ -171,6 +161,16 @@
       "Uses HTTPS": -1
     },
     {
+      "Agency": "African Development Foundation",
+      "Canonical": "http://adf.gov",
+      "Details": "This domain does not support HTTPS.",
+      "Domain": "adf.gov",
+      "Enforces HTTPS": -1,
+      "SSL Labs Grade": -1,
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": -1
+    },
+    {
       "Agency": "Department of Defense",
       "Canonical": "http://adlnet.gov",
       "Details": "This domain does not support HTTPS.",
@@ -236,7 +236,7 @@
       "Details": "This domain is offered over valid HTTPS, but uses a certificate chain that may cause issues for some visitors.",
       "Domain": "afrh.gov",
       "Enforces HTTPS": 3,
-      "SSL Labs Grade": 3,
+      "SSL Labs Grade": 2,
       "Strict Transport Security (HSTS)": 0,
       "Uses HTTPS": 1
     },
@@ -326,7 +326,7 @@
       "Details": "This domain is offered over valid HTTPS.",
       "Domain": "alertaenlinea.gov",
       "Enforces HTTPS": 1,
-      "SSL Labs Grade": 3,
+      "SSL Labs Grade": 2,
       "Strict Transport Security (HSTS)": 0,
       "Uses HTTPS": 2
     },
@@ -356,7 +356,7 @@
       "Details": "This domain is offered over valid HTTPS, but uses a certificate chain that may cause issues for some visitors.",
       "Domain": "ama.gov",
       "Enforces HTTPS": 3,
-      "SSL Labs Grade": 0,
+      "SSL Labs Grade": 2,
       "Strict Transport Security (HSTS)": 0,
       "Uses HTTPS": 1
     },
@@ -512,7 +512,7 @@
     },
     {
       "Agency": "Corporation for National & Community Service",
-      "Canonical": "http://www.americorpsweek.gov",
+      "Canonical": "http://americorpsweek.gov",
       "Details": "This domain does not support HTTPS.",
       "Domain": "americorpsweek.gov",
       "Enforces HTTPS": -1,
@@ -526,19 +526,19 @@
       "Details": "This domain is offered over valid HTTPS.",
       "Domain": "ameslab.gov",
       "Enforces HTTPS": 3,
-      "SSL Labs Grade": 4,
+      "SSL Labs Grade": 3,
       "Strict Transport Security (HSTS)": 0,
       "Uses HTTPS": 2
     },
     {
       "Agency": "AMTRAK",
-      "Canonical": "http://amtrakoig.gov",
-      "Details": "This domain is offered over valid HTTPS, but uses a certificate chain that may cause issues for some visitors.",
+      "Canonical": "https://amtrakoig.gov",
+      "Details": "This domain is offered over valid HTTPS.",
       "Domain": "amtrakoig.gov",
-      "Enforces HTTPS": 1,
-      "SSL Labs Grade": -1,
+      "Enforces HTTPS": 3,
+      "SSL Labs Grade": 2,
       "Strict Transport Security (HSTS)": 0,
-      "Uses HTTPS": 1
+      "Uses HTTPS": 2
     },
     {
       "Agency": "Department of Energy",
@@ -663,12 +663,12 @@
     {
       "Agency": "Department of Energy",
       "Canonical": "http://www.arm.gov",
-      "Details": "This domain does not support HTTPS.",
+      "Details": "This domain is offered over valid HTTPS.",
       "Domain": "arm.gov",
-      "Enforces HTTPS": -1,
-      "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": -1
+      "Enforces HTTPS": 1,
+      "SSL Labs Grade": 5,
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 2
     },
     {
       "Agency": "Department of Agriculture",
@@ -696,7 +696,7 @@
       "Details": "This domain is offered over valid HTTPS, but uses a certificate chain that may cause issues for some visitors.",
       "Domain": "asap.gov",
       "Enforces HTTPS": 3,
-      "SSL Labs Grade": 0,
+      "SSL Labs Grade": 2,
       "Strict Transport Security (HSTS)": 0,
       "Uses HTTPS": 1
     },
@@ -706,7 +706,7 @@
       "Details": "This domain is offered over valid HTTPS.",
       "Domain": "asc.gov",
       "Enforces HTTPS": 3,
-      "SSL Labs Grade": 3,
+      "SSL Labs Grade": 2,
       "Strict Transport Security (HSTS)": 0,
       "Uses HTTPS": 2
     },
@@ -742,12 +742,12 @@
     },
     {
       "Agency": "Department of Justice",
-      "Canonical": "http://www.atf.gov",
+      "Canonical": "https://www.atf.gov",
       "Details": "This domain is offered over valid HTTPS.",
       "Domain": "atf.gov",
-      "Enforces HTTPS": 1,
-      "SSL Labs Grade": 5,
-      "Strict Transport Security (HSTS)": 0,
+      "Enforces HTTPS": 3,
+      "SSL Labs Grade": 6,
+      "Strict Transport Security (HSTS)": 1,
       "Uses HTTPS": 2
     },
     {
@@ -773,12 +773,12 @@
     {
       "Agency": "Department of Commerce",
       "Canonical": "http://aviationweather.gov",
-      "Details": "This domain is offered over valid HTTPS.",
+      "Details": "This domain is offered over valid HTTPS, but uses a certificate chain that may cause issues for some visitors.",
       "Domain": "aviationweather.gov",
       "Enforces HTTPS": 1,
-      "SSL Labs Grade": 3,
+      "SSL Labs Grade": 2,
       "Strict Transport Security (HSTS)": 0,
-      "Uses HTTPS": 2
+      "Uses HTTPS": 1
     },
     {
       "Agency": "Department of the Treasury",
@@ -956,7 +956,7 @@
       "Details": "This domain is offered over valid HTTPS.",
       "Domain": "bfem.gov",
       "Enforces HTTPS": 3,
-      "SSL Labs Grade": 0,
+      "SSL Labs Grade": 2,
       "Strict Transport Security (HSTS)": 0,
       "Uses HTTPS": 2
     },
@@ -986,7 +986,7 @@
       "Details": "This domain is offered over valid HTTPS, but uses a certificate chain that may cause issues for some visitors.",
       "Domain": "bioethics.gov",
       "Enforces HTTPS": 1,
-      "SSL Labs Grade": 2,
+      "SSL Labs Grade": 1,
       "Strict Transport Security (HSTS)": 0,
       "Uses HTTPS": 1
     },
@@ -1036,7 +1036,7 @@
       "Details": "This domain is offered over valid HTTPS.",
       "Domain": "bja.gov",
       "Enforces HTTPS": 3,
-      "SSL Labs Grade": 2,
+      "SSL Labs Grade": 0,
       "Strict Transport Security (HSTS)": 0,
       "Uses HTTPS": 2
     },
@@ -1173,16 +1173,16 @@
     {
       "Agency": "Federal Communications Commission",
       "Canonical": "http://broadbandmap.gov",
-      "Details": "This domain does not support HTTPS.",
+      "Details": "This domain is offered over valid HTTPS.",
       "Domain": "broadbandmap.gov",
-      "Enforces HTTPS": -1,
-      "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": -1
+      "Enforces HTTPS": 1,
+      "SSL Labs Grade": 3,
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 2
     },
     {
       "Agency": "Government Printing Office",
-      "Canonical": "http://www.browsetopics.gov",
+      "Canonical": "http://browsetopics.gov",
       "Details": "This domain does not support HTTPS.",
       "Domain": "browsetopics.gov",
       "Enforces HTTPS": -1,
@@ -1193,12 +1193,12 @@
     {
       "Agency": "Department of the Interior",
       "Canonical": "http://www.bsee.gov",
-      "Details": "This domain does not support HTTPS.",
+      "Details": "This domain is offered over valid HTTPS.",
       "Domain": "bsee.gov",
-      "Enforces HTTPS": -1,
-      "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": -1
+      "Enforces HTTPS": 1,
+      "SSL Labs Grade": 3,
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 2
     },
     {
       "Agency": "Department of Transportation",
@@ -1311,14 +1311,24 @@
       "Uses HTTPS": 2
     },
     {
-      "Agency": "The Legislative Branch (Congress)",
-      "Canonical": "http://capitol.gov",
+      "Agency": "Civil Air Patrol",
+      "Canonical": "http://www.cap.gov",
       "Details": "This domain does not support HTTPS.",
-      "Domain": "capitol.gov",
+      "Domain": "cap.gov",
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
       "Uses HTTPS": -1
+    },
+    {
+      "Agency": "The Legislative Branch (Congress)",
+      "Canonical": "http://capitol.gov",
+      "Details": "This domain is offered over valid HTTPS.",
+      "Domain": "capitol.gov",
+      "Enforces HTTPS": 1,
+      "SSL Labs Grade": 2,
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 2
     },
     {
       "Agency": "The Legislative Branch (Congress)",
@@ -1343,18 +1353,8 @@
     {
       "Agency": "Civil Air Patrol",
       "Canonical": "http://www.capnhq.gov",
-      "Details": "This domain is offered over valid HTTPS.",
-      "Domain": "capnhq.gov",
-      "Enforces HTTPS": 1,
-      "SSL Labs Grade": 3,
-      "Strict Transport Security (HSTS)": 0,
-      "Uses HTTPS": 2
-    },
-    {
-      "Agency": "United Stated Global Change Research Program",
-      "Canonical": "http://www.carboncyclescience.gov",
       "Details": "This domain does not support HTTPS.",
-      "Domain": "carboncyclescience.gov",
+      "Domain": "capnhq.gov",
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
@@ -1386,7 +1386,7 @@
       "Details": "This domain is offered over valid HTTPS.",
       "Domain": "cbo.gov",
       "Enforces HTTPS": 1,
-      "SSL Labs Grade": 4,
+      "SSL Labs Grade": 3,
       "Strict Transport Security (HSTS)": 0,
       "Uses HTTPS": 2
     },
@@ -1453,12 +1453,12 @@
     {
       "Agency": "Department of the Treasury",
       "Canonical": "http://cdfifund.gov",
-      "Details": "This domain is offered over valid HTTPS, but uses a certificate chain that may cause issues for some visitors.",
+      "Details": "This domain does not support HTTPS.",
       "Domain": "cdfifund.gov",
-      "Enforces HTTPS": 1,
-      "SSL Labs Grade": 1,
-      "Strict Transport Security (HSTS)": 0,
-      "Uses HTTPS": 1
+      "Enforces HTTPS": -1,
+      "SSL Labs Grade": -1,
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": -1
     },
     {
       "Agency": "Department of Energy",
@@ -1506,7 +1506,7 @@
       "Details": "This domain is offered over valid HTTPS.",
       "Domain": "cfa.gov",
       "Enforces HTTPS": 1,
-      "SSL Labs Grade": 3,
+      "SSL Labs Grade": 2,
       "Strict Transport Security (HSTS)": 0,
       "Uses HTTPS": 2
     },
@@ -1576,7 +1576,7 @@
       "Details": "This domain is offered over valid HTTPS.",
       "Domain": "challenge.gov",
       "Enforces HTTPS": 1,
-      "SSL Labs Grade": 3,
+      "SSL Labs Grade": 2,
       "Strict Transport Security (HSTS)": 0,
       "Uses HTTPS": 2
     },
@@ -1606,7 +1606,7 @@
       "Details": "This domain is offered over valid HTTPS.",
       "Domain": "chcoc.gov",
       "Enforces HTTPS": 1,
-      "SSL Labs Grade": 3,
+      "SSL Labs Grade": 4,
       "Strict Transport Security (HSTS)": 0,
       "Uses HTTPS": 2
     },
@@ -1676,7 +1676,7 @@
       "Details": "This domain is offered over valid HTTPS.",
       "Domain": "christophercolumbusfoundation.gov",
       "Enforces HTTPS": 1,
-      "SSL Labs Grade": 3,
+      "SSL Labs Grade": 2,
       "Strict Transport Security (HSTS)": 0,
       "Uses HTTPS": 2
     },
@@ -1706,7 +1706,7 @@
       "Details": "This domain is offered over valid HTTPS.",
       "Domain": "citizencorps.gov",
       "Enforces HTTPS": 1,
-      "SSL Labs Grade": 4,
+      "SSL Labs Grade": 2,
       "Strict Transport Security (HSTS)": 0,
       "Uses HTTPS": 2
     },
@@ -1822,7 +1822,7 @@
     },
     {
       "Agency": "Corporation for National & Community Service",
-      "Canonical": "http://cncsoig.gov",
+      "Canonical": "http://www.cncsoig.gov",
       "Details": "This domain does not support HTTPS.",
       "Domain": "cncsoig.gov",
       "Enforces HTTPS": -1,
@@ -1911,16 +1911,6 @@
       "Uses HTTPS": 0
     },
     {
-      "Agency": "Department of the Treasury",
-      "Canonical": "http://www.complaintreferralexpress.gov",
-      "Details": "This domain is offered over valid HTTPS.",
-      "Domain": "complaintreferralexpress.gov",
-      "Enforces HTTPS": 1,
-      "SSL Labs Grade": 0,
-      "Strict Transport Security (HSTS)": 0,
-      "Uses HTTPS": 2
-    },
-    {
       "Agency": "Congressional Office of Compliance",
       "Canonical": "http://www.compliance.gov",
       "Details": "This domain does not support HTTPS.",
@@ -1956,7 +1946,7 @@
       "Details": "This domain is offered over valid HTTPS.",
       "Domain": "computersforlearning.gov",
       "Enforces HTTPS": 1,
-      "SSL Labs Grade": 4,
+      "SSL Labs Grade": 3,
       "Strict Transport Security (HSTS)": 0,
       "Uses HTTPS": 2
     },
@@ -1966,7 +1956,7 @@
       "Details": "This domain is offered over valid HTTPS.",
       "Domain": "congress.gov",
       "Enforces HTTPS": 3,
-      "SSL Labs Grade": 3,
+      "SSL Labs Grade": 2,
       "Strict Transport Security (HSTS)": 0,
       "Uses HTTPS": 2
     },
@@ -1996,7 +1986,7 @@
       "Details": "This domain is offered over valid HTTPS.",
       "Domain": "connect.gov",
       "Enforces HTTPS": 1,
-      "SSL Labs Grade": 3,
+      "SSL Labs Grade": 2,
       "Strict Transport Security (HSTS)": 0,
       "Uses HTTPS": 2
     },
@@ -2006,7 +1996,7 @@
       "Details": "This domain is offered over valid HTTPS.",
       "Domain": "consumer.gov",
       "Enforces HTTPS": 1,
-      "SSL Labs Grade": 3,
+      "SSL Labs Grade": 2,
       "Strict Transport Security (HSTS)": 0,
       "Uses HTTPS": 2
     },
@@ -2106,7 +2096,7 @@
       "Details": "This domain is offered over valid HTTPS.",
       "Domain": "consumidor.gov",
       "Enforces HTTPS": 1,
-      "SSL Labs Grade": 3,
+      "SSL Labs Grade": 2,
       "Strict Transport Security (HSTS)": 0,
       "Uses HTTPS": 2
     },
@@ -2186,7 +2176,7 @@
       "Details": "This domain is offered over valid HTTPS, but uses a certificate chain that may cause issues for some visitors.",
       "Domain": "cpars.gov",
       "Enforces HTTPS": 3,
-      "SSL Labs Grade": 3,
+      "SSL Labs Grade": 2,
       "Strict Transport Security (HSTS)": 0,
       "Uses HTTPS": 1
     },
@@ -2336,7 +2326,7 @@
       "Details": "This domain is offered over valid HTTPS.",
       "Domain": "data.gov",
       "Enforces HTTPS": 1,
-      "SSL Labs Grade": 3,
+      "SSL Labs Grade": 2,
       "Strict Transport Security (HSTS)": 0,
       "Uses HTTPS": 2
     },
@@ -2413,12 +2403,12 @@
     {
       "Agency": "Denali Commission",
       "Canonical": "http://denali.gov",
-      "Details": "This domain is offered over valid HTTPS, but uses a certificate chain that may cause issues for some visitors.",
+      "Details": "This domain does not support HTTPS.",
       "Domain": "denali.gov",
-      "Enforces HTTPS": 1,
-      "SSL Labs Grade": 2,
-      "Strict Transport Security (HSTS)": 0,
-      "Uses HTTPS": 1
+      "Enforces HTTPS": -1,
+      "SSL Labs Grade": -1,
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": -1
     },
     {
       "Agency": "U.S. Agency for International Development",
@@ -2476,7 +2466,7 @@
       "Details": "This domain is offered over valid HTTPS.",
       "Domain": "digitalgov.gov",
       "Enforces HTTPS": 1,
-      "SSL Labs Grade": 3,
+      "SSL Labs Grade": 2,
       "Strict Transport Security (HSTS)": 0,
       "Uses HTTPS": 2
     },
@@ -2613,12 +2603,12 @@
     {
       "Agency": "Department of Commerce",
       "Canonical": "http://www.dnsops.gov",
-      "Details": "This domain is offered over valid HTTPS, but uses a certificate chain that may cause issues for some visitors.",
+      "Details": "This domain does not support HTTPS.",
       "Domain": "dnsops.gov",
-      "Enforces HTTPS": 1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": 0,
-      "Uses HTTPS": 1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": -1
     },
     {
       "Agency": "Department of Commerce",
@@ -2655,16 +2645,6 @@
       "Canonical": "http://www.doe.gov",
       "Details": "This domain does not support HTTPS.",
       "Domain": "doe.gov",
-      "Enforces HTTPS": -1,
-      "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": -1
-    },
-    {
-      "Agency": "Department of Energy",
-      "Canonical": "http://www.doeal.gov",
-      "Details": "This domain does not support HTTPS.",
-      "Domain": "doeal.gov",
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
@@ -2816,7 +2796,7 @@
       "Details": "This domain is offered over valid HTTPS.",
       "Domain": "drugabuse.gov",
       "Enforces HTTPS": 1,
-      "SSL Labs Grade": 4,
+      "SSL Labs Grade": 3,
       "Strict Transport Security (HSTS)": 0,
       "Uses HTTPS": 2
     },
@@ -2926,7 +2906,7 @@
       "Details": "This domain is offered over valid HTTPS.",
       "Domain": "economicinclusion.gov",
       "Enforces HTTPS": 3,
-      "SSL Labs Grade": 3,
+      "SSL Labs Grade": 2,
       "Strict Transport Security (HSTS)": 0,
       "Uses HTTPS": 2
     },
@@ -2956,7 +2936,7 @@
       "Details": "This domain is offered over valid HTTPS.",
       "Domain": "ecpic.gov",
       "Enforces HTTPS": 2,
-      "SSL Labs Grade": 3,
+      "SSL Labs Grade": 2,
       "Strict Transport Security (HSTS)": 0,
       "Uses HTTPS": 2
     },
@@ -2966,7 +2946,7 @@
       "Details": "This domain is offered over valid HTTPS.",
       "Domain": "ecr.gov",
       "Enforces HTTPS": 1,
-      "SSL Labs Grade": 3,
+      "SSL Labs Grade": 2,
       "Strict Transport Security (HSTS)": 0,
       "Uses HTTPS": 2
     },
@@ -2976,7 +2956,7 @@
       "Details": "This domain is offered over valid HTTPS.",
       "Domain": "ed.gov",
       "Enforces HTTPS": 1,
-      "SSL Labs Grade": 3,
+      "SSL Labs Grade": 2,
       "Strict Transport Security (HSTS)": 0,
       "Uses HTTPS": 2
     },
@@ -3012,13 +2992,13 @@
     },
     {
       "Agency": "Department of Education",
-      "Canonical": "http://www.education.gov",
-      "Details": "This domain does not support HTTPS.",
+      "Canonical": "http://education.gov",
+      "Details": "This domain is offered over valid HTTPS, but uses a certificate chain that may cause issues for some visitors.",
       "Domain": "education.gov",
-      "Enforces HTTPS": -1,
+      "Enforces HTTPS": 1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": -1
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 1
     },
     {
       "Agency": "Recovery Accountability and Transparency Board",
@@ -3101,22 +3081,12 @@
       "Uses HTTPS": 2
     },
     {
-      "Agency": "National Archives and Records Administration",
-      "Canonical": "http://www.emergency-federal-register.gov",
-      "Details": "This domain does not support HTTPS.",
-      "Domain": "emergency-federal-register.gov",
-      "Enforces HTTPS": -1,
-      "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": -1
-    },
-    {
       "Agency": "Office of Personnel Management",
       "Canonical": "https://www.employeeexpress.gov",
       "Details": "This domain is offered over valid HTTPS.",
       "Domain": "employeeexpress.gov",
       "Enforces HTTPS": 3,
-      "SSL Labs Grade": 3,
+      "SSL Labs Grade": 2,
       "Strict Transport Security (HSTS)": 0,
       "Uses HTTPS": 2
     },
@@ -3126,7 +3096,7 @@
       "Details": "This domain is offered over valid HTTPS, but uses a certificate chain that may cause issues for some visitors.",
       "Domain": "empowhr.gov",
       "Enforces HTTPS": 3,
-      "SSL Labs Grade": -1,
+      "SSL Labs Grade": 0,
       "Strict Transport Security (HSTS)": 0,
       "Uses HTTPS": 1
     },
@@ -3206,7 +3176,7 @@
       "Details": "This domain is offered over valid HTTPS.",
       "Domain": "energystar.gov",
       "Enforces HTTPS": 1,
-      "SSL Labs Grade": 3,
+      "SSL Labs Grade": 2,
       "Strict Transport Security (HSTS)": 0,
       "Uses HTTPS": 2
     },
@@ -3219,26 +3189,6 @@
       "SSL Labs Grade": 5,
       "Strict Transport Security (HSTS)": 0,
       "Uses HTTPS": 2
-    },
-    {
-      "Agency": "Environmental Protection Agency",
-      "Canonical": "http://www.epa-echo.gov",
-      "Details": "This domain does not support HTTPS.",
-      "Domain": "epa-echo.gov",
-      "Enforces HTTPS": -1,
-      "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": -1
-    },
-    {
-      "Agency": "Environmental Protection Agency",
-      "Canonical": "http://www.epa-otis.gov",
-      "Details": "This domain does not support HTTPS.",
-      "Domain": "epa-otis.gov",
-      "Enforces HTTPS": -1,
-      "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": -1
     },
     {
       "Agency": "Environmental Protection Agency",
@@ -3372,7 +3322,7 @@
     },
     {
       "Agency": "Export/Import Bank of the U.S.",
-      "Canonical": "http://www.exim.gov",
+      "Canonical": "http://exim.gov",
       "Details": "This domain does not support HTTPS.",
       "Domain": "exim.gov",
       "Enforces HTTPS": -1,
@@ -3432,7 +3382,7 @@
     },
     {
       "Agency": "General Services Administration",
-      "Canonical": "http://faca.gov",
+      "Canonical": "http://www.faca.gov",
       "Details": "This domain is offered over valid HTTPS.",
       "Domain": "faca.gov",
       "Enforces HTTPS": 1,
@@ -3456,7 +3406,7 @@
       "Details": "This domain is offered over valid HTTPS.",
       "Domain": "fafsa.gov",
       "Enforces HTTPS": 1,
-      "SSL Labs Grade": 0,
+      "SSL Labs Grade": 3,
       "Strict Transport Security (HSTS)": 0,
       "Uses HTTPS": 2
     },
@@ -3486,7 +3436,7 @@
       "Details": "This domain is offered over valid HTTPS, but uses a certificate chain that may cause issues for some visitors.",
       "Domain": "fapiis.gov",
       "Enforces HTTPS": 3,
-      "SSL Labs Grade": 3,
+      "SSL Labs Grade": 2,
       "Strict Transport Security (HSTS)": 0,
       "Uses HTTPS": 1
     },
@@ -3536,8 +3486,8 @@
       "Details": "This domain is offered over valid HTTPS.",
       "Domain": "fatherhood.gov",
       "Enforces HTTPS": 3,
-      "SSL Labs Grade": 5,
-      "Strict Transport Security (HSTS)": 0,
+      "SSL Labs Grade": 6,
+      "Strict Transport Security (HSTS)": 3,
       "Uses HTTPS": 2
     },
     {
@@ -3566,7 +3516,7 @@
       "Details": "This domain is offered over valid HTTPS.",
       "Domain": "fbijobs.gov",
       "Enforces HTTPS": 2,
-      "SSL Labs Grade": 4,
+      "SSL Labs Grade": 3,
       "Strict Transport Security (HSTS)": 0,
       "Uses HTTPS": 2
     },
@@ -3592,10 +3542,10 @@
     },
     {
       "Agency": "Federal Communications Commission",
-      "Canonical": "http://www.fcc.gov",
+      "Canonical": "https://www.fcc.gov",
       "Details": "This domain is offered over valid HTTPS.",
       "Domain": "fcc.gov",
-      "Enforces HTTPS": 1,
+      "Enforces HTTPS": 2,
       "SSL Labs Grade": 3,
       "Strict Transport Security (HSTS)": 0,
       "Uses HTTPS": 2
@@ -3635,16 +3585,6 @@
       "Canonical": "http://fcsic.gov",
       "Details": "This domain does not support HTTPS.",
       "Domain": "fcsic.gov",
-      "Enforces HTTPS": -1,
-      "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": -1
-    },
-    {
-      "Agency": "Department of Commerce",
-      "Canonical": "http://fcsm.gov",
-      "Details": "This domain does not support HTTPS.",
-      "Domain": "fcsm.gov",
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
@@ -3732,13 +3672,13 @@
     },
     {
       "Agency": "Environmental Protection Agency",
-      "Canonical": "http://www.fdms.gov",
-      "Details": "This domain does not support HTTPS.",
+      "Canonical": "https://www.fdms.gov",
+      "Details": "This domain redirects visitors from HTTPS to HTTP.",
       "Domain": "fdms.gov",
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": -1
+      "Uses HTTPS": 0
     },
     {
       "Agency": "Department of Transportation",
@@ -3856,7 +3796,7 @@
       "Details": "This domain is offered over valid HTTPS.",
       "Domain": "federalregister.gov",
       "Enforces HTTPS": 2,
-      "SSL Labs Grade": 5,
+      "SSL Labs Grade": 3,
       "Strict Transport Security (HSTS)": 3,
       "Uses HTTPS": 2
     },
@@ -3872,13 +3812,13 @@
     },
     {
       "Agency": "Federal Reserve System",
-      "Canonical": "http://federalreserve.gov",
-      "Details": "This domain does not support HTTPS.",
+      "Canonical": "http://www.federalreserve.gov",
+      "Details": "This domain is offered over valid HTTPS.",
       "Domain": "federalreserve.gov",
-      "Enforces HTTPS": -1,
-      "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": -1
+      "Enforces HTTPS": 1,
+      "SSL Labs Grade": 3,
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 2
     },
     {
       "Agency": "Federal Reserve System",
@@ -3886,7 +3826,7 @@
       "Details": "This domain is offered over valid HTTPS.",
       "Domain": "federalreserveconsumerhelp.gov",
       "Enforces HTTPS": 1,
-      "SSL Labs Grade": 3,
+      "SSL Labs Grade": 2,
       "Strict Transport Security (HSTS)": 0,
       "Uses HTTPS": 2
     },
@@ -3895,16 +3835,6 @@
       "Canonical": "http://www.federalrules.gov",
       "Details": "This domain does not support HTTPS.",
       "Domain": "federalrules.gov",
-      "Enforces HTTPS": -1,
-      "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": -1
-    },
-    {
-      "Agency": "Recovery Accountability and Transparency Board",
-      "Canonical": "http://www.federaltransparency.gov",
-      "Details": "This domain does not support HTTPS.",
-      "Domain": "federaltransparency.gov",
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
@@ -3966,29 +3896,19 @@
       "Details": "This domain is offered over valid HTTPS.",
       "Domain": "fedramp.gov",
       "Enforces HTTPS": 1,
-      "SSL Labs Grade": 3,
+      "SSL Labs Grade": 2,
       "Strict Transport Security (HSTS)": 0,
       "Uses HTTPS": 2
-    },
-    {
-      "Agency": "General Services Administration",
-      "Canonical": "http://fedrealestate.gov",
-      "Details": "This domain does not support HTTPS.",
-      "Domain": "fedrealestate.gov",
-      "Enforces HTTPS": -1,
-      "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": -1
     },
     {
       "Agency": "Government Printing Office",
       "Canonical": "http://www.fedreg.gov",
-      "Details": "This domain is offered over valid HTTPS.",
+      "Details": "This domain does not support HTTPS.",
       "Domain": "fedreg.gov",
-      "Enforces HTTPS": 1,
-      "SSL Labs Grade": 0,
-      "Strict Transport Security (HSTS)": 0,
-      "Uses HTTPS": 2
+      "Enforces HTTPS": -1,
+      "SSL Labs Grade": -1,
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": -1
     },
     {
       "Agency": "General Services Administration",
@@ -4011,16 +3931,6 @@
       "Uses HTTPS": -1
     },
     {
-      "Agency": "Department of Commerce",
-      "Canonical": "http://fedstats.gov",
-      "Details": "This domain does not support HTTPS.",
-      "Domain": "fedstats.gov",
-      "Enforces HTTPS": -1,
-      "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": -1
-    },
-    {
       "Agency": "U.S. Agency for International Development",
       "Canonical": "http://feedthefuture.gov",
       "Details": "This domain redirects visitors from HTTPS to HTTP.",
@@ -4036,7 +3946,7 @@
       "Details": "This domain is offered over valid HTTPS.",
       "Domain": "fegli.gov",
       "Enforces HTTPS": 1,
-      "SSL Labs Grade": 3,
+      "SSL Labs Grade": 4,
       "Strict Transport Security (HSTS)": 0,
       "Uses HTTPS": 2
     },
@@ -4046,7 +3956,7 @@
       "Details": "This domain is offered over valid HTTPS.",
       "Domain": "fema.gov",
       "Enforces HTTPS": 1,
-      "SSL Labs Grade": 3,
+      "SSL Labs Grade": 2,
       "Strict Transport Security (HSTS)": 0,
       "Uses HTTPS": 2
     },
@@ -4056,7 +3966,7 @@
       "Details": "This domain is offered over valid HTTPS, but uses a certificate chain that may cause issues for some visitors.",
       "Domain": "femalefarmerclaims.gov",
       "Enforces HTTPS": 3,
-      "SSL Labs Grade": 1,
+      "SSL Labs Grade": 2,
       "Strict Transport Security (HSTS)": 0,
       "Uses HTTPS": 1
     },
@@ -4096,7 +4006,7 @@
       "Details": "This domain is offered over valid HTTPS.",
       "Domain": "fgdc.gov",
       "Enforces HTTPS": 1,
-      "SSL Labs Grade": 3,
+      "SSL Labs Grade": 4,
       "Strict Transport Security (HSTS)": 0,
       "Uses HTTPS": 2
     },
@@ -4141,16 +4051,6 @@
       "Uses HTTPS": -1
     },
     {
-      "Agency": "U.S. Agency for International Development",
-      "Canonical": "http://fightingmalaria.gov",
-      "Details": "This domain does not support HTTPS.",
-      "Domain": "fightingmalaria.gov",
-      "Enforces HTTPS": -1,
-      "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": -1
-    },
-    {
       "Agency": "Department of the Treasury",
       "Canonical": "http://financialresearch.gov",
       "Details": "This domain does not support HTTPS.",
@@ -4176,13 +4076,13 @@
       "Details": "This domain is offered over valid HTTPS, but uses a certificate chain that may cause issues for some visitors.",
       "Domain": "fincen.gov",
       "Enforces HTTPS": 1,
-      "SSL Labs Grade": 3,
+      "SSL Labs Grade": 2,
       "Strict Transport Security (HSTS)": 0,
       "Uses HTTPS": 1
     },
     {
       "Agency": "Department of Health And Human Services",
-      "Canonical": "http://findyouthinfo.gov",
+      "Canonical": "http://www.findyouthinfo.gov",
       "Details": "This domain is offered over valid HTTPS, but uses a certificate chain that may cause issues for some visitors.",
       "Domain": "findyouthinfo.gov",
       "Enforces HTTPS": 1,
@@ -4196,7 +4096,7 @@
       "Details": "This domain is offered over valid HTTPS.",
       "Domain": "firecode.gov",
       "Enforces HTTPS": 1,
-      "SSL Labs Grade": 3,
+      "SSL Labs Grade": 2,
       "Strict Transport Security (HSTS)": 0,
       "Uses HTTPS": 2
     },
@@ -4223,12 +4123,12 @@
     {
       "Agency": "Department of the Interior",
       "Canonical": "http://www.firescience.gov",
-      "Details": "This domain is offered over valid HTTPS.",
+      "Details": "This domain does not support HTTPS.",
       "Domain": "firescience.gov",
-      "Enforces HTTPS": 1,
-      "SSL Labs Grade": 3,
-      "Strict Transport Security (HSTS)": 0,
-      "Uses HTTPS": 2
+      "Enforces HTTPS": -1,
+      "SSL Labs Grade": -1,
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": -1
     },
     {
       "Agency": "Department of Justice",
@@ -4326,7 +4226,7 @@
       "Details": "This domain is offered over valid HTTPS.",
       "Domain": "fleta.gov",
       "Enforces HTTPS": 3,
-      "SSL Labs Grade": 3,
+      "SSL Labs Grade": 2,
       "Strict Transport Security (HSTS)": 0,
       "Uses HTTPS": 2
     },
@@ -4336,7 +4236,7 @@
       "Details": "This domain is offered over valid HTTPS.",
       "Domain": "fletc.gov",
       "Enforces HTTPS": 3,
-      "SSL Labs Grade": 3,
+      "SSL Labs Grade": 2,
       "Strict Transport Security (HSTS)": 0,
       "Uses HTTPS": 2
     },
@@ -4346,7 +4246,7 @@
       "Details": "This domain is offered over valid HTTPS.",
       "Domain": "flightschoolcandidates.gov",
       "Enforces HTTPS": 3,
-      "SSL Labs Grade": 3,
+      "SSL Labs Grade": 2,
       "Strict Transport Security (HSTS)": 0,
       "Uses HTTPS": 2
     },
@@ -4393,12 +4293,12 @@
     {
       "Agency": "Federal Mediation and Conciliation Service",
       "Canonical": "http://www.fmcs.gov",
-      "Details": "This domain redirects visitors from HTTPS to HTTP.",
+      "Details": "This domain does not support HTTPS.",
       "Domain": "fmcs.gov",
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Agency": "General Services Administration",
@@ -4426,7 +4326,7 @@
       "Details": "This domain is offered over valid HTTPS.",
       "Domain": "fmshrc.gov",
       "Enforces HTTPS": 1,
-      "SSL Labs Grade": 3,
+      "SSL Labs Grade": 2,
       "Strict Transport Security (HSTS)": 0,
       "Uses HTTPS": 2
     },
@@ -4436,7 +4336,7 @@
       "Details": "This domain is offered over valid HTTPS.",
       "Domain": "fnal.gov",
       "Enforces HTTPS": 1,
-      "SSL Labs Grade": 3,
+      "SSL Labs Grade": 2,
       "Strict Transport Security (HSTS)": 0,
       "Uses HTTPS": 2
     },
@@ -4592,7 +4492,7 @@
     },
     {
       "Agency": "Department of Agriculture",
-      "Canonical": "http://www.fs.fed.us",
+      "Canonical": "http://fs.fed.us",
       "Details": "This domain does not support HTTPS.",
       "Domain": "fs.fed.us",
       "Enforces HTTPS": -1,
@@ -4676,7 +4576,7 @@
       "Details": "This domain is offered over valid HTTPS.",
       "Domain": "ftc.gov",
       "Enforces HTTPS": 3,
-      "SSL Labs Grade": 3,
+      "SSL Labs Grade": 2,
       "Strict Transport Security (HSTS)": 0,
       "Uses HTTPS": 2
     },
@@ -4756,7 +4656,7 @@
       "Details": "This domain is offered over valid HTTPS, but uses a certificate chain that may cause issues for some visitors.",
       "Domain": "gao.gov",
       "Enforces HTTPS": 1,
-      "SSL Labs Grade": 3,
+      "SSL Labs Grade": 2,
       "Strict Transport Security (HSTS)": 0,
       "Uses HTTPS": 1
     },
@@ -4836,7 +4736,7 @@
       "Details": "This domain is offered over valid HTTPS.",
       "Domain": "geoplatform.gov",
       "Enforces HTTPS": 1,
-      "SSL Labs Grade": 3,
+      "SSL Labs Grade": 4,
       "Strict Transport Security (HSTS)": 0,
       "Uses HTTPS": 2
     },
@@ -4865,16 +4765,6 @@
       "Canonical": "http://getsmartaboutdrugs.gov",
       "Details": "This domain does not support HTTPS.",
       "Domain": "getsmartaboutdrugs.gov",
-      "Enforces HTTPS": -1,
-      "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": -1
-    },
-    {
-      "Agency": "Department of Commerce",
-      "Canonical": "http://www.getyouhome.gov",
-      "Details": "This domain does not support HTTPS.",
-      "Domain": "getyouhome.gov",
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
@@ -5002,7 +4892,7 @@
     },
     {
       "Agency": "The Legislative Branch (Congress)",
-      "Canonical": "http://www.gop.gov",
+      "Canonical": "http://gop.gov",
       "Details": "This domain does not support HTTPS.",
       "Domain": "gop.gov",
       "Enforces HTTPS": -1,
@@ -5075,16 +4965,6 @@
       "Canonical": "http://gpo.gov",
       "Details": "This domain does not support HTTPS.",
       "Domain": "gpo.gov",
-      "Enforces HTTPS": -1,
-      "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": -1
-    },
-    {
-      "Agency": "Government Printing Office",
-      "Canonical": "http://www.gpoaccess.gov",
-      "Details": "This domain does not support HTTPS.",
-      "Domain": "gpoaccess.gov",
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
@@ -5196,7 +5076,7 @@
       "Details": "This domain is offered over valid HTTPS.",
       "Domain": "gsaxcess.gov",
       "Enforces HTTPS": 1,
-      "SSL Labs Grade": 4,
+      "SSL Labs Grade": 3,
       "Strict Transport Security (HSTS)": 0,
       "Uses HTTPS": 2
     },
@@ -5226,7 +5106,7 @@
       "Details": "This domain is offered over valid HTTPS, but uses a certificate chain that may cause issues for some visitors.",
       "Domain": "gwa.gov",
       "Enforces HTTPS": 3,
-      "SSL Labs Grade": 0,
+      "SSL Labs Grade": 2,
       "Strict Transport Security (HSTS)": 0,
       "Uses HTTPS": 1
     },
@@ -5292,23 +5172,23 @@
     },
     {
       "Agency": "Department of Health And Human Services",
-      "Canonical": "http://www.healthdata.gov",
-      "Details": "This domain is offered over valid HTTPS.",
+      "Canonical": "http://healthdata.gov",
+      "Details": "This domain redirects visitors from HTTPS to HTTP.",
       "Domain": "healthdata.gov",
-      "Enforces HTTPS": 1,
-      "SSL Labs Grade": 5,
-      "Strict Transport Security (HSTS)": 0,
-      "Uses HTTPS": 2
+      "Enforces HTTPS": -1,
+      "SSL Labs Grade": -1,
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": 0
     },
     {
       "Agency": "Department of Health And Human Services",
       "Canonical": "http://healthfinder.gov",
-      "Details": "This domain is offered over valid HTTPS.",
+      "Details": "This domain does not support HTTPS.",
       "Domain": "healthfinder.gov",
-      "Enforces HTTPS": 1,
-      "SSL Labs Grade": 0,
-      "Strict Transport Security (HSTS)": 0,
-      "Uses HTTPS": 2
+      "Enforces HTTPS": -1,
+      "SSL Labs Grade": -1,
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": -1
     },
     {
       "Agency": "Department of Health And Human Services",
@@ -5323,12 +5203,12 @@
     {
       "Agency": "Department of Health And Human Services",
       "Canonical": "http://healthit.gov",
-      "Details": "This domain is offered over valid HTTPS, but uses a certificate chain that may cause issues for some visitors.",
+      "Details": "This domain does not support HTTPS.",
       "Domain": "healthit.gov",
-      "Enforces HTTPS": 1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": 0,
-      "Uses HTTPS": 1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": -1
     },
     {
       "Agency": "Department of Health And Human Services",
@@ -5433,22 +5313,22 @@
     {
       "Agency": "Department of Health And Human Services",
       "Canonical": "http://www.hhs.gov",
-      "Details": "This domain does not support HTTPS.",
+      "Details": "This domain redirects visitors from HTTPS to HTTP.",
       "Domain": "hhs.gov",
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": -1
+      "Uses HTTPS": 0
     },
     {
       "Agency": "Department of Health And Human Services",
       "Canonical": "http://www.hhsoig.gov",
-      "Details": "This domain is offered over valid HTTPS, but uses a certificate chain that may cause issues for some visitors.",
+      "Details": "This domain does not support HTTPS.",
       "Domain": "hhsoig.gov",
-      "Enforces HTTPS": 1,
+      "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": 0,
-      "Uses HTTPS": 1
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": -1
     },
     {
       "Agency": "Department of Energy",
@@ -5492,13 +5372,13 @@
     },
     {
       "Agency": "Department of Health And Human Services",
-      "Canonical": "http://www.hiv.gov",
-      "Details": "This domain is offered over valid HTTPS, but uses a certificate chain that may cause issues for some visitors.",
+      "Canonical": "http://hiv.gov",
+      "Details": "This domain is offered over valid HTTPS.",
       "Domain": "hiv.gov",
       "Enforces HTTPS": 1,
-      "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": 0,
-      "Uses HTTPS": 1
+      "SSL Labs Grade": 6,
+      "Strict Transport Security (HSTS)": 3,
+      "Uses HTTPS": 2
     },
     {
       "Agency": "Department of Energy",
@@ -5636,7 +5516,7 @@
       "Details": "This domain is offered over valid HTTPS.",
       "Domain": "hsr.gov",
       "Enforces HTTPS": 3,
-      "SSL Labs Grade": 5,
+      "SSL Labs Grade": 3,
       "Strict Transport Security (HSTS)": 3,
       "Uses HTTPS": 2
     },
@@ -5652,10 +5532,10 @@
     },
     {
       "Agency": "Department of Housing And Urban Development",
-      "Canonical": "http://www.hudoig.gov",
+      "Canonical": "https://www.hudoig.gov",
       "Details": "This domain is offered over valid HTTPS.",
       "Domain": "hudoig.gov",
-      "Enforces HTTPS": 1,
+      "Enforces HTTPS": 2,
       "SSL Labs Grade": 3,
       "Strict Transport Security (HSTS)": 0,
       "Uses HTTPS": 2
@@ -5726,7 +5606,7 @@
       "Details": "This domain is offered over valid HTTPS.",
       "Domain": "iarpa-ideas.gov",
       "Enforces HTTPS": 1,
-      "SSL Labs Grade": 3,
+      "SSL Labs Grade": 2,
       "Strict Transport Security (HSTS)": 0,
       "Uses HTTPS": 2
     },
@@ -5743,12 +5623,12 @@
     {
       "Agency": "Department of the Interior",
       "Canonical": "http://www.iat.gov",
-      "Details": "This domain is offered over valid HTTPS.",
+      "Details": "This domain does not support HTTPS.",
       "Domain": "iat.gov",
-      "Enforces HTTPS": 1,
-      "SSL Labs Grade": 2,
-      "Strict Transport Security (HSTS)": 0,
-      "Uses HTTPS": 2
+      "Enforces HTTPS": -1,
+      "SSL Labs Grade": -1,
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": -1
     },
     {
       "Agency": "Department of State",
@@ -5756,7 +5636,7 @@
       "Details": "This domain is offered over valid HTTPS.",
       "Domain": "iawg.gov",
       "Enforces HTTPS": 3,
-      "SSL Labs Grade": 3,
+      "SSL Labs Grade": 2,
       "Strict Transport Security (HSTS)": 0,
       "Uses HTTPS": 2
     },
@@ -5786,7 +5666,7 @@
       "Details": "This domain is offered over valid HTTPS.",
       "Domain": "ic3.gov",
       "Enforces HTTPS": 1,
-      "SSL Labs Grade": 3,
+      "SSL Labs Grade": 2,
       "Strict Transport Security (HSTS)": 0,
       "Uses HTTPS": 2
     },
@@ -5816,7 +5696,7 @@
       "Details": "This domain is offered over valid HTTPS.",
       "Domain": "ice.gov",
       "Enforces HTTPS": 1,
-      "SSL Labs Grade": 3,
+      "SSL Labs Grade": 2,
       "Strict Transport Security (HSTS)": 0,
       "Uses HTTPS": 2
     },
@@ -5842,13 +5722,13 @@
     },
     {
       "Agency": "Federal Trade Commission",
-      "Canonical": "http://www.identitytheft.gov",
-      "Details": "This domain does not support HTTPS.",
+      "Canonical": "https://www.identitytheft.gov",
+      "Details": "This domain is offered over valid HTTPS.",
       "Domain": "identitytheft.gov",
-      "Enforces HTTPS": -1,
-      "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": -1
+      "Enforces HTTPS": 3,
+      "SSL Labs Grade": 2,
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 2
     },
     {
       "Agency": "General Services Administration",
@@ -5863,12 +5743,12 @@
     {
       "Agency": "Federal Trade Commission",
       "Canonical": "http://www.idtheft.gov",
-      "Details": "This domain does not support HTTPS.",
+      "Details": "This domain is offered over valid HTTPS.",
       "Domain": "idtheft.gov",
-      "Enforces HTTPS": -1,
-      "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": -1
+      "Enforces HTTPS": 1,
+      "SSL Labs Grade": 2,
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 2
     },
     {
       "Agency": "Department of Health And Human Services",
@@ -5896,7 +5776,7 @@
       "Details": "This domain is offered over valid HTTPS.",
       "Domain": "ihs.gov",
       "Enforces HTTPS": 1,
-      "SSL Labs Grade": -1,
+      "SSL Labs Grade": 3,
       "Strict Transport Security (HSTS)": 0,
       "Uses HTTPS": 2
     },
@@ -5956,7 +5836,7 @@
       "Details": "This domain is offered over valid HTTPS.",
       "Domain": "inl.gov",
       "Enforces HTTPS": 3,
-      "SSL Labs Grade": 5,
+      "SSL Labs Grade": 3,
       "Strict Transport Security (HSTS)": 0,
       "Uses HTTPS": 2
     },
@@ -6043,12 +5923,12 @@
     {
       "Agency": "Securities and Exchange Commission",
       "Canonical": "http://investor.gov",
-      "Details": "This domain redirects visitors from HTTPS to HTTP.",
+      "Details": "This domain is offered over valid HTTPS.",
       "Domain": "investor.gov",
-      "Enforces HTTPS": -1,
-      "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Enforces HTTPS": 1,
+      "SSL Labs Grade": 5,
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 2
     },
     {
       "Agency": "Department of Defense",
@@ -6066,7 +5946,7 @@
       "Details": "This domain is offered over valid HTTPS, but uses a certificate chain that may cause issues for some visitors.",
       "Domain": "ipac.gov",
       "Enforces HTTPS": 3,
-      "SSL Labs Grade": 0,
+      "SSL Labs Grade": 2,
       "Strict Transport Security (HSTS)": 0,
       "Uses HTTPS": 1
     },
@@ -6096,7 +5976,7 @@
       "Details": "This domain is offered over valid HTTPS.",
       "Domain": "ipp.gov",
       "Enforces HTTPS": 1,
-      "SSL Labs Grade": 3,
+      "SSL Labs Grade": 2,
       "Strict Transport Security (HSTS)": 0,
       "Uses HTTPS": 2
     },
@@ -6256,7 +6136,7 @@
       "Details": "This domain is offered over valid HTTPS, but uses a certificate chain that may cause issues for some visitors.",
       "Domain": "its.gov",
       "Enforces HTTPS": 3,
-      "SSL Labs Grade": 0,
+      "SSL Labs Grade": 2,
       "Strict Transport Security (HSTS)": 0,
       "Uses HTTPS": 1
     },
@@ -6286,7 +6166,7 @@
       "Details": "This domain is offered over valid HTTPS.",
       "Domain": "jct.gov",
       "Enforces HTTPS": 2,
-      "SSL Labs Grade": 0,
+      "SSL Labs Grade": 5,
       "Strict Transport Security (HSTS)": 0,
       "Uses HTTPS": 2
     },
@@ -6296,7 +6176,7 @@
       "Details": "This domain is offered over valid HTTPS.",
       "Domain": "jem.gov",
       "Enforces HTTPS": 1,
-      "SSL Labs Grade": 3,
+      "SSL Labs Grade": 4,
       "Strict Transport Security (HSTS)": 0,
       "Uses HTTPS": 2
     },
@@ -6353,12 +6233,12 @@
     {
       "Agency": "Department of Labor",
       "Canonical": "http://www.jobcorps.gov",
-      "Details": "This domain is offered over valid HTTPS.",
+      "Details": "This domain does not support HTTPS.",
       "Domain": "jobcorps.gov",
-      "Enforces HTTPS": 1,
-      "SSL Labs Grade": 3,
-      "Strict Transport Security (HSTS)": 0,
-      "Uses HTTPS": 2
+      "Enforces HTTPS": -1,
+      "SSL Labs Grade": -1,
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": -1
     },
     {
       "Agency": "Executive Office of the President",
@@ -6411,16 +6291,6 @@
       "Uses HTTPS": -1
     },
     {
-      "Agency": "Comm for People Who Are Blind/Severly Disabled",
-      "Canonical": "http://jwod.gov",
-      "Details": "This domain does not support HTTPS.",
-      "Domain": "jwod.gov",
-      "Enforces HTTPS": -1,
-      "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": -1
-    },
-    {
       "Agency": "General Services Administration",
       "Canonical": "http://www.kids.gov",
       "Details": "This domain does not support HTTPS.",
@@ -6456,7 +6326,7 @@
       "Details": "This domain is offered over valid HTTPS.",
       "Domain": "lacoast.gov",
       "Enforces HTTPS": 1,
-      "SSL Labs Grade": 3,
+      "SSL Labs Grade": 4,
       "Strict Transport Security (HSTS)": 0,
       "Uses HTTPS": 2
     },
@@ -6486,7 +6356,7 @@
       "Details": "This domain is offered over valid HTTPS.",
       "Domain": "lanl.gov",
       "Enforces HTTPS": 1,
-      "SSL Labs Grade": 4,
+      "SSL Labs Grade": 3,
       "Strict Transport Security (HSTS)": 0,
       "Uses HTTPS": 2
     },
@@ -6516,7 +6386,7 @@
       "Details": "This domain is offered over valid HTTPS.",
       "Domain": "lbl.gov",
       "Enforces HTTPS": 1,
-      "SSL Labs Grade": 3,
+      "SSL Labs Grade": 2,
       "Strict Transport Security (HSTS)": 0,
       "Uses HTTPS": 2
     },
@@ -6566,7 +6436,7 @@
       "Details": "This domain is offered over valid HTTPS.",
       "Domain": "learnperformance.gov",
       "Enforces HTTPS": 2,
-      "SSL Labs Grade": 3,
+      "SSL Labs Grade": 2,
       "Strict Transport Security (HSTS)": 0,
       "Uses HTTPS": 2
     },
@@ -6643,12 +6513,12 @@
     {
       "Agency": "Library of Congress",
       "Canonical": "http://www.lis.gov",
-      "Details": "This domain does not support HTTPS.",
+      "Details": "This domain redirects visitors from HTTPS to HTTP.",
       "Domain": "lis.gov",
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": -1
+      "Uses HTTPS": 0
     },
     {
       "Agency": "Department of Homeland Security",
@@ -6676,7 +6546,7 @@
       "Details": "This domain is offered over valid HTTPS.",
       "Domain": "llis.gov",
       "Enforces HTTPS": 1,
-      "SSL Labs Grade": 4,
+      "SSL Labs Grade": 2,
       "Strict Transport Security (HSTS)": 0,
       "Uses HTTPS": 2
     },
@@ -6696,7 +6566,7 @@
       "Details": "This domain is offered over valid HTTPS.",
       "Domain": "lmrcouncil.gov",
       "Enforces HTTPS": 1,
-      "SSL Labs Grade": 3,
+      "SSL Labs Grade": 4,
       "Strict Transport Security (HSTS)": 0,
       "Uses HTTPS": 2
     },
@@ -6716,7 +6586,7 @@
       "Details": "This domain is offered over valid HTTPS.",
       "Domain": "loc.gov",
       "Enforces HTTPS": 1,
-      "SSL Labs Grade": 3,
+      "SSL Labs Grade": 2,
       "Strict Transport Security (HSTS)": 0,
       "Uses HTTPS": 2
     },
@@ -6891,16 +6761,6 @@
       "Uses HTTPS": -1
     },
     {
-      "Agency": "Department of Commerce",
-      "Canonical": "http://www.mapstats.gov",
-      "Details": "This domain does not support HTTPS.",
-      "Domain": "mapstats.gov",
-      "Enforces HTTPS": -1,
-      "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": -1
-    },
-    {
       "Agency": "Department of the Interior",
       "Canonical": "http://marine.gov",
       "Details": "This domain does not support HTTPS.",
@@ -6986,7 +6846,7 @@
       "Details": "This domain is offered over valid HTTPS.",
       "Domain": "medalofvalor.gov",
       "Enforces HTTPS": 3,
-      "SSL Labs Grade": 2,
+      "SSL Labs Grade": 0,
       "Strict Transport Security (HSTS)": 0,
       "Uses HTTPS": 2
     },
@@ -7153,12 +7013,12 @@
     {
       "Agency": "Department of the Treasury",
       "Canonical": "http://www.moneyfactorystore.gov",
-      "Details": "This domain redirects visitors from HTTPS to HTTP.",
+      "Details": "This domain does not support HTTPS.",
       "Domain": "moneyfactorystore.gov",
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Agency": "Department of the Interior",
@@ -7166,7 +7026,7 @@
       "Details": "This domain is offered over valid HTTPS.",
       "Domain": "mrgo.gov",
       "Enforces HTTPS": 1,
-      "SSL Labs Grade": 3,
+      "SSL Labs Grade": 4,
       "Strict Transport Security (HSTS)": 0,
       "Uses HTTPS": 2
     },
@@ -7301,16 +7161,6 @@
       "Uses HTTPS": 1
     },
     {
-      "Agency": "General Services Administration",
-      "Canonical": "http://myusa.gov",
-      "Details": "This domain does not support HTTPS.",
-      "Domain": "myusa.gov",
-      "Enforces HTTPS": -1,
-      "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": -1
-    },
-    {
       "Agency": "Department of Agriculture",
       "Canonical": "http://nafri.gov",
       "Details": "This domain is offered over valid HTTPS, but uses a certificate chain that may cause issues for some visitors.",
@@ -7366,7 +7216,7 @@
       "Details": "This domain is offered over valid HTTPS.",
       "Domain": "nasa.gov",
       "Enforces HTTPS": 1,
-      "SSL Labs Grade": 5,
+      "SSL Labs Grade": 3,
       "Strict Transport Security (HSTS)": 0,
       "Uses HTTPS": 2
     },
@@ -7413,12 +7263,12 @@
     {
       "Agency": "Department of Health And Human Services",
       "Canonical": "http://www.nationalchildrensstudy.gov",
-      "Details": "This domain is offered over valid HTTPS.",
+      "Details": "This domain does not support HTTPS.",
       "Domain": "nationalchildrensstudy.gov",
-      "Enforces HTTPS": 1,
-      "SSL Labs Grade": 3,
-      "Strict Transport Security (HSTS)": 0,
-      "Uses HTTPS": 2
+      "Enforces HTTPS": -1,
+      "SSL Labs Grade": -1,
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": -1
     },
     {
       "Agency": "Department of Justice",
@@ -7426,7 +7276,7 @@
       "Details": "This domain is offered over valid HTTPS, but uses a certificate chain that may cause issues for some visitors.",
       "Domain": "nationalgangcenter.gov",
       "Enforces HTTPS": 1,
-      "SSL Labs Grade": 3,
+      "SSL Labs Grade": 2,
       "Strict Transport Security (HSTS)": 0,
       "Uses HTTPS": 1
     },
@@ -7466,7 +7316,7 @@
       "Details": "This domain is offered over valid HTTPS.",
       "Domain": "nationalresourcedirectory.gov",
       "Enforces HTTPS": 1,
-      "SSL Labs Grade": 3,
+      "SSL Labs Grade": 2,
       "Strict Transport Security (HSTS)": 0,
       "Uses HTTPS": 2
     },
@@ -7526,7 +7376,7 @@
       "Details": "This domain is offered over valid HTTPS.",
       "Domain": "nbc.gov",
       "Enforces HTTPS": 1,
-      "SSL Labs Grade": 3,
+      "SSL Labs Grade": 2,
       "Strict Transport Security (HSTS)": 0,
       "Uses HTTPS": 2
     },
@@ -7573,12 +7423,12 @@
     {
       "Agency": "Department of Health And Human Services",
       "Canonical": "http://www.ncifcrf.gov",
-      "Details": "This domain is offered over valid HTTPS.",
+      "Details": "This domain is offered over valid HTTPS, but uses a certificate chain that may cause issues for some visitors.",
       "Domain": "ncifcrf.gov",
       "Enforces HTTPS": 1,
-      "SSL Labs Grade": 2,
+      "SSL Labs Grade": 1,
       "Strict Transport Security (HSTS)": 0,
-      "Uses HTTPS": 2
+      "Uses HTTPS": 1
     },
     {
       "Agency": "Department of Justice",
@@ -7586,13 +7436,13 @@
       "Details": "This domain is offered over valid HTTPS.",
       "Domain": "ncirc.gov",
       "Enforces HTTPS": 3,
-      "SSL Labs Grade": 3,
+      "SSL Labs Grade": 2,
       "Strict Transport Security (HSTS)": 0,
       "Uses HTTPS": 2
     },
     {
       "Agency": "Director of National Intelligence",
-      "Canonical": "http://ncix.gov",
+      "Canonical": "http://www.ncix.gov",
       "Details": "This domain does not support HTTPS.",
       "Domain": "ncix.gov",
       "Enforces HTTPS": -1,
@@ -7602,11 +7452,11 @@
     },
     {
       "Agency": "Department of Justice",
-      "Canonical": "https://ncjrs.gov",
+      "Canonical": "https://www.ncjrs.gov",
       "Details": "This domain is offered over valid HTTPS.",
       "Domain": "ncjrs.gov",
       "Enforces HTTPS": 3,
-      "SSL Labs Grade": 2,
+      "SSL Labs Grade": 3,
       "Strict Transport Security (HSTS)": 0,
       "Uses HTTPS": 2
     },
@@ -7626,7 +7476,7 @@
       "Details": "This domain is offered over valid HTTPS.",
       "Domain": "ncpw.gov",
       "Enforces HTTPS": 1,
-      "SSL Labs Grade": 3,
+      "SSL Labs Grade": 2,
       "Strict Transport Security (HSTS)": 0,
       "Uses HTTPS": 2
     },
@@ -7636,7 +7486,7 @@
       "Details": "This domain is offered over valid HTTPS.",
       "Domain": "ncrc.gov",
       "Enforces HTTPS": 1,
-      "SSL Labs Grade": 3,
+      "SSL Labs Grade": 2,
       "Strict Transport Security (HSTS)": 0,
       "Uses HTTPS": 2
     },
@@ -7702,7 +7552,7 @@
     },
     {
       "Agency": "U.S. Agency for International Development",
-      "Canonical": "http://neglecteddiseases.gov",
+      "Canonical": "http://www.neglecteddiseases.gov",
       "Details": "This domain does not support HTTPS.",
       "Domain": "neglecteddiseases.gov",
       "Enforces HTTPS": -1,
@@ -7746,7 +7596,7 @@
       "Details": "This domain is offered over valid HTTPS.",
       "Domain": "nemi.gov",
       "Enforces HTTPS": 1,
-      "SSL Labs Grade": 3,
+      "SSL Labs Grade": 4,
       "Strict Transport Security (HSTS)": 0,
       "Uses HTTPS": 2
     },
@@ -7766,7 +7616,7 @@
       "Details": "This domain is offered over valid HTTPS.",
       "Domain": "nersc.gov",
       "Enforces HTTPS": 1,
-      "SSL Labs Grade": 3,
+      "SSL Labs Grade": 2,
       "Strict Transport Security (HSTS)": 0,
       "Uses HTTPS": 2
     },
@@ -7796,7 +7646,7 @@
       "Details": "This domain is offered over valid HTTPS.",
       "Domain": "nfpors.gov",
       "Enforces HTTPS": 2,
-      "SSL Labs Grade": 3,
+      "SSL Labs Grade": 2,
       "Strict Transport Security (HSTS)": 0,
       "Uses HTTPS": 2
     },
@@ -7886,7 +7736,7 @@
       "Details": "This domain is offered over valid HTTPS, but uses a certificate chain that may cause issues for some visitors.",
       "Domain": "nifc.gov",
       "Enforces HTTPS": 1,
-      "SSL Labs Grade": 3,
+      "SSL Labs Grade": 2,
       "Strict Transport Security (HSTS)": 0,
       "Uses HTTPS": 1
     },
@@ -7932,7 +7782,7 @@
     },
     {
       "Agency": "Department of Justice",
-      "Canonical": "http://www.nij.gov",
+      "Canonical": "http://nij.gov",
       "Details": "This domain does not support HTTPS.",
       "Domain": "nij.gov",
       "Enforces HTTPS": -1,
@@ -7956,7 +7806,7 @@
       "Details": "This domain is offered over valid HTTPS.",
       "Domain": "nist.gov",
       "Enforces HTTPS": 1,
-      "SSL Labs Grade": 3,
+      "SSL Labs Grade": 2,
       "Strict Transport Security (HSTS)": 0,
       "Uses HTTPS": 2
     },
@@ -8041,6 +7891,16 @@
       "Uses HTTPS": -1
     },
     {
+      "Agency": "Department of Homeland Security",
+      "Canonical": "http://nmsc.gov",
+      "Details": "This domain is offered over valid HTTPS.",
+      "Domain": "nmsc.gov",
+      "Enforces HTTPS": 1,
+      "SSL Labs Grade": 5,
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 2
+    },
+    {
       "Agency": "Department of Justice",
       "Canonical": "http://www.nmvtis.gov",
       "Details": "This domain does not support HTTPS.",
@@ -8053,12 +7913,12 @@
     {
       "Agency": "Department of Health And Human Services",
       "Canonical": "http://nnlm.gov",
-      "Details": "This domain is offered over valid HTTPS, but uses a certificate chain that may cause issues for some visitors.",
+      "Details": "This domain is offered over valid HTTPS.",
       "Domain": "nnlm.gov",
       "Enforces HTTPS": 1,
       "SSL Labs Grade": 2,
       "Strict Transport Security (HSTS)": 0,
-      "Uses HTTPS": 1
+      "Uses HTTPS": 2
     },
     {
       "Agency": "Department of Commerce",
@@ -8086,7 +7946,7 @@
       "Details": "This domain is offered over valid HTTPS.",
       "Domain": "nolaenvironmental.gov",
       "Enforces HTTPS": 1,
-      "SSL Labs Grade": 3,
+      "SSL Labs Grade": 4,
       "Strict Transport Security (HSTS)": 0,
       "Uses HTTPS": 2
     },
@@ -8107,7 +7967,7 @@
       "Domain": "notalone.gov",
       "Enforces HTTPS": 3,
       "SSL Labs Grade": 3,
-      "Strict Transport Security (HSTS)": 3,
+      "Strict Transport Security (HSTS)": 1,
       "Uses HTTPS": 2
     },
     {
@@ -8136,7 +7996,7 @@
       "Details": "This domain is offered over valid HTTPS.",
       "Domain": "nrd.gov",
       "Enforces HTTPS": 3,
-      "SSL Labs Grade": 3,
+      "SSL Labs Grade": 2,
       "Strict Transport Security (HSTS)": 0,
       "Uses HTTPS": 2
     },
@@ -8192,7 +8052,7 @@
     },
     {
       "Agency": "National Science Foundation",
-      "Canonical": "http://www.nsf.gov",
+      "Canonical": "http://nsf.gov",
       "Details": "This domain redirects visitors from HTTPS to HTTP.",
       "Domain": "nsf.gov",
       "Enforces HTTPS": -1,
@@ -8306,7 +8166,7 @@
       "Details": "This domain is offered over valid HTTPS.",
       "Domain": "nwbc.gov",
       "Enforces HTTPS": 3,
-      "SSL Labs Grade": 3,
+      "SSL Labs Grade": 2,
       "Strict Transport Security (HSTS)": 0,
       "Uses HTTPS": 2
     },
@@ -8422,7 +8282,7 @@
     },
     {
       "Agency": "Department of Justice",
-      "Canonical": "http://ojjdp.gov",
+      "Canonical": "http://www.ojjdp.gov",
       "Details": "This domain does not support HTTPS.",
       "Domain": "ojjdp.gov",
       "Enforces HTTPS": -1,
@@ -8476,7 +8336,7 @@
       "Details": "This domain is offered over valid HTTPS.",
       "Domain": "onguardonline.gov",
       "Enforces HTTPS": 1,
-      "SSL Labs Grade": 3,
+      "SSL Labs Grade": 2,
       "Strict Transport Security (HSTS)": 0,
       "Uses HTTPS": 2
     },
@@ -8536,7 +8396,7 @@
       "Details": "This domain is offered over valid HTTPS.",
       "Domain": "opensource.gov",
       "Enforces HTTPS": 3,
-      "SSL Labs Grade": 0,
+      "SSL Labs Grade": 4,
       "Strict Transport Security (HSTS)": 0,
       "Uses HTTPS": 2
     },
@@ -8556,7 +8416,7 @@
       "Details": "This domain is offered over valid HTTPS.",
       "Domain": "opic.gov",
       "Enforces HTTPS": 3,
-      "SSL Labs Grade": 4,
+      "SSL Labs Grade": 6,
       "Strict Transport Security (HSTS)": 1,
       "Uses HTTPS": 2
     },
@@ -8566,7 +8426,7 @@
       "Details": "This domain is offered over valid HTTPS.",
       "Domain": "opm.gov",
       "Enforces HTTPS": 1,
-      "SSL Labs Grade": 3,
+      "SSL Labs Grade": 4,
       "Strict Transport Security (HSTS)": 0,
       "Uses HTTPS": 2
     },
@@ -8616,7 +8476,7 @@
       "Details": "This domain is offered over valid HTTPS.",
       "Domain": "osac.gov",
       "Enforces HTTPS": 3,
-      "SSL Labs Grade": 3,
+      "SSL Labs Grade": 2,
       "Strict Transport Security (HSTS)": 0,
       "Uses HTTPS": 2
     },
@@ -8783,12 +8643,12 @@
     {
       "Agency": "General Services Administration",
       "Canonical": "http://www.partner4solutions.gov",
-      "Details": "This domain does not support HTTPS.",
+      "Details": "This domain is offered over valid HTTPS.",
       "Domain": "partner4solutions.gov",
-      "Enforces HTTPS": -1,
-      "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": -1
+      "Enforces HTTPS": 1,
+      "SSL Labs Grade": 2,
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 2
     },
     {
       "Agency": "Department of the Treasury",
@@ -8806,7 +8666,7 @@
       "Details": "This domain is offered over valid HTTPS, but uses a certificate chain that may cause issues for some visitors.",
       "Domain": "pay.gov",
       "Enforces HTTPS": 3,
-      "SSL Labs Grade": 0,
+      "SSL Labs Grade": 2,
       "Strict Transport Security (HSTS)": 0,
       "Uses HTTPS": 1
     },
@@ -8826,7 +8686,7 @@
       "Details": "This domain is offered over valid HTTPS.",
       "Domain": "pbgc.gov",
       "Enforces HTTPS": 1,
-      "SSL Labs Grade": 3,
+      "SSL Labs Grade": 2,
       "Strict Transport Security (HSTS)": 0,
       "Uses HTTPS": 2
     },
@@ -8942,10 +8802,10 @@
     },
     {
       "Agency": "General Services Administration",
-      "Canonical": "https://pic.gov",
+      "Canonical": "http://pic.gov",
       "Details": "This domain is offered over valid HTTPS.",
       "Domain": "pic.gov",
-      "Enforces HTTPS": 3,
+      "Enforces HTTPS": 1,
       "SSL Labs Grade": 0,
       "Strict Transport Security (HSTS)": 0,
       "Uses HTTPS": 2
@@ -8976,13 +8836,13 @@
       "Details": "This domain is offered over valid HTTPS.",
       "Domain": "pmf.gov",
       "Enforces HTTPS": 1,
-      "SSL Labs Grade": 3,
+      "SSL Labs Grade": 4,
       "Strict Transport Security (HSTS)": 0,
       "Uses HTTPS": 2
     },
     {
       "Agency": "U.S. Agency for International Development",
-      "Canonical": "http://pmi.gov",
+      "Canonical": "http://www.pmi.gov",
       "Details": "This domain does not support HTTPS.",
       "Domain": "pmi.gov",
       "Enforces HTTPS": -1,
@@ -9056,7 +8916,7 @@
       "Details": "This domain is offered over valid HTTPS, but uses a certificate chain that may cause issues for some visitors.",
       "Domain": "ppirs.gov",
       "Enforces HTTPS": 3,
-      "SSL Labs Grade": 3,
+      "SSL Labs Grade": 2,
       "Strict Transport Security (HSTS)": 0,
       "Uses HTTPS": 1
     },
@@ -9131,24 +8991,14 @@
       "Uses HTTPS": -1
     },
     {
-      "Agency": "Executive Office of the President",
-      "Canonical": "http://www.presidiotrust.gov",
-      "Details": "This domain does not support HTTPS.",
-      "Domain": "presidiotrust.gov",
-      "Enforces HTTPS": -1,
-      "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": -1
-    },
-    {
       "Agency": "Court Services and Offender Supervision",
       "Canonical": "http://pretrialservices.gov",
-      "Details": "This domain does not support HTTPS.",
+      "Details": "This domain is offered over valid HTTPS, but uses a certificate chain that may cause issues for some visitors.",
       "Domain": "pretrialservices.gov",
-      "Enforces HTTPS": -1,
+      "Enforces HTTPS": 1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": -1
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 1
     },
     {
       "Agency": "Library of Congress",
@@ -9196,19 +9046,19 @@
       "Details": "This domain is offered over valid HTTPS.",
       "Domain": "protectyourmove.gov",
       "Enforces HTTPS": 3,
-      "SSL Labs Grade": 3,
+      "SSL Labs Grade": 2,
       "Strict Transport Security (HSTS)": 0,
       "Uses HTTPS": 2
     },
     {
       "Agency": "Court Services and Offender Supervision",
       "Canonical": "http://psa.gov",
-      "Details": "This domain does not support HTTPS.",
+      "Details": "This domain is offered over valid HTTPS, but uses a certificate chain that may cause issues for some visitors.",
       "Domain": "psa.gov",
-      "Enforces HTTPS": -1,
-      "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": -1
+      "Enforces HTTPS": 1,
+      "SSL Labs Grade": 0,
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 1
     },
     {
       "Agency": "Department of Health And Human Services",
@@ -9222,7 +9072,7 @@
     },
     {
       "Agency": "Department of Commerce",
-      "Canonical": "http://pscr.gov",
+      "Canonical": "http://www.pscr.gov",
       "Details": "This domain does not support HTTPS.",
       "Domain": "pscr.gov",
       "Enforces HTTPS": -1,
@@ -9232,11 +9082,11 @@
     },
     {
       "Agency": "Department of Justice",
-      "Canonical": "https://psob.gov",
+      "Canonical": "https://www.psob.gov",
       "Details": "This domain is offered over valid HTTPS.",
       "Domain": "psob.gov",
       "Enforces HTTPS": 3,
-      "SSL Labs Grade": 2,
+      "SSL Labs Grade": 0,
       "Strict Transport Security (HSTS)": 0,
       "Uses HTTPS": 2
     },
@@ -9322,7 +9172,7 @@
     },
     {
       "Agency": "Library of Congress",
-      "Canonical": "http://www.read.gov",
+      "Canonical": "http://read.gov",
       "Details": "This domain does not support HTTPS.",
       "Domain": "read.gov",
       "Enforces HTTPS": -1,
@@ -9366,7 +9216,7 @@
       "Details": "This domain is offered over valid HTTPS.",
       "Domain": "realestatesales.gov",
       "Enforces HTTPS": 1,
-      "SSL Labs Grade": 4,
+      "SSL Labs Grade": 3,
       "Strict Transport Security (HSTS)": 0,
       "Uses HTTPS": 2
     },
@@ -9442,7 +9292,7 @@
     },
     {
       "Agency": "Environmental Protection Agency",
-      "Canonical": "http://www.regulation.gov",
+      "Canonical": "http://regulation.gov",
       "Details": "This domain does not support HTTPS.",
       "Domain": "regulation.gov",
       "Enforces HTTPS": -1,
@@ -9516,7 +9366,7 @@
       "Details": "This domain is offered over valid HTTPS.",
       "Domain": "restorethegulf.gov",
       "Enforces HTTPS": 1,
-      "SSL Labs Grade": 3,
+      "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": 0,
       "Uses HTTPS": 2
     },
@@ -9536,7 +9386,7 @@
       "Details": "This domain is offered over valid HTTPS, but uses a certificate chain that may cause issues for some visitors.",
       "Domain": "rocis.gov",
       "Enforces HTTPS": 1,
-      "SSL Labs Grade": 3,
+      "SSL Labs Grade": 2,
       "Strict Transport Security (HSTS)": 0,
       "Uses HTTPS": 1
     },
@@ -9563,12 +9413,12 @@
     {
       "Agency": "Department of the Interior",
       "Canonical": "http://www.safecom.gov",
-      "Details": "This domain is offered over valid HTTPS.",
+      "Details": "This domain does not support HTTPS.",
       "Domain": "safecom.gov",
-      "Enforces HTTPS": 1,
-      "SSL Labs Grade": 2,
-      "Strict Transport Security (HSTS)": 0,
-      "Uses HTTPS": 2
+      "Enforces HTTPS": -1,
+      "SSL Labs Grade": -1,
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": -1
     },
     {
       "Agency": "Department of Homeland Security",
@@ -9622,13 +9472,13 @@
     },
     {
       "Agency": "Department of Homeland Security",
-      "Canonical": "https://safetyact.gov",
-      "Details": "This domain is offered over valid HTTPS, but uses a certificate chain that may cause issues for some visitors.",
+      "Canonical": "http://www.safetyact.gov",
+      "Details": "This domain does not support HTTPS.",
       "Domain": "safetyact.gov",
-      "Enforces HTTPS": 3,
-      "SSL Labs Grade": 1,
-      "Strict Transport Security (HSTS)": 0,
-      "Uses HTTPS": 1
+      "Enforces HTTPS": -1,
+      "SSL Labs Grade": -1,
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": -1
     },
     {
       "Agency": "U.S. Chemical Safety and Hazard Investigation Board",
@@ -9666,7 +9516,7 @@
       "Details": "This domain is offered over valid HTTPS, but uses a certificate chain that may cause issues for some visitors.",
       "Domain": "sam.gov",
       "Enforces HTTPS": 3,
-      "SSL Labs Grade": 3,
+      "SSL Labs Grade": 2,
       "Strict Transport Security (HSTS)": 0,
       "Uses HTTPS": 1
     },
@@ -9746,19 +9596,19 @@
       "Details": "This domain is offered over valid HTTPS.",
       "Domain": "sba.gov",
       "Enforces HTTPS": 3,
-      "SSL Labs Grade": 3,
+      "SSL Labs Grade": 2,
       "Strict Transport Security (HSTS)": 0,
       "Uses HTTPS": 2
     },
     {
       "Agency": "National Science Foundation",
-      "Canonical": "http://www.sbir.gov",
-      "Details": "This domain is offered over valid HTTPS, but uses a certificate chain that may cause issues for some visitors.",
+      "Canonical": "https://www.sbir.gov",
+      "Details": "This domain is offered over valid HTTPS.",
       "Domain": "sbir.gov",
-      "Enforces HTTPS": 1,
-      "SSL Labs Grade": 3,
+      "Enforces HTTPS": 3,
+      "SSL Labs Grade": 2,
       "Strict Transport Security (HSTS)": 0,
-      "Uses HTTPS": 1
+      "Uses HTTPS": 2
     },
     {
       "Agency": "Department of Energy",
@@ -9776,7 +9626,7 @@
       "Details": "This domain is offered over valid HTTPS.",
       "Domain": "science.gov",
       "Enforces HTTPS": 1,
-      "SSL Labs Grade": 3,
+      "SSL Labs Grade": 2,
       "Strict Transport Security (HSTS)": 0,
       "Uses HTTPS": 2
     },
@@ -9791,34 +9641,14 @@
       "Uses HTTPS": 1
     },
     {
-      "Agency": "Department of Energy",
-      "Canonical": "http://www.scienceaccelerator.gov",
-      "Details": "This domain does not support HTTPS.",
-      "Domain": "scienceaccelerator.gov",
-      "Enforces HTTPS": -1,
-      "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": -1
-    },
-    {
       "Agency": "Department of the Interior",
       "Canonical": "https://www.sciencebase.gov",
       "Details": "This domain is offered over valid HTTPS.",
       "Domain": "sciencebase.gov",
       "Enforces HTTPS": 3,
-      "SSL Labs Grade": 3,
+      "SSL Labs Grade": 4,
       "Strict Transport Security (HSTS)": 0,
       "Uses HTTPS": 2
-    },
-    {
-      "Agency": "Department of Energy",
-      "Canonical": "http://www.scienceeducation.gov",
-      "Details": "This domain does not support HTTPS.",
-      "Domain": "scienceeducation.gov",
-      "Enforces HTTPS": -1,
-      "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": -1
     },
     {
       "Agency": "National Aeronautics and Space Administration",
@@ -9883,12 +9713,12 @@
     {
       "Agency": "General Services Administration",
       "Canonical": "http://section508.gov",
-      "Details": "This domain redirects visitors from HTTPS to HTTP.",
+      "Details": "This domain does not support HTTPS.",
       "Domain": "section508.gov",
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Agency": "Consumer Product Safety Commission",
@@ -10036,7 +9866,7 @@
       "Details": "This domain is offered over valid HTTPS.",
       "Domain": "sftool.gov",
       "Enforces HTTPS": 3,
-      "SSL Labs Grade": 5,
+      "SSL Labs Grade": 3,
       "Strict Transport Security (HSTS)": 3,
       "Uses HTTPS": 2
     },
@@ -10085,16 +9915,6 @@
       "Canonical": "http://slgs.gov",
       "Details": "This domain does not support HTTPS.",
       "Domain": "slgs.gov",
-      "Enforces HTTPS": -1,
-      "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": -1
-    },
-    {
-      "Agency": "Small Business Administration",
-      "Canonical": "http://www.smallbusiness.gov",
-      "Details": "This domain does not support HTTPS.",
-      "Domain": "smallbusiness.gov",
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
@@ -10246,7 +10066,7 @@
       "Details": "This domain is offered over valid HTTPS, but uses a certificate chain that may cause issues for some visitors.",
       "Domain": "sss.gov",
       "Enforces HTTPS": 1,
-      "SSL Labs Grade": 3,
+      "SSL Labs Grade": 2,
       "Strict Transport Security (HSTS)": 0,
       "Uses HTTPS": 1
     },
@@ -10282,13 +10102,13 @@
     },
     {
       "Agency": "Stennis Center for Public Service",
-      "Canonical": "http://stennis.gov",
-      "Details": "This domain does not support HTTPS.",
+      "Canonical": "https://stennis.gov",
+      "Details": "This domain is offered over valid HTTPS.",
       "Domain": "stennis.gov",
-      "Enforces HTTPS": -1,
-      "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": -1
+      "Enforces HTTPS": 3,
+      "SSL Labs Grade": 2,
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 2
     },
     {
       "Agency": "Department of Health And Human Services",
@@ -10382,10 +10202,10 @@
     },
     {
       "Agency": "Department of Education",
-      "Canonical": "https://www.studentaid.gov",
+      "Canonical": "http://www.studentaid.gov",
       "Details": "This domain is offered over valid HTTPS.",
       "Domain": "studentaid.gov",
-      "Enforces HTTPS": 2,
+      "Enforces HTTPS": 1,
       "SSL Labs Grade": 3,
       "Strict Transport Security (HSTS)": 0,
       "Uses HTTPS": 2
@@ -10406,7 +10226,7 @@
       "Details": "This domain is offered over valid HTTPS.",
       "Domain": "supportthevoter.gov",
       "Enforces HTTPS": 1,
-      "SSL Labs Grade": 3,
+      "SSL Labs Grade": 2,
       "Strict Transport Security (HSTS)": 0,
       "Uses HTTPS": 2
     },
@@ -10716,7 +10536,7 @@
       "Details": "This domain is offered over valid HTTPS, but uses a certificate chain that may cause issues for some visitors.",
       "Domain": "treaslockbox.gov",
       "Enforces HTTPS": 3,
-      "SSL Labs Grade": 0,
+      "SSL Labs Grade": 2,
       "Strict Transport Security (HSTS)": 0,
       "Uses HTTPS": 1
     },
@@ -10806,7 +10626,7 @@
       "Details": "This domain is offered over valid HTTPS.",
       "Domain": "tsa.gov",
       "Enforces HTTPS": 1,
-      "SSL Labs Grade": 3,
+      "SSL Labs Grade": 2,
       "Strict Transport Security (HSTS)": 0,
       "Uses HTTPS": 2
     },
@@ -10881,6 +10701,16 @@
       "Uses HTTPS": -1
     },
     {
+      "Agency": "Tennessee Valley Authority",
+      "Canonical": "http://tvaoig.gov",
+      "Details": "This domain does not support HTTPS.",
+      "Domain": "tvaoig.gov",
+      "Enforces HTTPS": -1,
+      "SSL Labs Grade": -1,
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": -1
+    },
+    {
       "Agency": "Department of Justice",
       "Canonical": "http://ucrdatatool.gov",
       "Details": "This domain does not support HTTPS.",
@@ -10896,7 +10726,7 @@
       "Details": "This domain is offered over valid HTTPS.",
       "Domain": "udall.gov",
       "Enforces HTTPS": 1,
-      "SSL Labs Grade": 3,
+      "SSL Labs Grade": 2,
       "Strict Transport Security (HSTS)": 0,
       "Uses HTTPS": 2
     },
@@ -10956,7 +10786,7 @@
       "Details": "This domain is offered over valid HTTPS.",
       "Domain": "unlocktalent.gov",
       "Enforces HTTPS": 3,
-      "SSL Labs Grade": 3,
+      "SSL Labs Grade": 4,
       "Strict Transport Security (HSTS)": 0,
       "Uses HTTPS": 2
     },
@@ -10976,7 +10806,7 @@
       "Details": "This domain is offered over valid HTTPS.",
       "Domain": "us-cert.gov",
       "Enforces HTTPS": 2,
-      "SSL Labs Grade": 3,
+      "SSL Labs Grade": 2,
       "Strict Transport Security (HSTS)": 0,
       "Uses HTTPS": 2
     },
@@ -11011,6 +10841,16 @@
       "Uses HTTPS": -1
     },
     {
+      "Agency": "African Development Foundation",
+      "Canonical": "http://usadf.gov",
+      "Details": "This domain does not support HTTPS.",
+      "Domain": "usadf.gov",
+      "Enforces HTTPS": -1,
+      "SSL Labs Grade": -1,
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": -1
+    },
+    {
       "Agency": "General Services Administration",
       "Canonical": "http://www.usagov.gov",
       "Details": "This domain does not support HTTPS.",
@@ -11023,22 +10863,22 @@
     {
       "Agency": "U.S. Agency for International Development",
       "Canonical": "http://www.usaid.gov",
-      "Details": "This domain redirects visitors from HTTPS to HTTP.",
+      "Details": "This domain does not support HTTPS.",
       "Domain": "usaid.gov",
       "Enforces HTTPS": -1,
       "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": 0
+      "Uses HTTPS": -1
     },
     {
       "Agency": "U.S. Agency for International Development",
-      "Canonical": "http://www.usaidallnet.gov",
-      "Details": "This domain does not support HTTPS.",
+      "Canonical": "https://www.usaidallnet.gov",
+      "Details": "This domain is offered over valid HTTPS.",
       "Domain": "usaidallnet.gov",
-      "Enforces HTTPS": -1,
-      "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": -1
+      "Enforces HTTPS": 2,
+      "SSL Labs Grade": 0,
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 2
     },
     {
       "Agency": "Office of Personnel Management",
@@ -11073,12 +10913,12 @@
     {
       "Agency": "National Science Foundation",
       "Canonical": "http://usap.gov",
-      "Details": "This domain is offered over valid HTTPS.",
+      "Details": "This domain does not support HTTPS.",
       "Domain": "usap.gov",
-      "Enforces HTTPS": 1,
-      "SSL Labs Grade": 3,
-      "Strict Transport Security (HSTS)": 0,
-      "Uses HTTPS": 2
+      "Enforces HTTPS": -1,
+      "SSL Labs Grade": -1,
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": -1
     },
     {
       "Agency": "General Services Administration",
@@ -11102,10 +10942,10 @@
     },
     {
       "Agency": "Office of Personnel Management",
-      "Canonical": "http://www.usastaffing.gov",
+      "Canonical": "https://www.usastaffing.gov",
       "Details": "This domain is offered over valid HTTPS.",
       "Domain": "usastaffing.gov",
-      "Enforces HTTPS": 1,
+      "Enforces HTTPS": 3,
       "SSL Labs Grade": 3,
       "Strict Transport Security (HSTS)": 0,
       "Uses HTTPS": 2
@@ -11136,13 +10976,13 @@
       "Details": "This domain is offered over valid HTTPS.",
       "Domain": "usbr.gov",
       "Enforces HTTPS": 1,
-      "SSL Labs Grade": 4,
+      "SSL Labs Grade": 3,
       "Strict Transport Security (HSTS)": 0,
       "Uses HTTPS": 2
     },
     {
       "Agency": "The Legislative Branch (Congress)",
-      "Canonical": "http://uscapital.gov",
+      "Canonical": "http://www.uscapital.gov",
       "Details": "This domain does not support HTTPS.",
       "Domain": "uscapital.gov",
       "Enforces HTTPS": -1,
@@ -11152,7 +10992,7 @@
     },
     {
       "Agency": "The Legislative Branch (Congress)",
-      "Canonical": "http://uscapitol.gov",
+      "Canonical": "http://www.uscapitol.gov",
       "Details": "This domain does not support HTTPS.",
       "Domain": "uscapitol.gov",
       "Enforces HTTPS": -1,
@@ -11172,7 +11012,7 @@
     },
     {
       "Agency": "The Legislative Branch (Congress)",
-      "Canonical": "http://uscapitolvisitorcenter.gov",
+      "Canonical": "http://www.uscapitolvisitorcenter.gov",
       "Details": "This domain does not support HTTPS.",
       "Domain": "uscapitolvisitorcenter.gov",
       "Enforces HTTPS": -1,
@@ -11262,7 +11102,7 @@
     },
     {
       "Agency": "The Legislative Branch (Congress)",
-      "Canonical": "http://uscvc.gov",
+      "Canonical": "http://www.uscvc.gov",
       "Details": "This domain does not support HTTPS.",
       "Domain": "uscvc.gov",
       "Enforces HTTPS": -1,
@@ -11386,7 +11226,7 @@
       "Details": "This domain is offered over valid HTTPS.",
       "Domain": "usgs.gov",
       "Enforces HTTPS": 1,
-      "SSL Labs Grade": 3,
+      "SSL Labs Grade": 4,
       "Strict Transport Security (HSTS)": 0,
       "Uses HTTPS": 2
     },
@@ -11466,19 +11306,19 @@
       "Details": "This domain is offered over valid HTTPS.",
       "Domain": "usmint.gov",
       "Enforces HTTPS": 1,
-      "SSL Labs Grade": 3,
+      "SSL Labs Grade": 2,
       "Strict Transport Security (HSTS)": 0,
       "Uses HTTPS": 2
     },
     {
       "Agency": "Department of State",
-      "Canonical": "http://usmission.gov",
-      "Details": "This domain does not support HTTPS.",
+      "Canonical": "http://www.usmission.gov",
+      "Details": "This domain is offered over valid HTTPS, but uses a certificate chain that may cause issues for some visitors.",
       "Domain": "usmission.gov",
-      "Enforces HTTPS": -1,
+      "Enforces HTTPS": 1,
       "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": -1
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 1
     },
     {
       "Agency": "United States Office of Government Ethics",
@@ -11536,7 +11376,7 @@
       "Details": "This domain is offered over valid HTTPS.",
       "Domain": "uspsoig.gov",
       "Enforces HTTPS": 3,
-      "SSL Labs Grade": 5,
+      "SSL Labs Grade": 3,
       "Strict Transport Security (HSTS)": 3,
       "Uses HTTPS": 2
     },
@@ -11563,22 +11403,22 @@
     {
       "Agency": "The Judicial Branch (Courts)",
       "Canonical": "http://ustaxcourt.gov",
-      "Details": "This domain does not support HTTPS.",
+      "Details": "This domain is offered over valid HTTPS.",
       "Domain": "ustaxcourt.gov",
-      "Enforces HTTPS": -1,
-      "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": -1
+      "Enforces HTTPS": 1,
+      "SSL Labs Grade": 3,
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 2
     },
     {
       "Agency": "U.S. Trade and Development Agency",
       "Canonical": "http://ustda.gov",
-      "Details": "This domain is offered over valid HTTPS, but uses a certificate chain that may cause issues for some visitors.",
+      "Details": "This domain does not support HTTPS.",
       "Domain": "ustda.gov",
-      "Enforces HTTPS": 1,
-      "SSL Labs Grade": 0,
-      "Strict Transport Security (HSTS)": 0,
-      "Uses HTTPS": 1
+      "Enforces HTTPS": -1,
+      "SSL Labs Grade": -1,
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": -1
     },
     {
       "Agency": "Executive Office of the President",
@@ -11586,7 +11426,7 @@
       "Details": "This domain is offered over valid HTTPS.",
       "Domain": "ustr.gov",
       "Enforces HTTPS": 3,
-      "SSL Labs Grade": 0,
+      "SSL Labs Grade": -1,
       "Strict Transport Security (HSTS)": 1,
       "Uses HTTPS": 2
     },
@@ -11702,7 +11542,7 @@
     },
     {
       "Agency": "The Legislative Branch (Congress)",
-      "Canonical": "http://visitthecapital.gov",
+      "Canonical": "http://www.visitthecapital.gov",
       "Details": "This domain does not support HTTPS.",
       "Domain": "visitthecapital.gov",
       "Enforces HTTPS": -1,
@@ -11712,13 +11552,13 @@
     },
     {
       "Agency": "The Legislative Branch (Congress)",
-      "Canonical": "http://www.visitthecapitol.gov",
-      "Details": "This domain does not support HTTPS.",
+      "Canonical": "https://www.visitthecapitol.gov",
+      "Details": "This domain is offered over valid HTTPS.",
       "Domain": "visitthecapitol.gov",
-      "Enforces HTTPS": -1,
-      "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": -1
+      "Enforces HTTPS": 3,
+      "SSL Labs Grade": 2,
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 2
     },
     {
       "Agency": "Corporation for National & Community Service",
@@ -11756,19 +11596,19 @@
       "Details": "This domain is offered over valid HTTPS.",
       "Domain": "volunteer.gov",
       "Enforces HTTPS": 1,
-      "SSL Labs Grade": 3,
+      "SSL Labs Grade": 2,
       "Strict Transport Security (HSTS)": 0,
       "Uses HTTPS": 2
     },
     {
       "Agency": "Corporation for National & Community Service",
       "Canonical": "http://www.volunteeringinamerica.gov",
-      "Details": "This domain does not support HTTPS.",
+      "Details": "This domain is offered over valid HTTPS.",
       "Domain": "volunteeringinamerica.gov",
-      "Enforces HTTPS": -1,
-      "SSL Labs Grade": -1,
-      "Strict Transport Security (HSTS)": -1,
-      "Uses HTTPS": -1
+      "Enforces HTTPS": 1,
+      "SSL Labs Grade": 3,
+      "Strict Transport Security (HSTS)": 0,
+      "Uses HTTPS": 2
     },
     {
       "Agency": "Department of Energy",
@@ -11956,7 +11796,7 @@
       "Details": "This domain is offered over valid HTTPS.",
       "Domain": "wlci.gov",
       "Enforces HTTPS": 2,
-      "SSL Labs Grade": 3,
+      "SSL Labs Grade": 4,
       "Strict Transport Security (HSTS)": 0,
       "Uses HTTPS": 2
     },

--- a/assets/data/tables/https/domains.json
+++ b/assets/data/tables/https/domains.json
@@ -71,6 +71,16 @@
       "Uses HTTPS": 2
     },
     {
+      "Agency": "Comm for People Who Are Blind/Severly Disabled",
+      "Canonical": "http://abilityone.gov",
+      "Details": "This domain does not support HTTPS.",
+      "Domain": "abilityone.gov",
+      "Enforces HTTPS": -1,
+      "SSL Labs Grade": -1,
+      "Strict Transport Security (HSTS)": -1,
+      "Uses HTTPS": -1
+    },
+    {
       "Agency": "American Battle Monuments Commission",
       "Canonical": "http://abmc.gov",
       "Details": "This domain is offered over valid HTTPS, but uses a certificate chain that may cause issues for some visitors.",


### PR DESCRIPTION
This performs a full scan and update of the dataset in Pulse, as of May 29th, 2015.

As input, it uses the .gov domain list [as published here](https://github.com/GSA/data/tree/gh-pages/dotgov-domains) on 2015-03-15. This is the same input as our last scan on April 30th, 2015.

It also uses as input a (not yet publicly) updated CSV that the DAP releases, of participating domains/subdomains that have registered at least 1 visit over the prior 2 weeks. In our last April 30th scan, we used a CSV released around March 15th, so the data is fresher by around 2.5 months.

When rounded, the HTTPS participation % remains the same at **31%**. The DAP participation % rises from **33%** to **43%**.

Note that the eligible domains also shifted a bit, as some domains were reachable during the scan that were not before, and some were unreachable that were reachable before.

**Use HTTPS:**

* April 2015 - 370 use HTTPS **/** 1207 total - **30.7%**
* May 2015 - 371 use HTTPS **/** 1192 total - **31.1%**

**Participate in DAP:**

* April 2015 - 265 participate **/** 792 total - **33.5%**
* May 2015 - 342 participate **/** 790 total - **43.3%**
