### PR TITLE
Always link to the SSL Labs report

### DIFF
--- a/assets/js/https/domains.js
+++ b/assets/js/https/domains.js
@@ -151,10 +151,13 @@ $(document).ready(function () {
     if (row["Forward Secrecy"] <= 1)
       config.push("should enable " + l("fs", "forward secrecy"));
 
+    var issues = "";
     if (config.length > 0)
-      return "This domain " + config.join(", ") + ". ";
-    else
-      return "No data.";
+      issues += "This domain " + config.join(", ") + ". ";
+
+    issues += "See the " + l(labsUrlFor(row["Domain"]), "full SSL Labs report") + " for details.";
+
+    return issues;
   };
 
   var renderTable = function(data) {


### PR DESCRIPTION
And remove the "No data." descriptor for cases where we do have data (there just aren't any negative issues to call out, among the ones we look for here).

![screenshot from 2015-06-01 01 20 56](https://cloud.githubusercontent.com/assets/4592/7906646/8a4f5bbc-07fc-11e5-8253-a0a79d62d304.png)

I do this in part because the actual grade link is small and easy to miss -- and even harder to click now that we made the whole row clickable, since the cursor pointer is always-on.