### PR TITLE
Data update - June 7, 2015

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,6 @@ logs
 /_site
 /.sass-cache
 /data/*.csv
-/data/*.json
 
 # Mac specific
 .DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ logs
 /_site
 /.sass-cache
 /data/*.csv
+/data/*.json
 
 # Mac specific
 .DS_Store

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -86,3 +86,6 @@ DEPENDENCIES
   redcarpet
   rouge
   sass
+
+BUNDLED WITH
+   1.10.3

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ css ?= assets/css/main.css
 all: styles
 
 run:
-	bundle exec jekyll serve
+	bundle exec jekyll serve --watch
 
 styles:
 	bundle exec sass $(scss):$(css)

--- a/_config.yml
+++ b/_config.yml
@@ -37,6 +37,9 @@ exclude:
 - todo.txt
 - Gemfile
 - Gemfile.lock
+- deploy
+- data
+- Staticfile
 - Makefile
 - vendor
 - lib

--- a/assets/data/https.csv
+++ b/assets/data/https.csv
@@ -1,3 +1,3 @@
 status,value
-active,31
-inactive,69
+active,32
+inactive,68

--- a/assets/data/tables/analytics/agencies.json
+++ b/assets/data/tables/analytics/agencies.json
@@ -52,12 +52,12 @@
     },
     {
       "Agency": "Civil Air Patrol",
-      "Number of Domains": 1,
+      "Number of Domains": 2,
       "Participates in DAP?": 0
     },
     {
       "Agency": "Comm for People Who Are Blind/Severly Disabled",
-      "Number of Domains": 1,
+      "Number of Domains": 2,
       "Participates in DAP?": 0
     },
     {
@@ -117,13 +117,13 @@
     },
     {
       "Agency": "Department of Defense",
-      "Number of Domains": 22,
-      "Participates in DAP?": 45
+      "Number of Domains": 23,
+      "Participates in DAP?": 43
     },
     {
       "Agency": "Department of Education",
-      "Number of Domains": 10,
-      "Participates in DAP?": 80
+      "Number of Domains": 9,
+      "Participates in DAP?": 67
     },
     {
       "Agency": "Department of Energy",
@@ -147,8 +147,8 @@
     },
     {
       "Agency": "Department of Justice",
-      "Number of Domains": 50,
-      "Participates in DAP?": 72
+      "Number of Domains": 49,
+      "Participates in DAP?": 73
     },
     {
       "Agency": "Department of Labor",
@@ -162,8 +162,8 @@
     },
     {
       "Agency": "Department of Transportation",
-      "Number of Domains": 25,
-      "Participates in DAP?": 68
+      "Number of Domains": 24,
+      "Participates in DAP?": 67
     },
     {
       "Agency": "Department of Veterans Affairs",
@@ -172,13 +172,13 @@
     },
     {
       "Agency": "Department of the Interior",
-      "Number of Domains": 73,
-      "Participates in DAP?": 36
+      "Number of Domains": 74,
+      "Participates in DAP?": 35
     },
     {
       "Agency": "Department of the Treasury",
-      "Number of Domains": 71,
-      "Participates in DAP?": 65
+      "Number of Domains": 72,
+      "Participates in DAP?": 64
     },
     {
       "Agency": "Director of National Intelligence",
@@ -522,7 +522,7 @@
     },
     {
       "Agency": "U. S. Peace Corps",
-      "Number of Domains": 3,
+      "Number of Domains": 2,
       "Participates in DAP?": 0
     },
     {

--- a/assets/data/tables/analytics/domains.json
+++ b/assets/data/tables/analytics/domains.json
@@ -541,6 +541,12 @@
       "Participates in DAP?": 0
     },
     {
+      "Agency": "Civil Air Patrol",
+      "Canonical": "http://www.capnhq.gov",
+      "Domain": "capnhq.gov",
+      "Participates in DAP?": 0
+    },
+    {
       "Agency": "Department of Energy",
       "Canonical": "http://www.casl.gov",
       "Domain": "casl.gov",
@@ -649,12 +655,6 @@
       "Participates in DAP?": 0
     },
     {
-      "Agency": "Department of Education",
-      "Canonical": "http://www.childstats.gov",
-      "Domain": "childstats.gov",
-      "Participates in DAP?": 1
-    },
-    {
       "Agency": "Department of Health And Human Services",
       "Canonical": "https://childwelfare.gov",
       "Domain": "childwelfare.gov",
@@ -760,6 +760,12 @@
       "Agency": "Department of Health And Human Services",
       "Canonical": "http://collegedrinkingprevention.gov",
       "Domain": "collegedrinkingprevention.gov",
+      "Participates in DAP?": 0
+    },
+    {
+      "Agency": "Department of Education",
+      "Canonical": "http://collegenavigator.gov",
+      "Domain": "collegenavigator.gov",
       "Participates in DAP?": 0
     },
     {
@@ -884,13 +890,13 @@
     },
     {
       "Agency": "Court Services and Offender Supervision",
-      "Canonical": "http://csosa.gov",
+      "Canonical": "http://www.csosa.gov",
       "Domain": "csosa.gov",
       "Participates in DAP?": 0
     },
     {
       "Agency": "Department of Defense",
-      "Canonical": "http://cttso.gov",
+      "Canonical": "http://www.cttso.gov",
       "Domain": "cttso.gov",
       "Participates in DAP?": 0
     },
@@ -1069,12 +1075,6 @@
       "Participates in DAP?": 1
     },
     {
-      "Agency": "Department of Transportation",
-      "Canonical": "http://www.dot.gov",
-      "Domain": "dot.gov",
-      "Participates in DAP?": 1
-    },
-    {
       "Agency": "General Services Administration",
       "Canonical": "https://www.dotgov.gov",
       "Domain": "dotgov.gov",
@@ -1172,7 +1172,7 @@
     },
     {
       "Agency": "Department of Education",
-      "Canonical": "http://education.gov",
+      "Canonical": "http://www.education.gov",
       "Domain": "education.gov",
       "Participates in DAP?": 1
     },
@@ -1238,7 +1238,7 @@
     },
     {
       "Agency": "Department of Energy",
-      "Canonical": "http://www.energycodes.gov",
+      "Canonical": "https://www.energycodes.gov",
       "Domain": "energycodes.gov",
       "Participates in DAP?": 0
     },
@@ -1514,7 +1514,7 @@
     },
     {
       "Agency": "Federal Reserve System",
-      "Canonical": "http://www.federalreserve.gov",
+      "Canonical": "http://federalreserve.gov",
       "Domain": "federalreserve.gov",
       "Participates in DAP?": 0
     },
@@ -1670,7 +1670,7 @@
     },
     {
       "Agency": "Executive Office of the President",
-      "Canonical": "http://www.fiscalcommission.gov",
+      "Canonical": "https://www.fiscalcommission.gov",
       "Domain": "fiscalcommission.gov",
       "Participates in DAP?": 0
     },
@@ -2096,7 +2096,7 @@
     },
     {
       "Agency": "Department of Health And Human Services",
-      "Canonical": "http://healthdata.gov",
+      "Canonical": "http://www.healthdata.gov",
       "Domain": "healthdata.gov",
       "Participates in DAP?": 0
     },
@@ -2528,7 +2528,7 @@
     },
     {
       "Agency": "Department of Labor",
-      "Canonical": "http://www.jobcorps.gov",
+      "Canonical": "http://jobcorps.gov",
       "Domain": "jobcorps.gov",
       "Participates in DAP?": 0
     },
@@ -2549,6 +2549,12 @@
       "Canonical": "http://juvenilecouncil.gov",
       "Domain": "juvenilecouncil.gov",
       "Participates in DAP?": 1
+    },
+    {
+      "Agency": "Comm for People Who Are Blind/Severly Disabled",
+      "Canonical": "http://jwod.gov",
+      "Domain": "jwod.gov",
+      "Participates in DAP?": 0
     },
     {
       "Agency": "Department of the Interior",
@@ -2815,6 +2821,12 @@
       "Participates in DAP?": 0
     },
     {
+      "Agency": "Department of Defense",
+      "Canonical": "https://mojavedata.gov",
+      "Domain": "mojavedata.gov",
+      "Participates in DAP?": 0
+    },
+    {
       "Agency": "Department of the Treasury",
       "Canonical": "http://moneyfactory.gov",
       "Domain": "moneyfactory.gov",
@@ -2881,6 +2893,12 @@
       "Participates in DAP?": 1
     },
     {
+      "Agency": "Department of the Treasury",
+      "Canonical": "https://myra.gov",
+      "Domain": "myra.gov",
+      "Participates in DAP?": 0
+    },
+    {
       "Agency": "Department of Agriculture",
       "Canonical": "http://nafri.gov",
       "Domain": "nafri.gov",
@@ -2945,12 +2963,6 @@
       "Canonical": "http://www.nationalservice.gov",
       "Domain": "nationalservice.gov",
       "Participates in DAP?": 0
-    },
-    {
-      "Agency": "Department of Education",
-      "Canonical": "http://www.nationsreportcard.gov",
-      "Domain": "nationsreportcard.gov",
-      "Participates in DAP?": 1
     },
     {
       "Agency": "Department of the Treasury",
@@ -3512,7 +3524,7 @@
     },
     {
       "Agency": "General Services Administration",
-      "Canonical": "http://www.partner4solutions.gov",
+      "Canonical": "http://partner4solutions.gov",
       "Domain": "partner4solutions.gov",
       "Participates in DAP?": 1
     },
@@ -3554,13 +3566,7 @@
     },
     {
       "Agency": "U. S. Peace Corps",
-      "Canonical": "http://peacecore.gov",
-      "Domain": "peacecore.gov",
-      "Participates in DAP?": 0
-    },
-    {
-      "Agency": "U. S. Peace Corps",
-      "Canonical": "http://peacecorp.gov",
+      "Canonical": "http://www.peacecorp.gov",
       "Domain": "peacecorp.gov",
       "Participates in DAP?": 0
     },
@@ -3664,12 +3670,6 @@
       "Agency": "Court Services and Offender Supervision",
       "Canonical": "http://pretrialservices.gov",
       "Domain": "pretrialservices.gov",
-      "Participates in DAP?": 0
-    },
-    {
-      "Agency": "Department of Justice",
-      "Canonical": "http://www.projectsafeneighborhoods.gov",
-      "Domain": "projectsafeneighborhoods.gov",
       "Participates in DAP?": 0
     },
     {
@@ -3823,6 +3823,12 @@
       "Participates in DAP?": 0
     },
     {
+      "Agency": "Department of the Interior",
+      "Canonical": "http://www.safecom.gov",
+      "Domain": "safecom.gov",
+      "Participates in DAP?": 0
+    },
+    {
       "Agency": "Department of Transportation",
       "Canonical": "http://www.safercar.gov",
       "Domain": "safercar.gov",
@@ -3842,7 +3848,7 @@
     },
     {
       "Agency": "Department of Homeland Security",
-      "Canonical": "http://www.safetyact.gov",
+      "Canonical": "https://safetyact.gov",
       "Domain": "safetyact.gov",
       "Participates in DAP?": 0
     },
@@ -3890,13 +3896,13 @@
     },
     {
       "Agency": "Small Business Administration",
-      "Canonical": "https://www.sba.gov",
+      "Canonical": "http://www.sba.gov",
       "Domain": "sba.gov",
       "Participates in DAP?": 1
     },
     {
       "Agency": "National Science Foundation",
-      "Canonical": "https://www.sbir.gov",
+      "Canonical": "http://www.sbir.gov",
       "Domain": "sbir.gov",
       "Participates in DAP?": 0
     },
@@ -4286,7 +4292,7 @@
     },
     {
       "Agency": "Department of Defense",
-      "Canonical": "http://tswg.gov",
+      "Canonical": "http://www.tswg.gov",
       "Domain": "tswg.gov",
       "Participates in DAP?": 0
     },

--- a/assets/data/tables/https/agencies.json
+++ b/assets/data/tables/https/agencies.json
@@ -86,12 +86,12 @@
       "Number of Domains": 2,
       "SSL Labs (A- or higher)": 0,
       "Strict Transport Security (HSTS)": 0,
-      "Uses HTTPS": 0
+      "Uses HTTPS": 50
     },
     {
       "Agency": "Comm for People Who Are Blind/Severly Disabled",
       "Enforces HTTPS": 0,
-      "Number of Domains": 1,
+      "Number of Domains": 2,
       "SSL Labs (A- or higher)": 0,
       "Strict Transport Security (HSTS)": 0,
       "Uses HTTPS": 0
@@ -194,25 +194,25 @@
     },
     {
       "Agency": "Department of Defense",
-      "Enforces HTTPS": 17,
-      "Number of Domains": 23,
+      "Enforces HTTPS": 21,
+      "Number of Domains": 24,
       "SSL Labs (A- or higher)": 4,
       "Strict Transport Security (HSTS)": 0,
-      "Uses HTTPS": 30
+      "Uses HTTPS": 33
     },
     {
       "Agency": "Department of Education",
-      "Enforces HTTPS": 19,
-      "Number of Domains": 16,
-      "SSL Labs (A- or higher)": 6,
-      "Strict Transport Security (HSTS)": 6,
-      "Uses HTTPS": 44
+      "Enforces HTTPS": 21,
+      "Number of Domains": 14,
+      "SSL Labs (A- or higher)": 7,
+      "Strict Transport Security (HSTS)": 7,
+      "Uses HTTPS": 43
     },
     {
       "Agency": "Department of Energy",
-      "Enforces HTTPS": 11,
+      "Enforces HTTPS": 13,
       "Number of Domains": 55,
-      "SSL Labs (A- or higher)": 7,
+      "SSL Labs (A- or higher)": 9,
       "Strict Transport Security (HSTS)": 0,
       "Uses HTTPS": 40
     },
@@ -220,17 +220,17 @@
       "Agency": "Department of Health And Human Services",
       "Enforces HTTPS": 9,
       "Number of Domains": 112,
-      "SSL Labs (A- or higher)": 11,
+      "SSL Labs (A- or higher)": 9,
       "Strict Transport Security (HSTS)": 4,
-      "Uses HTTPS": 28
+      "Uses HTTPS": 29
     },
     {
       "Agency": "Department of Homeland Security",
-      "Enforces HTTPS": 20,
+      "Enforces HTTPS": 24,
       "Number of Domains": 25,
       "SSL Labs (A- or higher)": 4,
       "Strict Transport Security (HSTS)": 0,
-      "Uses HTTPS": 44
+      "Uses HTTPS": 48
     },
     {
       "Agency": "Department of Housing And Urban Development",
@@ -244,9 +244,9 @@
       "Agency": "Department of Justice",
       "Enforces HTTPS": 15,
       "Number of Domains": 66,
-      "SSL Labs (A- or higher)": 3,
+      "SSL Labs (A- or higher)": 5,
       "Strict Transport Security (HSTS)": 2,
-      "Uses HTTPS": 18
+      "Uses HTTPS": 20
     },
     {
       "Agency": "Department of Labor",
@@ -254,7 +254,7 @@
       "Number of Domains": 20,
       "SSL Labs (A- or higher)": 0,
       "Strict Transport Security (HSTS)": 0,
-      "Uses HTTPS": 20
+      "Uses HTTPS": 25
     },
     {
       "Agency": "Department of State",
@@ -286,15 +286,15 @@
       "Number of Domains": 83,
       "SSL Labs (A- or higher)": 13,
       "Strict Transport Security (HSTS)": 0,
-      "Uses HTTPS": 30
+      "Uses HTTPS": 34
     },
     {
       "Agency": "Department of the Treasury",
-      "Enforces HTTPS": 20,
-      "Number of Domains": 84,
+      "Enforces HTTPS": 21,
+      "Number of Domains": 85,
       "SSL Labs (A- or higher)": 1,
       "Strict Transport Security (HSTS)": 0,
-      "Uses HTTPS": 25
+      "Uses HTTPS": 27
     },
     {
       "Agency": "Director of National Intelligence",
@@ -322,10 +322,10 @@
     },
     {
       "Agency": "Executive Office of the President",
-      "Enforces HTTPS": 27,
-      "Number of Domains": 30,
-      "SSL Labs (A- or higher)": 47,
-      "Strict Transport Security (HSTS)": 23,
+      "Enforces HTTPS": 29,
+      "Number of Domains": 31,
+      "SSL Labs (A- or higher)": 48,
+      "Strict Transport Security (HSTS)": 26,
       "Uses HTTPS": 77
     },
     {
@@ -422,7 +422,7 @@
       "Number of Domains": 6,
       "SSL Labs (A- or higher)": 0,
       "Strict Transport Security (HSTS)": 0,
-      "Uses HTTPS": 83
+      "Uses HTTPS": 67
     },
     {
       "Agency": "Federal Retirement Thrift Investment Board",
@@ -443,10 +443,10 @@
     {
       "Agency": "General Services Administration",
       "Enforces HTTPS": 29,
-      "Number of Domains": 92,
-      "SSL Labs (A- or higher)": 1,
-      "Strict Transport Security (HSTS)": 7,
-      "Uses HTTPS": 53
+      "Number of Domains": 91,
+      "SSL Labs (A- or higher)": 0,
+      "Strict Transport Security (HSTS)": 5,
+      "Uses HTTPS": 51
     },
     {
       "Agency": "Government Printing Office",
@@ -454,7 +454,7 @@
       "Number of Domains": 22,
       "SSL Labs (A- or higher)": 0,
       "Strict Transport Security (HSTS)": 5,
-      "Uses HTTPS": 9
+      "Uses HTTPS": 14
     },
     {
       "Agency": "Harry S. Truman Scholarship Foundation",
@@ -658,7 +658,7 @@
     },
     {
       "Agency": "National Science Foundation",
-      "Enforces HTTPS": 12,
+      "Enforces HTTPS": 0,
       "Number of Domains": 8,
       "SSL Labs (A- or higher)": 0,
       "Strict Transport Security (HSTS)": 0,
@@ -716,9 +716,9 @@
       "Agency": "Office of Personnel Management",
       "Enforces HTTPS": 33,
       "Number of Domains": 21,
-      "SSL Labs (A- or higher)": 29,
+      "SSL Labs (A- or higher)": 33,
       "Strict Transport Security (HSTS)": 5,
-      "Uses HTTPS": 57
+      "Uses HTTPS": 62
     },
     {
       "Agency": "Overseas Private Investment Corporation",
@@ -774,15 +774,15 @@
       "Number of Domains": 1,
       "SSL Labs (A- or higher)": 0,
       "Strict Transport Security (HSTS)": 0,
-      "Uses HTTPS": 100
+      "Uses HTTPS": 0
     },
     {
       "Agency": "Small Business Administration",
-      "Enforces HTTPS": 33,
+      "Enforces HTTPS": 17,
       "Number of Domains": 6,
       "SSL Labs (A- or higher)": 0,
       "Strict Transport Security (HSTS)": 0,
-      "Uses HTTPS": 33
+      "Uses HTTPS": 17
     },
     {
       "Agency": "Smithsonian Institution",
@@ -854,7 +854,7 @@
       "Number of Domains": 41,
       "SSL Labs (A- or higher)": 2,
       "Strict Transport Security (HSTS)": 0,
-      "Uses HTTPS": 22
+      "Uses HTTPS": 24
     },
     {
       "Agency": "The United States World War One Centennial Commission",
@@ -950,7 +950,7 @@
       "Number of Domains": 1,
       "SSL Labs (A- or higher)": 0,
       "Strict Transport Security (HSTS)": 0,
-      "Uses HTTPS": 0
+      "Uses HTTPS": 100
     },
     {
       "Agency": "US Interagency Council on Homelessness",

--- a/assets/data/tables/https/agencies.json
+++ b/assets/data/tables/https/agencies.json
@@ -443,9 +443,9 @@
     {
       "Agency": "General Services Administration",
       "Enforces HTTPS": 29,
-      "Number of Domains": 91,
-      "SSL Labs (A- or higher)": 0,
-      "Strict Transport Security (HSTS)": 5,
+      "Number of Domains": 92,
+      "SSL Labs (A- or higher)": 1,
+      "Strict Transport Security (HSTS)": 7,
       "Uses HTTPS": 51
     },
     {

--- a/assets/data/tables/https/domains.json
+++ b/assets/data/tables/https/domains.json
@@ -1,6 +1,21 @@
 {
   "data": [
     {
+      "Agency": "General Services Administration",
+      "Canonical": "http://www.18f.gov",
+      "Domain": "18f.gov",
+      "Enforces HTTPS": 3,
+      "Forward Secrecy": 4,
+      "HSTS max-age": 31536000,
+      "RC4": false,
+      "SSL Labs Grade": 6,
+      "SSLv3": false,
+      "Signature Algorithm": "SHA256withRSA",
+      "Strict Transport Security (HSTS)": 1,
+      "TLSv1.2": true,
+      "Uses HTTPS": 2
+    },
+    {
       "Agency": "Securities and Exchange Commission",
       "Canonical": "http://404.gov",
       "Domain": "404.gov",

--- a/assets/data/tables/https/domains.json
+++ b/assets/data/tables/https/domains.json
@@ -1,21 +1,6 @@
 {
   "data": [
     {
-      "Agency": "General Services Administration",
-      "Canonical": "http://www.18f.gov",
-      "Domain": "18f.gov",
-      "Enforces HTTPS": 3,
-      "Forward Secrecy": 4,
-      "HSTS max-age": 31536000,
-      "RC4": false,
-      "SSL Labs Grade": 6,
-      "SSLv3": false,
-      "Signature Algorithm": "SHA256withRSA",
-      "Strict Transport Security (HSTS)": 1,
-      "TLSv1.2": true,
-      "Uses HTTPS": 2
-    },
-    {
       "Agency": "Securities and Exchange Commission",
       "Canonical": "http://404.gov",
       "Domain": "404.gov",
@@ -128,8 +113,8 @@
       "Forward Secrecy": 1,
       "HSTS max-age": null,
       "RC4": true,
-      "SSL Labs Grade": 2,
-      "SSLv3": true,
+      "SSL Labs Grade": 3,
+      "SSLv3": false,
       "Signature Algorithm": "SHA256withRSA",
       "Strict Transport Security (HSTS)": 0,
       "TLSv1.2": true,
@@ -553,7 +538,7 @@
       "Signature Algorithm": "SHA256withRSA",
       "Strict Transport Security (HSTS)": 0,
       "TLSv1.2": true,
-      "Uses HTTPS": 1
+      "Uses HTTPS": 2
     },
     {
       "Agency": "Department of Justice",
@@ -1063,7 +1048,7 @@
       "Signature Algorithm": "SHA256withRSA",
       "Strict Transport Security (HSTS)": 0,
       "TLSv1.2": true,
-      "Uses HTTPS": 1
+      "Uses HTTPS": 2
     },
     {
       "Agency": "Appraisal Subcommittee",
@@ -1183,7 +1168,7 @@
       "Signature Algorithm": "SHA256withRSA",
       "Strict Transport Security (HSTS)": 0,
       "TLSv1.2": false,
-      "Uses HTTPS": 1
+      "Uses HTTPS": 2
     },
     {
       "Agency": "Department of the Treasury",
@@ -2044,16 +2029,16 @@
       "Agency": "Civil Air Patrol",
       "Canonical": "http://www.capnhq.gov",
       "Domain": "capnhq.gov",
-      "Enforces HTTPS": 0,
-      "Forward Secrecy": null,
+      "Enforces HTTPS": 1,
+      "Forward Secrecy": 0,
       "HSTS max-age": null,
-      "RC4": null,
-      "SSL Labs Grade": -1,
-      "SSLv3": null,
-      "Signature Algorithm": null,
-      "Strict Transport Security (HSTS)": -1,
-      "TLSv1.2": null,
-      "Uses HTTPS": -1
+      "RC4": false,
+      "SSL Labs Grade": 2,
+      "SSLv3": false,
+      "Signature Algorithm": "SHA256withRSA",
+      "Strict Transport Security (HSTS)": 0,
+      "TLSv1.2": false,
+      "Uses HTTPS": 2
     },
     {
       "Agency": "Department of Energy",
@@ -2149,16 +2134,16 @@
       "Agency": "General Services Administration",
       "Canonical": "http://www.ccr.gov",
       "Domain": "ccr.gov",
-      "Enforces HTTPS": 1,
+      "Enforces HTTPS": 0,
       "Forward Secrecy": null,
       "HSTS max-age": null,
       "RC4": null,
       "SSL Labs Grade": -1,
       "SSLv3": null,
       "Signature Algorithm": null,
-      "Strict Transport Security (HSTS)": 0,
+      "Strict Transport Security (HSTS)": -1,
       "TLSv1.2": null,
-      "Uses HTTPS": 1
+      "Uses HTTPS": -1
     },
     {
       "Agency": "Department of Health And Human Services",
@@ -2194,16 +2179,16 @@
       "Agency": "Department of the Treasury",
       "Canonical": "http://cdfifund.gov",
       "Domain": "cdfifund.gov",
-      "Enforces HTTPS": 0,
-      "Forward Secrecy": null,
+      "Enforces HTTPS": 1,
+      "Forward Secrecy": 0,
       "HSTS max-age": null,
-      "RC4": null,
-      "SSL Labs Grade": -1,
-      "SSLv3": null,
-      "Signature Algorithm": null,
-      "Strict Transport Security (HSTS)": -1,
-      "TLSv1.2": null,
-      "Uses HTTPS": -1
+      "RC4": true,
+      "SSL Labs Grade": 1,
+      "SSLv3": true,
+      "Signature Algorithm": "SHA256withRSA",
+      "Strict Transport Security (HSTS)": 0,
+      "TLSv1.2": false,
+      "Uses HTTPS": 1
     },
     {
       "Agency": "Department of Energy",
@@ -2293,7 +2278,7 @@
       "Signature Algorithm": "SHA1withRSA",
       "Strict Transport Security (HSTS)": 0,
       "TLSv1.2": true,
-      "Uses HTTPS": 1
+      "Uses HTTPS": 2
     },
     {
       "Agency": "Department of Transportation",
@@ -2449,21 +2434,6 @@
       "Agency": "U.S. Agency for International Development",
       "Canonical": "http://www.childreninadversity.gov",
       "Domain": "childreninadversity.gov",
-      "Enforces HTTPS": 0,
-      "Forward Secrecy": null,
-      "HSTS max-age": null,
-      "RC4": null,
-      "SSL Labs Grade": -1,
-      "SSLv3": null,
-      "Signature Algorithm": null,
-      "Strict Transport Security (HSTS)": -1,
-      "TLSv1.2": null,
-      "Uses HTTPS": -1
-    },
-    {
-      "Agency": "Department of Education",
-      "Canonical": "http://www.childstats.gov",
-      "Domain": "childstats.gov",
       "Enforces HTTPS": 0,
       "Forward Secrecy": null,
       "HSTS max-age": null,
@@ -2704,16 +2674,16 @@
       "Agency": "Department of Health And Human Services",
       "Canonical": "http://cms.gov",
       "Domain": "cms.gov",
-      "Enforces HTTPS": 1,
-      "Forward Secrecy": 0,
+      "Enforces HTTPS": 0,
+      "Forward Secrecy": null,
       "HSTS max-age": null,
-      "RC4": false,
-      "SSL Labs Grade": 4,
-      "SSLv3": false,
-      "Signature Algorithm": "SHA256withRSA",
-      "Strict Transport Security (HSTS)": 0,
-      "TLSv1.2": true,
-      "Uses HTTPS": 2
+      "RC4": null,
+      "SSL Labs Grade": -1,
+      "SSLv3": null,
+      "Signature Algorithm": null,
+      "Strict Transport Security (HSTS)": -1,
+      "TLSv1.2": null,
+      "Uses HTTPS": -1
     },
     {
       "Agency": "Department of Defense",
@@ -2852,7 +2822,7 @@
     },
     {
       "Agency": "Department of Education",
-      "Canonical": "http://www.collegenavigator.gov",
+      "Canonical": "http://collegenavigator.gov",
       "Domain": "collegenavigator.gov",
       "Enforces HTTPS": 0,
       "Forward Secrecy": null,
@@ -2879,6 +2849,21 @@
       "Strict Transport Security (HSTS)": -1,
       "TLSv1.2": null,
       "Uses HTTPS": 0
+    },
+    {
+      "Agency": "Department of the Treasury",
+      "Canonical": "http://www.complaintreferralexpress.gov",
+      "Domain": "complaintreferralexpress.gov",
+      "Enforces HTTPS": 3,
+      "Forward Secrecy": 0,
+      "HSTS max-age": null,
+      "RC4": true,
+      "SSL Labs Grade": 0,
+      "SSLv3": true,
+      "Signature Algorithm": "SHA1withRSA",
+      "Strict Transport Security (HSTS)": 0,
+      "TLSv1.2": false,
+      "Uses HTTPS": 2
     },
     {
       "Agency": "Congressional Office of Compliance",
@@ -2950,7 +2935,7 @@
       "RC4": true,
       "SSL Labs Grade": 2,
       "SSLv3": false,
-      "Signature Algorithm": "SHA1withRSA",
+      "Signature Algorithm": "SHA256withRSA",
       "Strict Transport Security (HSTS)": 0,
       "TLSv1.2": true,
       "Uses HTTPS": 2
@@ -3193,7 +3178,7 @@
       "Signature Algorithm": "SHA1withRSA",
       "Strict Transport Security (HSTS)": 0,
       "TLSv1.2": true,
-      "Uses HTTPS": 1
+      "Uses HTTPS": 2
     },
     {
       "Agency": "Department of Commerce",
@@ -3407,7 +3392,7 @@
     },
     {
       "Agency": "Court Services and Offender Supervision",
-      "Canonical": "http://csosa.gov",
+      "Canonical": "http://www.csosa.gov",
       "Domain": "csosa.gov",
       "Enforces HTTPS": 0,
       "Forward Secrecy": null,
@@ -3422,7 +3407,7 @@
     },
     {
       "Agency": "Department of Defense",
-      "Canonical": "http://cttso.gov",
+      "Canonical": "http://www.cttso.gov",
       "Domain": "cttso.gov",
       "Enforces HTTPS": 0,
       "Forward Secrecy": null,
@@ -4042,12 +4027,12 @@
       "Enforces HTTPS": 1,
       "Forward Secrecy": 0,
       "HSTS max-age": null,
-      "RC4": true,
-      "SSL Labs Grade": 3,
+      "RC4": false,
+      "SSL Labs Grade": 2,
       "SSLv3": false,
       "Signature Algorithm": "SHA256withRSA",
       "Strict Transport Security (HSTS)": 0,
-      "TLSv1.2": true,
+      "TLSv1.2": false,
       "Uses HTTPS": 2
     },
     {
@@ -4318,7 +4303,7 @@
       "Signature Algorithm": null,
       "Strict Transport Security (HSTS)": -1,
       "TLSv1.2": null,
-      "Uses HTTPS": -1
+      "Uses HTTPS": 0
     },
     {
       "Agency": "Executive Office of the President",
@@ -4502,18 +4487,18 @@
     },
     {
       "Agency": "Department of Education",
-      "Canonical": "http://education.gov",
+      "Canonical": "http://www.education.gov",
       "Domain": "education.gov",
-      "Enforces HTTPS": 1,
+      "Enforces HTTPS": 0,
       "Forward Secrecy": null,
       "HSTS max-age": null,
       "RC4": null,
       "SSL Labs Grade": -1,
       "SSLv3": null,
       "Signature Algorithm": null,
-      "Strict Transport Security (HSTS)": 0,
+      "Strict Transport Security (HSTS)": -1,
       "TLSv1.2": null,
-      "Uses HTTPS": 1
+      "Uses HTTPS": -1
     },
     {
       "Agency": "Recovery Accountability and Transparency Board",
@@ -4657,9 +4642,9 @@
       "Enforces HTTPS": 3,
       "Forward Secrecy": 0,
       "HSTS max-age": null,
-      "RC4": true,
-      "SSL Labs Grade": 0,
-      "SSLv3": true,
+      "RC4": false,
+      "SSL Labs Grade": 3,
+      "SSLv3": false,
       "Signature Algorithm": "SHA1withRSA",
       "Strict Transport Security (HSTS)": 0,
       "TLSv1.2": true,
@@ -4712,9 +4697,9 @@
     },
     {
       "Agency": "Department of Energy",
-      "Canonical": "http://www.energycodes.gov",
+      "Canonical": "https://www.energycodes.gov",
       "Domain": "energycodes.gov",
-      "Enforces HTTPS": 1,
+      "Enforces HTTPS": 3,
       "Forward Secrecy": 0,
       "HSTS max-age": null,
       "RC4": true,
@@ -4819,16 +4804,16 @@
       "Agency": "General Services Administration",
       "Canonical": "http://www.epls.gov",
       "Domain": "epls.gov",
-      "Enforces HTTPS": 1,
+      "Enforces HTTPS": 0,
       "Forward Secrecy": null,
       "HSTS max-age": null,
       "RC4": null,
       "SSL Labs Grade": -1,
       "SSLv3": null,
       "Signature Algorithm": null,
-      "Strict Transport Security (HSTS)": 0,
+      "Strict Transport Security (HSTS)": -1,
       "TLSv1.2": null,
-      "Uses HTTPS": 1
+      "Uses HTTPS": -1
     },
     {
       "Agency": "Department of Health And Human Services",
@@ -4865,7 +4850,7 @@
       "Canonical": "http://www.esc.gov",
       "Domain": "esc.gov",
       "Enforces HTTPS": 1,
-      "Forward Secrecy": 0,
+      "Forward Secrecy": 2,
       "HSTS max-age": null,
       "RC4": true,
       "SSL Labs Grade": 3,
@@ -5254,16 +5239,16 @@
       "Agency": "Department of Justice",
       "Canonical": "http://www.fbi.gov",
       "Domain": "fbi.gov",
-      "Enforces HTTPS": 0,
-      "Forward Secrecy": null,
+      "Enforces HTTPS": 1,
+      "Forward Secrecy": 0,
       "HSTS max-age": null,
-      "RC4": null,
-      "SSL Labs Grade": -1,
-      "SSLv3": null,
-      "Signature Algorithm": null,
-      "Strict Transport Security (HSTS)": -1,
-      "TLSv1.2": null,
-      "Uses HTTPS": 0
+      "RC4": false,
+      "SSL Labs Grade": 4,
+      "SSLv3": false,
+      "Signature Algorithm": "SHA256withRSA",
+      "Strict Transport Security (HSTS)": 0,
+      "TLSv1.2": true,
+      "Uses HTTPS": 2
     },
     {
       "Agency": "Federal Reserve System",
@@ -5308,7 +5293,7 @@
       "Signature Algorithm": "SHA1withRSA",
       "Strict Transport Security (HSTS)": 0,
       "TLSv1.2": true,
-      "Uses HTTPS": 1
+      "Uses HTTPS": 2
     },
     {
       "Agency": "Farm Credit Administration",
@@ -5569,16 +5554,16 @@
       "Agency": "Office of Personnel Management",
       "Canonical": "http://feb.gov",
       "Domain": "feb.gov",
-      "Enforces HTTPS": 0,
-      "Forward Secrecy": null,
+      "Enforces HTTPS": 1,
+      "Forward Secrecy": 0,
       "HSTS max-age": null,
-      "RC4": null,
-      "SSL Labs Grade": -1,
-      "SSLv3": null,
-      "Signature Algorithm": null,
-      "Strict Transport Security (HSTS)": -1,
-      "TLSv1.2": null,
-      "Uses HTTPS": -1
+      "RC4": false,
+      "SSL Labs Grade": 4,
+      "SSLv3": false,
+      "Signature Algorithm": "SHA256withRSA",
+      "Strict Transport Security (HSTS)": 0,
+      "TLSv1.2": true,
+      "Uses HTTPS": 2
     },
     {
       "Agency": "Federal Elections Commission",
@@ -5608,7 +5593,7 @@
       "Signature Algorithm": "SHA1withRSA",
       "Strict Transport Security (HSTS)": 0,
       "TLSv1.2": true,
-      "Uses HTTPS": 1
+      "Uses HTTPS": 2
     },
     {
       "Agency": "Environmental Protection Agency",
@@ -5732,18 +5717,18 @@
     },
     {
       "Agency": "Federal Reserve System",
-      "Canonical": "http://www.federalreserve.gov",
+      "Canonical": "http://federalreserve.gov",
       "Domain": "federalreserve.gov",
-      "Enforces HTTPS": 1,
-      "Forward Secrecy": 0,
+      "Enforces HTTPS": 0,
+      "Forward Secrecy": null,
       "HSTS max-age": null,
-      "RC4": true,
-      "SSL Labs Grade": 3,
-      "SSLv3": false,
-      "Signature Algorithm": "SHA256withRSA",
-      "Strict Transport Security (HSTS)": 0,
-      "TLSv1.2": true,
-      "Uses HTTPS": 2
+      "RC4": null,
+      "SSL Labs Grade": -1,
+      "SSLv3": null,
+      "Signature Algorithm": null,
+      "Strict Transport Security (HSTS)": -1,
+      "TLSv1.2": null,
+      "Uses HTTPS": -1
     },
     {
       "Agency": "Federal Reserve System",
@@ -5869,16 +5854,16 @@
       "Agency": "Government Printing Office",
       "Canonical": "http://www.fedreg.gov",
       "Domain": "fedreg.gov",
-      "Enforces HTTPS": 0,
-      "Forward Secrecy": null,
+      "Enforces HTTPS": 1,
+      "Forward Secrecy": 0,
       "HSTS max-age": null,
-      "RC4": null,
-      "SSL Labs Grade": -1,
-      "SSLv3": null,
-      "Signature Algorithm": null,
-      "Strict Transport Security (HSTS)": -1,
-      "TLSv1.2": null,
-      "Uses HTTPS": -1
+      "RC4": true,
+      "SSL Labs Grade": 0,
+      "SSLv3": true,
+      "Signature Algorithm": "SHA256withRSA",
+      "Strict Transport Security (HSTS)": 0,
+      "TLSv1.2": false,
+      "Uses HTTPS": 2
     },
     {
       "Agency": "General Services Administration",
@@ -6199,16 +6184,16 @@
       "Agency": "Department of the Interior",
       "Canonical": "http://www.firescience.gov",
       "Domain": "firescience.gov",
-      "Enforces HTTPS": 0,
-      "Forward Secrecy": null,
+      "Enforces HTTPS": 1,
+      "Forward Secrecy": 0,
       "HSTS max-age": null,
-      "RC4": null,
-      "SSL Labs Grade": -1,
-      "SSLv3": null,
-      "Signature Algorithm": null,
-      "Strict Transport Security (HSTS)": -1,
-      "TLSv1.2": null,
-      "Uses HTTPS": -1
+      "RC4": true,
+      "SSL Labs Grade": 2,
+      "SSLv3": true,
+      "Signature Algorithm": "SHA1withRSA",
+      "Strict Transport Security (HSTS)": 0,
+      "TLSv1.2": false,
+      "Uses HTTPS": 2
     },
     {
       "Agency": "Department of Justice",
@@ -6287,18 +6272,18 @@
     },
     {
       "Agency": "Executive Office of the President",
-      "Canonical": "http://www.fiscalcommission.gov",
+      "Canonical": "https://www.fiscalcommission.gov",
       "Domain": "fiscalcommission.gov",
-      "Enforces HTTPS": 0,
-      "Forward Secrecy": null,
+      "Enforces HTTPS": 3,
+      "Forward Secrecy": 2,
       "HSTS max-age": null,
-      "RC4": null,
-      "SSL Labs Grade": -1,
-      "SSLv3": null,
-      "Signature Algorithm": null,
-      "Strict Transport Security (HSTS)": -1,
-      "TLSv1.2": null,
-      "Uses HTTPS": -1
+      "RC4": false,
+      "SSL Labs Grade": 5,
+      "SSLv3": false,
+      "Signature Algorithm": "SHA256withRSA",
+      "Strict Transport Security (HSTS)": 0,
+      "TLSv1.2": true,
+      "Uses HTTPS": 2
     },
     {
       "Agency": "Department of Commerce",
@@ -6463,7 +6448,7 @@
       "Signature Algorithm": null,
       "Strict Transport Security (HSTS)": -1,
       "TLSv1.2": null,
-      "Uses HTTPS": -1
+      "Uses HTTPS": 0
     },
     {
       "Agency": "General Services Administration",
@@ -7352,7 +7337,7 @@
     },
     {
       "Agency": "The Legislative Branch (Congress)",
-      "Canonical": "http://gop.gov",
+      "Canonical": "http://www.gop.gov",
       "Domain": "gop.gov",
       "Enforces HTTPS": 0,
       "Forward Secrecy": null,
@@ -7678,7 +7663,7 @@
       "Signature Algorithm": "SHA256withRSA",
       "Strict Transport Security (HSTS)": 0,
       "TLSv1.2": true,
-      "Uses HTTPS": 1
+      "Uses HTTPS": 2
     },
     {
       "Agency": "Department of Energy",
@@ -7772,7 +7757,7 @@
     },
     {
       "Agency": "Department of Health And Human Services",
-      "Canonical": "http://healthdata.gov",
+      "Canonical": "http://www.healthdata.gov",
       "Domain": "healthdata.gov",
       "Enforces HTTPS": 0,
       "Forward Secrecy": null,
@@ -7789,16 +7774,16 @@
       "Agency": "Department of Health And Human Services",
       "Canonical": "http://healthfinder.gov",
       "Domain": "healthfinder.gov",
-      "Enforces HTTPS": 0,
-      "Forward Secrecy": null,
+      "Enforces HTTPS": 1,
+      "Forward Secrecy": 0,
       "HSTS max-age": null,
-      "RC4": null,
-      "SSL Labs Grade": -1,
-      "SSLv3": null,
-      "Signature Algorithm": null,
-      "Strict Transport Security (HSTS)": -1,
-      "TLSv1.2": null,
-      "Uses HTTPS": -1
+      "RC4": true,
+      "SSL Labs Grade": 0,
+      "SSLv3": true,
+      "Signature Algorithm": "SHA1withRSA",
+      "Strict Transport Security (HSTS)": 0,
+      "TLSv1.2": false,
+      "Uses HTTPS": 2
     },
     {
       "Agency": "Department of Health And Human Services",
@@ -7999,16 +7984,16 @@
       "Agency": "Department of Health And Human Services",
       "Canonical": "http://www.hhsoig.gov",
       "Domain": "hhsoig.gov",
-      "Enforces HTTPS": 0,
+      "Enforces HTTPS": 1,
       "Forward Secrecy": null,
       "HSTS max-age": null,
       "RC4": null,
       "SSL Labs Grade": -1,
       "SSLv3": null,
       "Signature Algorithm": null,
-      "Strict Transport Security (HSTS)": -1,
+      "Strict Transport Security (HSTS)": 0,
       "TLSv1.2": null,
-      "Uses HTTPS": -1
+      "Uses HTTPS": 1
     },
     {
       "Agency": "Department of Energy",
@@ -8290,7 +8275,7 @@
       "RC4": false,
       "SSL Labs Grade": 3,
       "SSLv3": false,
-      "Signature Algorithm": "SHA1withRSA",
+      "Signature Algorithm": "SHA256withRSA",
       "Strict Transport Security (HSTS)": 3,
       "TLSv1.2": true,
       "Uses HTTPS": 2
@@ -8449,16 +8434,16 @@
       "Agency": "Department of the Interior",
       "Canonical": "http://www.iat.gov",
       "Domain": "iat.gov",
-      "Enforces HTTPS": 0,
-      "Forward Secrecy": null,
+      "Enforces HTTPS": 1,
+      "Forward Secrecy": 0,
       "HSTS max-age": null,
-      "RC4": null,
-      "SSL Labs Grade": -1,
-      "SSLv3": null,
-      "Signature Algorithm": null,
-      "Strict Transport Security (HSTS)": -1,
-      "TLSv1.2": null,
-      "Uses HTTPS": -1
+      "RC4": false,
+      "SSL Labs Grade": 2,
+      "SSLv3": true,
+      "Signature Algorithm": "SHA1withRSA",
+      "Strict Transport Security (HSTS)": 0,
+      "TLSv1.2": false,
+      "Uses HTTPS": 2
     },
     {
       "Agency": "Department of State",
@@ -8938,7 +8923,7 @@
       "Signature Algorithm": "SHA256withRSA",
       "Strict Transport Security (HSTS)": 0,
       "TLSv1.2": true,
-      "Uses HTTPS": 1
+      "Uses HTTPS": 2
     },
     {
       "Agency": "United Stated Global Change Research Program",
@@ -9223,7 +9208,7 @@
       "Signature Algorithm": "SHA256withRSA",
       "Strict Transport Security (HSTS)": 0,
       "TLSv1.2": true,
-      "Uses HTTPS": 1
+      "Uses HTTPS": 2
     },
     {
       "Agency": "James Madison Memorial Fellowship Foundation",
@@ -9248,7 +9233,7 @@
       "Forward Secrecy": 0,
       "HSTS max-age": null,
       "RC4": false,
-      "SSL Labs Grade": 1,
+      "SSL Labs Grade": 0,
       "SSLv3": false,
       "Signature Algorithm": "SHA1withRSA",
       "Strict Transport Security (HSTS)": 0,
@@ -9362,18 +9347,18 @@
     },
     {
       "Agency": "Department of Labor",
-      "Canonical": "http://www.jobcorps.gov",
+      "Canonical": "http://jobcorps.gov",
       "Domain": "jobcorps.gov",
-      "Enforces HTTPS": 0,
-      "Forward Secrecy": null,
+      "Enforces HTTPS": 1,
+      "Forward Secrecy": 0,
       "HSTS max-age": null,
-      "RC4": null,
-      "SSL Labs Grade": -1,
-      "SSLv3": null,
-      "Signature Algorithm": null,
-      "Strict Transport Security (HSTS)": -1,
-      "TLSv1.2": null,
-      "Uses HTTPS": -1
+      "RC4": false,
+      "SSL Labs Grade": 2,
+      "SSLv3": false,
+      "Signature Algorithm": "SHA1withRSA",
+      "Strict Transport Security (HSTS)": 0,
+      "TLSv1.2": false,
+      "Uses HTTPS": 2
     },
     {
       "Agency": "Executive Office of the President",
@@ -9439,6 +9424,21 @@
       "Agency": "Department of Justice",
       "Canonical": "http://juvenilecouncil.gov",
       "Domain": "juvenilecouncil.gov",
+      "Enforces HTTPS": 0,
+      "Forward Secrecy": null,
+      "HSTS max-age": null,
+      "RC4": null,
+      "SSL Labs Grade": -1,
+      "SSLv3": null,
+      "Signature Algorithm": null,
+      "Strict Transport Security (HSTS)": -1,
+      "TLSv1.2": null,
+      "Uses HTTPS": -1
+    },
+    {
+      "Agency": "Comm for People Who Are Blind/Severly Disabled",
+      "Canonical": "http://jwod.gov",
+      "Domain": "jwod.gov",
       "Enforces HTTPS": 0,
       "Forward Secrecy": null,
       "HSTS max-age": null,
@@ -9593,11 +9593,11 @@
       "Forward Secrecy": 1,
       "HSTS max-age": null,
       "RC4": false,
-      "SSL Labs Grade": 2,
+      "SSL Labs Grade": 4,
       "SSLv3": false,
       "Signature Algorithm": "SHA1withRSA",
       "Strict Transport Security (HSTS)": 0,
-      "TLSv1.2": false,
+      "TLSv1.2": true,
       "Uses HTTPS": 2
     },
     {
@@ -10339,16 +10339,16 @@
       "Agency": "Department of Health And Human Services",
       "Canonical": "http://medicare.gov",
       "Domain": "medicare.gov",
-      "Enforces HTTPS": 1,
-      "Forward Secrecy": 0,
+      "Enforces HTTPS": 0,
+      "Forward Secrecy": null,
       "HSTS max-age": null,
-      "RC4": false,
-      "SSL Labs Grade": 4,
-      "SSLv3": false,
-      "Signature Algorithm": "SHA256withRSA",
-      "Strict Transport Security (HSTS)": 0,
-      "TLSv1.2": true,
-      "Uses HTTPS": 2
+      "RC4": null,
+      "SSL Labs Grade": -1,
+      "SSLv3": null,
+      "Signature Algorithm": null,
+      "Strict Transport Security (HSTS)": -1,
+      "TLSv1.2": null,
+      "Uses HTTPS": -1
     },
     {
       "Agency": "Department of Health And Human Services",
@@ -10516,6 +10516,21 @@
       "Uses HTTPS": -1
     },
     {
+      "Agency": "Department of Defense",
+      "Canonical": "https://mojavedata.gov",
+      "Domain": "mojavedata.gov",
+      "Enforces HTTPS": 3,
+      "Forward Secrecy": null,
+      "HSTS max-age": null,
+      "RC4": null,
+      "SSL Labs Grade": -1,
+      "SSLv3": null,
+      "Signature Algorithm": null,
+      "Strict Transport Security (HSTS)": 0,
+      "TLSv1.2": null,
+      "Uses HTTPS": 1
+    },
+    {
       "Agency": "Department of the Treasury",
       "Canonical": "http://moneyfactory.gov",
       "Domain": "moneyfactory.gov",
@@ -10543,7 +10558,7 @@
       "Signature Algorithm": null,
       "Strict Transport Security (HSTS)": -1,
       "TLSv1.2": null,
-      "Uses HTTPS": -1
+      "Uses HTTPS": 0
     },
     {
       "Agency": "Department of the Interior",
@@ -10742,7 +10757,7 @@
     },
     {
       "Agency": "Department of the Treasury",
-      "Canonical": "http://www.myra.gov",
+      "Canonical": "https://myra.gov",
       "Domain": "myra.gov",
       "Enforces HTTPS": 3,
       "Forward Secrecy": 1,
@@ -10753,7 +10768,7 @@
       "Signature Algorithm": "SHA256withRSA",
       "Strict Transport Security (HSTS)": 0,
       "TLSv1.2": true,
-      "Uses HTTPS": 1
+      "Uses HTTPS": 2
     },
     {
       "Agency": "Department of Agriculture",
@@ -10909,16 +10924,16 @@
       "Agency": "Department of Health And Human Services",
       "Canonical": "http://www.nationalchildrensstudy.gov",
       "Domain": "nationalchildrensstudy.gov",
-      "Enforces HTTPS": 0,
-      "Forward Secrecy": null,
+      "Enforces HTTPS": 1,
+      "Forward Secrecy": 0,
       "HSTS max-age": null,
-      "RC4": null,
-      "SSL Labs Grade": -1,
-      "SSLv3": null,
-      "Signature Algorithm": null,
-      "Strict Transport Security (HSTS)": -1,
-      "TLSv1.2": null,
-      "Uses HTTPS": -1
+      "RC4": true,
+      "SSL Labs Grade": 2,
+      "SSLv3": true,
+      "Signature Algorithm": "SHA1withRSA",
+      "Strict Transport Security (HSTS)": 0,
+      "TLSv1.2": false,
+      "Uses HTTPS": 2
     },
     {
       "Agency": "Department of Justice",
@@ -11024,21 +11039,6 @@
       "Strict Transport Security (HSTS)": 0,
       "TLSv1.2": true,
       "Uses HTTPS": 2
-    },
-    {
-      "Agency": "Department of Education",
-      "Canonical": "http://www.nationsreportcard.gov",
-      "Domain": "nationsreportcard.gov",
-      "Enforces HTTPS": 0,
-      "Forward Secrecy": null,
-      "HSTS max-age": null,
-      "RC4": null,
-      "SSL Labs Grade": -1,
-      "SSLv3": null,
-      "Signature Algorithm": null,
-      "Strict Transport Security (HSTS)": -1,
-      "TLSv1.2": null,
-      "Uses HTTPS": -1
     },
     {
       "Agency": "Library of Congress",
@@ -11153,12 +11153,12 @@
       "Forward Secrecy": 0,
       "HSTS max-age": null,
       "RC4": false,
-      "SSL Labs Grade": 1,
+      "SSL Labs Grade": 2,
       "SSLv3": true,
       "Signature Algorithm": "SHA256withRSA",
       "Strict Transport Security (HSTS)": 0,
       "TLSv1.2": true,
-      "Uses HTTPS": 1
+      "Uses HTTPS": 2
     },
     {
       "Agency": "Department of Justice",
@@ -12977,7 +12977,7 @@
     },
     {
       "Agency": "General Services Administration",
-      "Canonical": "http://www.partner4solutions.gov",
+      "Canonical": "http://partner4solutions.gov",
       "Domain": "partner4solutions.gov",
       "Enforces HTTPS": 1,
       "Forward Secrecy": 1,
@@ -13015,10 +13015,10 @@
       "RC4": false,
       "SSL Labs Grade": 2,
       "SSLv3": true,
-      "Signature Algorithm": "SHA1withRSA",
+      "Signature Algorithm": "SHA256withRSA",
       "Strict Transport Security (HSTS)": 0,
       "TLSv1.2": true,
-      "Uses HTTPS": 1
+      "Uses HTTPS": 2
     },
     {
       "Agency": "Executive Office of the President",
@@ -13127,7 +13127,7 @@
     },
     {
       "Agency": "U. S. Peace Corps",
-      "Canonical": "http://peacecorp.gov",
+      "Canonical": "http://www.peacecorp.gov",
       "Domain": "peacecorp.gov",
       "Enforces HTTPS": 0,
       "Forward Secrecy": null,
@@ -13501,6 +13501,21 @@
       "Uses HTTPS": -1
     },
     {
+      "Agency": "Executive Office of the President",
+      "Canonical": "http://www.presidiotrust.gov",
+      "Domain": "presidiotrust.gov",
+      "Enforces HTTPS": 0,
+      "Forward Secrecy": null,
+      "HSTS max-age": null,
+      "RC4": null,
+      "SSL Labs Grade": -1,
+      "SSLv3": null,
+      "Signature Algorithm": null,
+      "Strict Transport Security (HSTS)": -1,
+      "TLSv1.2": null,
+      "Uses HTTPS": -1
+    },
+    {
       "Agency": "Court Services and Offender Supervision",
       "Canonical": "http://pretrialservices.gov",
       "Domain": "pretrialservices.gov",
@@ -13565,14 +13580,14 @@
       "Canonical": "http://www.protecciondelconsumidor.gov",
       "Domain": "protecciondelconsumidor.gov",
       "Enforces HTTPS": 1,
-      "Forward Secrecy": 0,
+      "Forward Secrecy": 1,
       "HSTS max-age": null,
-      "RC4": true,
-      "SSL Labs Grade": 3,
+      "RC4": false,
+      "SSL Labs Grade": 2,
       "SSLv3": false,
       "Signature Algorithm": "SHA256withRSA",
       "Strict Transport Security (HSTS)": 0,
-      "TLSv1.2": true,
+      "TLSv1.2": false,
       "Uses HTTPS": 2
     },
     {
@@ -14060,14 +14075,14 @@
       "Canonical": "http://restorethegulf.gov",
       "Domain": "restorethegulf.gov",
       "Enforces HTTPS": 1,
-      "Forward Secrecy": null,
+      "Forward Secrecy": 1,
       "HSTS max-age": null,
-      "RC4": null,
-      "SSL Labs Grade": -1,
-      "SSLv3": null,
-      "Signature Algorithm": null,
+      "RC4": false,
+      "SSL Labs Grade": 2,
+      "SSLv3": false,
+      "Signature Algorithm": "SHA256withRSA",
       "Strict Transport Security (HSTS)": 0,
-      "TLSv1.2": null,
+      "TLSv1.2": false,
       "Uses HTTPS": 2
     },
     {
@@ -14134,16 +14149,16 @@
       "Agency": "Department of the Interior",
       "Canonical": "http://www.safecom.gov",
       "Domain": "safecom.gov",
-      "Enforces HTTPS": 0,
-      "Forward Secrecy": null,
+      "Enforces HTTPS": 1,
+      "Forward Secrecy": 0,
       "HSTS max-age": null,
-      "RC4": null,
-      "SSL Labs Grade": -1,
-      "SSLv3": null,
-      "Signature Algorithm": null,
-      "Strict Transport Security (HSTS)": -1,
-      "TLSv1.2": null,
-      "Uses HTTPS": -1
+      "RC4": false,
+      "SSL Labs Grade": 2,
+      "SSLv3": true,
+      "Signature Algorithm": "SHA1withRSA",
+      "Strict Transport Security (HSTS)": 0,
+      "TLSv1.2": false,
+      "Uses HTTPS": 2
     },
     {
       "Agency": "Department of Homeland Security",
@@ -14222,18 +14237,18 @@
     },
     {
       "Agency": "Department of Homeland Security",
-      "Canonical": "http://www.safetyact.gov",
+      "Canonical": "https://safetyact.gov",
       "Domain": "safetyact.gov",
-      "Enforces HTTPS": 0,
-      "Forward Secrecy": null,
+      "Enforces HTTPS": 3,
+      "Forward Secrecy": 0,
       "HSTS max-age": null,
-      "RC4": null,
-      "SSL Labs Grade": -1,
-      "SSLv3": null,
-      "Signature Algorithm": null,
-      "Strict Transport Security (HSTS)": -1,
-      "TLSv1.2": null,
-      "Uses HTTPS": -1
+      "RC4": true,
+      "SSL Labs Grade": 1,
+      "SSLv3": true,
+      "Signature Algorithm": "SHA256withRSA",
+      "Strict Transport Security (HSTS)": 0,
+      "TLSv1.2": false,
+      "Uses HTTPS": 1
     },
     {
       "Agency": "U.S. Chemical Safety and Hazard Investigation Board",
@@ -14293,7 +14308,7 @@
       "Signature Algorithm": "SHA1withRSA",
       "Strict Transport Security (HSTS)": 0,
       "TLSv1.2": false,
-      "Uses HTTPS": 1
+      "Uses HTTPS": 2
     },
     {
       "Agency": "Department of Health And Human Services",
@@ -14402,33 +14417,33 @@
     },
     {
       "Agency": "Small Business Administration",
-      "Canonical": "https://www.sba.gov",
+      "Canonical": "http://www.sba.gov",
       "Domain": "sba.gov",
-      "Enforces HTTPS": 3,
-      "Forward Secrecy": 0,
+      "Enforces HTTPS": 0,
+      "Forward Secrecy": null,
       "HSTS max-age": null,
-      "RC4": false,
-      "SSL Labs Grade": 2,
-      "SSLv3": false,
-      "Signature Algorithm": "SHA256withRSA",
-      "Strict Transport Security (HSTS)": 0,
-      "TLSv1.2": false,
-      "Uses HTTPS": 2
+      "RC4": null,
+      "SSL Labs Grade": -1,
+      "SSLv3": null,
+      "Signature Algorithm": null,
+      "Strict Transport Security (HSTS)": -1,
+      "TLSv1.2": null,
+      "Uses HTTPS": -1
     },
     {
       "Agency": "National Science Foundation",
-      "Canonical": "https://www.sbir.gov",
+      "Canonical": "http://www.sbir.gov",
       "Domain": "sbir.gov",
-      "Enforces HTTPS": 3,
-      "Forward Secrecy": 0,
+      "Enforces HTTPS": 0,
+      "Forward Secrecy": null,
       "HSTS max-age": null,
-      "RC4": false,
-      "SSL Labs Grade": 2,
-      "SSLv3": false,
-      "Signature Algorithm": "SHA256withRSA",
-      "Strict Transport Security (HSTS)": 0,
-      "TLSv1.2": false,
-      "Uses HTTPS": 2
+      "RC4": null,
+      "SSL Labs Grade": -1,
+      "SSLv3": null,
+      "Signature Algorithm": null,
+      "Strict Transport Security (HSTS)": -1,
+      "TLSv1.2": null,
+      "Uses HTTPS": -1
     },
     {
       "Agency": "Department of Energy",
@@ -14659,16 +14674,16 @@
       "Agency": "The Legislative Branch (Congress)",
       "Canonical": "http://www.senate.gov",
       "Domain": "senate.gov",
-      "Enforces HTTPS": 0,
-      "Forward Secrecy": null,
+      "Enforces HTTPS": 1,
+      "Forward Secrecy": 0,
       "HSTS max-age": null,
-      "RC4": null,
-      "SSL Labs Grade": -1,
-      "SSLv3": null,
-      "Signature Algorithm": null,
-      "Strict Transport Security (HSTS)": -1,
-      "TLSv1.2": null,
-      "Uses HTTPS": 0
+      "RC4": true,
+      "SSL Labs Grade": 3,
+      "SSLv3": false,
+      "Signature Algorithm": "SHA1withRSA",
+      "Strict Transport Security (HSTS)": 0,
+      "TLSv1.2": true,
+      "Uses HTTPS": 2
     },
     {
       "Agency": "Government Printing Office",
@@ -15109,16 +15124,16 @@
       "Agency": "Selective Service System",
       "Canonical": "http://www.sss.gov",
       "Domain": "sss.gov",
-      "Enforces HTTPS": 1,
-      "Forward Secrecy": 0,
+      "Enforces HTTPS": 0,
+      "Forward Secrecy": null,
       "HSTS max-age": null,
-      "RC4": true,
-      "SSL Labs Grade": 2,
-      "SSLv3": true,
-      "Signature Algorithm": "SHA256withRSA",
-      "Strict Transport Security (HSTS)": 0,
-      "TLSv1.2": true,
-      "Uses HTTPS": 1
+      "RC4": null,
+      "SSL Labs Grade": -1,
+      "SSLv3": null,
+      "Signature Algorithm": null,
+      "Strict Transport Security (HSTS)": -1,
+      "TLSv1.2": null,
+      "Uses HTTPS": 0
     },
     {
       "Agency": "Department of Commerce",
@@ -15823,7 +15838,7 @@
       "Signature Algorithm": "SHA256withRSA",
       "Strict Transport Security (HSTS)": 0,
       "TLSv1.2": true,
-      "Uses HTTPS": 1
+      "Uses HTTPS": 2
     },
     {
       "Agency": "Department of the Treasury",
@@ -16007,7 +16022,7 @@
     },
     {
       "Agency": "Department of Defense",
-      "Canonical": "http://tswg.gov",
+      "Canonical": "http://www.tswg.gov",
       "Domain": "tswg.gov",
       "Enforces HTTPS": 0,
       "Forward Secrecy": null,
@@ -16318,7 +16333,7 @@
       "Signature Algorithm": null,
       "Strict Transport Security (HSTS)": -1,
       "TLSv1.2": null,
-      "Uses HTTPS": -1
+      "Uses HTTPS": 0
     },
     {
       "Agency": "U.S. Agency for International Development",
@@ -16384,16 +16399,16 @@
       "Agency": "National Science Foundation",
       "Canonical": "http://usap.gov",
       "Domain": "usap.gov",
-      "Enforces HTTPS": 0,
-      "Forward Secrecy": null,
+      "Enforces HTTPS": 1,
+      "Forward Secrecy": 0,
       "HSTS max-age": null,
-      "RC4": null,
-      "SSL Labs Grade": -1,
-      "SSLv3": null,
-      "Signature Algorithm": null,
-      "Strict Transport Security (HSTS)": -1,
-      "TLSv1.2": null,
-      "Uses HTTPS": -1
+      "RC4": true,
+      "SSL Labs Grade": 2,
+      "SSLv3": true,
+      "Signature Algorithm": "SHA1withRSA",
+      "Strict Transport Security (HSTS)": 0,
+      "TLSv1.2": false,
+      "Uses HTTPS": 2
     },
     {
       "Agency": "General Services Administration",
@@ -17031,7 +17046,7 @@
       "Domain": "uspis.gov",
       "Enforces HTTPS": 0,
       "Forward Secrecy": null,
-      "HSTS max-age": null,
+      "HSTS max-age": 1296000,
       "RC4": null,
       "SSL Labs Grade": -1,
       "SSLv3": null,
@@ -17134,16 +17149,16 @@
       "Agency": "U.S. Trade and Development Agency",
       "Canonical": "http://ustda.gov",
       "Domain": "ustda.gov",
-      "Enforces HTTPS": 0,
-      "Forward Secrecy": null,
+      "Enforces HTTPS": 1,
+      "Forward Secrecy": 0,
       "HSTS max-age": null,
-      "RC4": null,
-      "SSL Labs Grade": -1,
-      "SSLv3": null,
-      "Signature Algorithm": null,
-      "Strict Transport Security (HSTS)": -1,
-      "TLSv1.2": null,
-      "Uses HTTPS": -1
+      "RC4": true,
+      "SSL Labs Grade": 0,
+      "SSLv3": true,
+      "Signature Algorithm": "SHA256withRSA",
+      "Strict Transport Security (HSTS)": 0,
+      "TLSv1.2": false,
+      "Uses HTTPS": 1
     },
     {
       "Agency": "Executive Office of the President",
@@ -17601,12 +17616,12 @@
       "Domain": "whitehouse.gov",
       "Enforces HTTPS": 3,
       "Forward Secrecy": 2,
-      "HSTS max-age": 3600,
+      "HSTS max-age": 31536000,
       "RC4": false,
       "SSL Labs Grade": 5,
       "SSLv3": false,
       "Signature Algorithm": "SHA256withRSA",
-      "Strict Transport Security (HSTS)": 0,
+      "Strict Transport Security (HSTS)": 2,
       "TLSv1.2": true,
       "Uses HTTPS": 2
     },

--- a/data/meta.json
+++ b/data/meta.json
@@ -1,0 +1,5 @@
+{
+  "command": "./scan ../data/federal-2015-03-15.csv --scan=inspect,tls,analytics --analytics=../data/dap-2015-05-29.csv --debug --output=../reports/federal-2015-06-07",
+  "end_time": "2015-06-09T18:52:41Z",
+  "start_time": "2015-06-09T18:52:33Z"
+}


### PR DESCRIPTION
This data update goes from a scan on **May 29, 2015** to a scan on **June 7, 2015**. (There's another scan in progress now, but I'd like to get this merged so we can see granular differences.)

The DAP data has not changed here (and won't be changing in future updates until DAP speeds up its export process). 

The HTTPS number goes up from **31%** to **32%**. A couple notable things:

* sba.gov and sbir.gov are now unreachable by cURL with default options, they get an "Unknown SSL protocol error". SSL Labs doesn't get blocked in the same way, but indicates they both only support TLSv1.0. When I try cURL with `--tlsv1.0`, I can get through to both sites. When I try it with no options, or with `--tlsv1.2`, I get the same unknown error. I think something changed on those domains over that week, for the worst, so they're now marked as not using HTTPS because our scanners can't connect properly. I'm comfortable pushing that back over to them to fix/
* 5 domains went from having good chains to bad chains, and 19 domains went from having bad chains to good chains (including `pay.gov`).

**Use HTTPS:**

* 2015-06-07 - 371 use HTTPS **/** 1192 total - **31.1%**
* 2015-06-07 - 381 use HTTPS **/** 1194 total - **31.9%**
