### PR TITLE
Removed blank links

### DIFF
--- a/assets/js/https/domains.js
+++ b/assets/js/https/domains.js
@@ -52,6 +52,8 @@ $(document).ready(function () {
     var grade = display(names.grade)(data, type);
     if (type == "sort")
       return grade;
+    else if (grade == "")
+      return ""
     else
       return "" +
         "<a href=\"" + labsUrlFor(row['Domain']) + "\" target=\"blank\">" +


### PR DESCRIPTION
Links with no text were appearing in the domain table when their grade wasn't provided for ssl. 

These links are removed 