### PR TITLE
Deploy hotfixed scan date to production

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -14,7 +14,7 @@ data:
   # The export date for the DAP participating sub/domain list.
   dap: 2015-05-29
   # The scan date for HTTP/TLS data.
-  scan: 2015-06-13
+  scan: 2015-06-26
 
 # Markdown configuration.
 highlighter: rouge


### PR DESCRIPTION
I neglected to manually update `_config.yml` with the scan date. I hotfixed it on `master` and this deploys it to production.

An idea for future work: during the `./update` process, use the (now-versioned) `meta.json` file to automatically update `_config.yml` with the scan date.