### PR TITLE
Add cloud.gov, pif.gov, presidentialinnovationfellows.gov

### DIFF
--- a/data/domains.csv
+++ b/data/domains.csv
@@ -1,5 +1,8 @@
 Domain Name,Domain Type,Agency,City,State
 18F.GOV,Federal Agency,General Services Administration,Washington,DC
+CLOUD.GOV,Federal Agency,General Services Administration,Washington,DC
+PIF.GOV,Federal Agency,General Services Administration,Washington,DC
+PRESIDENTIALINNOVATIONFELLOWS.GOV,Federal Agency,General Services Administration,Washington,DC
 EVERYKIDINAPARK.GOV,Federal Agency,Department of the Interior,Washington,DC
 SBST.GOV,Federal Agency,General Services Administration,Washington,DC
 ACUS.GOV,Federal Agency,Administrative Conference of the United States,WASHINGTON,DC


### PR DESCRIPTION
Starting next week, 3 new domains (all held by GSA) are added to the list. We haven't gotten an official update to the second-level domain list in quite some time, so I'm doing these by hand.