### PR TITLE
Add everykidinapark.gov

### DIFF
--- a/data/domains.csv
+++ b/data/domains.csv
@@ -1,5 +1,6 @@
 Domain Name,Domain Type,Agency,City,State
 18F.GOV,Federal Agency,General Services Administration,Washington,DC
+EVERYKIDINAPARK.GOV,Federal Agency,Department of the Interior,Washington,DC
 ACUS.GOV,Federal Agency,Administrative Conference of the United States,WASHINGTON,DC
 ACHP.GOV,Federal Agency,Advisory Council on Historic Preservation,Washington,DC
 PRESERVEAMERICA.GOV,Federal Agency,Advisory Council on Historic Preservation,Washington,DC


### PR DESCRIPTION
This manually adds [everykidinapark.gov](https://everykidinapark.gov/), which launched last week. We're still waiting on a formal update from the .gov team, so I'm adding this one by hand until we get a new one.

@khandelwal, would you mind pinging us if/when `everykid.gov` goes live?