### PR TITLE
Make pulse.cio.gov the canonical URL

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,5 +1,8 @@
 # Site metadata.
 
+# Canonical URL
+url: https://pulse.cio.gov
+
 name: Pulse
 title: "The pulse of the federal .gov space"
 description: "How federal government domains are meeting best practices on the web."

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -28,6 +28,8 @@
   <meta property="og:description" content="{{ site.description | xml_escape }}" />
 {% endif %}
 
+<link rel="canonical" href="{{ site.url }}{{ page.url }}" />
+
 <!-- Favicons
 ================================================== -->
 <!-- 128x128 -->


### PR DESCRIPTION
This will let search engines prefer our production site, and transfer any PageRank for our staging site to our production site.