### PR TITLE
Proper deployment for a Python app through fabric

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,12 @@ css ?= static/css/main.css
 
 all: styles
 
+staging:
+	cd deploy/ && fab deploy && cd ..
+
+production:
+	cd deploy/ && fab deploy --set environment=production && cd ..
+
 run:
 	python pulse.py
 

--- a/README.md
+++ b/README.md
@@ -30,6 +30,28 @@ make run
 make watch
 ```
 
+## Deploying the site
+
+The site can be easily deployed (by someone with credentials to the right server) through [Fabric](https://github.com/fabric/fabric), which requires Python 2.
+
+The Fabric script will expect a defined `ssh` configuration called `pulse`, which you should already have defined in your SSH configuration with the right hostname and key.
+
+To deploy to staging, switch to a Python 2 virtualenv with `fabric` installed, and run:
+
+```
+make staging
+```
+
+This will `cd` into `deploy/` and run `fab deploy`.
+
+To deploy to production, activate Python 2 and `fabric` and run:
+
+```
+make production
+```
+
+This will run the fabric command to deploy to production.
+
 ## Updating the data in Pulse
 
 Updating Pulse is a multi-step process that combines data published by government offices with data scanned from the public internet.

--- a/deploy/fabfile.py
+++ b/deploy/fabfile.py
@@ -1,43 +1,123 @@
 import time
-from fabric.api import run, execute, env, cd
+from fabric.api import run, execute, env
 
-"""
-Manage auto-deploy webhooks remotely.
+# Will default to staging, override with "fab [command] --set environment=production"
 
-Production hook:
-
-  forever start -l $HOME/pulse/hookshot.log -a deploy/hookshot.js -p 5000 -b production -c "cd $HOME/pulse/production/current && git pull && bundle exec jekyll build >> $HOME/pulse/hookshot.log"
-  forever restart deploy/hookshot.js -p 5000 -b production -c "cd $HOME/pulse/production/current && git pull && bundle exec jekyll build >> $HOME/pulse/hookshot.log"
-  forever stop deploy/hookshot.js -p 5000 -b production -c "cd $HOME/pulse/production/current && git pull && bundle exec jekyll build >> $HOME/pulse/hookshot.log"
-"""
-
-environment = "production"
-branch = "production"
-port = 5000
+environment = env.get('environment', None)
 
 env.use_ssh_config = True
+env.hosts = ["site@pulse"]
 
-home = "/home/site/pulse"
-log = "%s/hookshot.log" % home
-current = "%s/%s/current" % (home, environment)
+repo = "https://github.com/18F/pulse"
 
-# principal command to run upon update
-command = "cd %s && git pull && bundle exec jekyll build >> %s" % (current, log)
+if environment == "production":
+  branch = "production"
+  port = 3000
+else:
+  environment = "staging"
+  branch = "deployment"
+  port = 6000
+
+home = "/home/site/pulse/%s" % environment
+shared_path = "%s/shared" % home
+versions_path = "%s/versions" % home
+version_path = "%s/%s" % (versions_path, time.strftime("%Y%m%d%H%M%S"))
+current_path = "%s/current" % home
+
+virtualenv = "pulse-%s" % environment
+
+pid_file = "%s/gunicorn.pid" % shared_path
+log_file = "%s/gunicorn.log" % shared_path
+
+wsgi = "pulse:app"
+
+# Keep the last 5 deployed versions around for easy rollback.
+keep = 5
+
+
+def checkout():
+  run('git clone -q -b %s %s %s' % (branch, repo, version_path))
+
+def dependencies():
+  run('cd %s && workon %s && pip install -r requirements.txt' % (version_path, virtualenv))
+
+def make_current():
+  run('rm -f %s && ln -s %s %s' % (current_path, version_path, current_path))
+
+def cleanup():
+  versions = run("ls -x %s" % versions_path).split()
+  destroy = versions[:-keep]
+
+  for version in destroy:
+    command = "rm -rf %s/%s" % (versions_path, version)
+    run(command)
+
+
+## can be run on their own
 
 def start():
   run(
-    "cd %s && forever start -l %s -a deploy/hookshot.js -p %i -b %s -c \"%s\""
-    % (current, log, port, branch, command)
+    (
+      "cd %s && PORT=%i gunicorn %s -D --log-file=%s --pid %s"
+    ) % (current_path, port, wsgi, log_file, pid_file), pty=False
   )
 
 def stop():
-  run(
-    "cd %s && forever stop deploy/hookshot.js -p %i -b %s -c \"%s\""
-    % (current, port, branch, command)
-  )
+  run("kill `cat %s`" % pid_file)
 
 def restart():
-  run(
-    "cd %s && forever restart deploy/hookshot.js -p %i -b %s -c \"%s\""
-    % (current, port, branch, command)
-  )
+  run("kill -HUP `cat %s`" % pid_file)
+
+
+def deploy():
+  execute(checkout)
+  execute(dependencies)
+  execute(make_current)
+  execute(restart)
+  execute(cleanup)
+
+
+
+# import time
+# from fabric.api import run, execute, env, cd
+
+# """
+# Manage auto-deploy webhooks remotely.
+
+# Production hook:
+
+#   forever start -l $HOME/pulse/hookshot.log -a deploy/hookshot.js -p 5000 -b production -c "cd $HOME/pulse/production/current && git pull && bundle exec jekyll build >> $HOME/pulse/hookshot.log"
+#   forever restart deploy/hookshot.js -p 5000 -b production -c "cd $HOME/pulse/production/current && git pull && bundle exec jekyll build >> $HOME/pulse/hookshot.log"
+#   forever stop deploy/hookshot.js -p 5000 -b production -c "cd $HOME/pulse/production/current && git pull && bundle exec jekyll build >> $HOME/pulse/hookshot.log"
+# """
+
+# environment = "production"
+# branch = "production"
+# port = 5000
+
+# env.use_ssh_config = True
+
+# home = "/home/site/pulse"
+# log = "%s/hookshot.log" % home
+# current = "%s/%s/current" % (home, environment)
+
+# # principal command to run upon update
+# command = "cd %s && git pull && bundle exec jekyll build >> %s" % (current, log)
+
+# def start():
+#   run(
+#     "cd %s && forever start -l %s -a deploy/hookshot.js -p %i -b %s -c \"%s\""
+#     % (current, log, port, branch, command)
+#   )
+
+# def stop():
+#   run(
+#     "cd %s && forever stop deploy/hookshot.js -p %i -b %s -c \"%s\""
+#     % (current, port, branch, command)
+#   )
+
+# def restart():
+#   run(
+#     "cd %s && forever restart deploy/hookshot.js -p %i -b %s -c \"%s\""
+#     % (current, port, branch, command)
+#   )

--- a/deploy/fabfile.py
+++ b/deploy/fabfile.py
@@ -15,7 +15,7 @@ if environment == "production":
   port = 3000
 else:
   environment = "staging"
-  branch = "deployment"
+  branch = "staging"
   port = 6000
 
 home = "/home/site/pulse/%s" % environment

--- a/deploy/pulse.conf
+++ b/deploy/pulse.conf
@@ -1,3 +1,12 @@
+# Ports:
+#
+# 3000: production app
+# 5000: production webhook
+# 6000: staging app
+# 7000: staging webhook
+#
+# 4000: https webhook
+
 # active development - lifecycle managed through fabric, primary server
 upstream production_pulse {
    server 127.0.0.1:3000;
@@ -40,7 +49,6 @@ server {
     expires 1w;
   }
 
-  # production hook runs on port 5000
   location /deploy {
     proxy_pass http://localhost:5000/;
     proxy_http_version 1.1;
@@ -107,7 +115,6 @@ server {
     expires 1w;
   }
 
-  # production hook runs on port 7000
   location /deploy {
     proxy_pass http://localhost:7000/;
     proxy_http_version 1.1;

--- a/deploy/pulse.conf
+++ b/deploy/pulse.conf
@@ -133,3 +133,9 @@ server {
     server_name staging.pulse.cio.gov;
     return 301 https://staging.pulse.cio.gov$request_uri;
 }
+
+server {
+    listen 80;
+    server_name pulse.cio.gov;
+    return 301 https://pulse.cio.gov$request_uri;
+}

--- a/templates/layout.html
+++ b/templates/layout.html
@@ -3,8 +3,6 @@
 
 <head>
 
-<!-- testing -->
-
 <!-- Title and meta description
 ================================================== -->
 <title>{% block title %}{% endblock %}</title>

--- a/templates/layout.html
+++ b/templates/layout.html
@@ -3,6 +3,8 @@
 
 <head>
 
+<!-- testing -->
+
 <!-- Title and meta description
 ================================================== -->
 <title>{% block title %}{% endblock %}</title>


### PR DESCRIPTION
This updates our deployment process to use fabric to properly deploy a dynamic gunicorn-based Python app. I've tested it and successfully deployed our staging and production apps with it.

To deploy to staging, go to the `deploy/` directory, have fabric ready in your `$PATH` somehow, and run:

```
fab deploy
```

To deploy to production, run:

```
fab deploy --set environment=production
```

For convenience, I've added `make staging` and `make production` commands from the project's root that will `cd` into `deploy/` and run the right command for you and `cd/` out. So you can actually just do:

```
make staging
```

and

```
make production
```

Since Fabric is (**_still_**) Python 2 only, I typically make a virtualenv locked to Python 2 just to hold `fabric`, called `fab`, and switch into it before deploying, like so:

```
workon fab
make production
```

This PR also documents the above in the README.