### PR TITLE
Manage and incorporate a list of ineligible DAP domains

### DIFF
--- a/data/ineligible/analytics.yml
+++ b/data/ineligible/analytics.yml
@@ -1,0 +1,1 @@
+- fdms.gov


### PR DESCRIPTION
This adds a list, with one starting member (`fdms.gov`), of domains ineligible for DAP participation. This list is versioned in the repo as `data/ineligible/analytics.yml`, and is a simple list of domains in YAML format. Any domain in this list will be excluded from DAP eligibility during data loading.