### PR TITLE
Fix HTTPS and DAP links in About page

### DIFF
--- a/pages/about.html
+++ b/pages/about.html
@@ -55,7 +55,7 @@ description: "Frequently asked questions and information on what it Pulse measur
 					What does Pulse measure about federal domains?
 				</h3>
 				<p>
-					The first two best practices Pulse is measuring are the use of <a href="/https/">HTTPS</a>, and participation in the federal government's <a href="/analytics/">Digital Analytics Program</a>.
+					The first two best practices Pulse is measuring are the use of <a href="/https/domains/">HTTPS</a>, and participation in the federal government's <a href="/analytics/domains/">Digital Analytics Program</a>.
 				</p>
 			</li>
 


### PR DESCRIPTION
Currently they 403 due to a missing `/domains/` path component.