### PR TITLE
Collapsed menu displays now

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -350,7 +350,8 @@ a#skipnav {
   background: #fff;
   -webkit-overflow-scrolling: touch;
   overflow-y: auto;
-  z-index: 999999; }
+  z-index: 999999; 
+  display:none;}
   .site-header #menu-content a {
     color: #4A4A4A; }
   .site-header #menu-content ul {
@@ -362,7 +363,8 @@ a#skipnav {
     -moz-transform: translateX(0);
     -ms-transform: translateX(0);
     -o-transform: translateX(0);
-    transform: translateX(0); }
+    transform: translateX(0); 
+    display:block;}
 .site-header .overlay {
   position: fixed;
   top: 0;


### PR DESCRIPTION
The collapsed menu wasn't displaying when selected. 

Fixed by updating CSS. 

This also prevents those links from being tabbable while offscreen. 