### PR TITLE
Added package.json, cleaned up hookshot.js

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,6 @@ logs
 
 # Mac specific
 .DS_Store
+
+# Node
+node_modules/

--- a/deploy/hookshot.js
+++ b/deploy/hookshot.js
@@ -1,18 +1,20 @@
 #!/usr/bin/env node
 
 var hookshot = require("hookshot");
-var spawn = require("child_process").spawn;
-var options = require('minimist')(process.argv.slice(2));
+var program  = require("commander");
 
-var branch = options.b || options.branch;
-var command = options.c || options.command;
-var port = options.p || options.port;
+program
+  .option("-b, --branch <branch>", "Git branch to use when waiting for posthooks")
+  .option("-c, --command <command>", "Command to run after posthook.")
+  .option("-p, --port <number>", "Port in which to watch for postcommit web hooks.")
+  .parse(process.argv);
 
-if (!branch || !command || !port) {
+if (!program.branch || !program.command || !program.port) {
   console.error("--branch, --command, and --port are all required.")
+  program.outputHelp();
   process.exit(1);
 }
 
-hookshot('refs/heads/' + branch, command).listen(port);
-
-console.log("Huzzah! Listening on port " + port + " for push events on " + branch + ".")
+hookshot("refs/heads/" + program.branch, program.command).listen(program.port, function() {
+  console.log("Huzzah! Listening on port " + program.port + " for push events on " + program.branch + ".")
+});

--- a/package.json
+++ b/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "pulse",
+  "version": "1.0.0",
+  "description": "How the .gov domain space is doing at best practices and federal requirements. ",
+  "main": "deploy/hookshot.js",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/ScottONeal/pulse.git"
+  },
+  "author": "18F",
+  "license": "CC0 dedication",
+  "bugs": {
+    "url": "https://github.com/ScottONeal/pulse/issues"
+  },
+  "homepage": "https://github.com/ScottONeal/pulse",
+  "dependencies": {
+    "commander": "^2.8.1",
+    "hookshot": "^0.1.0"
+  }
+}

--- a/package.json
+++ b/package.json
@@ -3,16 +3,17 @@
   "version": "1.0.0",
   "description": "How the .gov domain space is doing at best practices and federal requirements. ",
   "main": "deploy/hookshot.js",
+  "private": true,
   "repository": {
     "type": "git",
-    "url": "https://github.com/ScottONeal/pulse.git"
+    "url": "https://github.com/18F/pulse.git"
   },
   "author": "18F",
   "license": "CC0 dedication",
   "bugs": {
-    "url": "https://github.com/ScottONeal/pulse/issues"
+    "url": "https://github.com/18F/pulse/issues"
   },
-  "homepage": "https://github.com/ScottONeal/pulse",
+  "homepage": "https://github.com/18F/pulse",
   "dependencies": {
     "commander": "^2.8.1",
     "hookshot": "^0.1.0"


### PR DESCRIPTION
Thanks for this cool initiative.

Although not used much by contributors, I decided to clean up deploy/hookshot.js, which also involved adding a package.json.

Switched from `minimalist` to `commander` for most robust cli options

hookshot.js now has `--help` command
deploy/hookshot.js --help

Deferred logging of hookshot 'started' line, until the hookshot server was actually listening on the port.

Quite a minor PR, don't mind if it gets reject! 