### PR TITLE
Fix sorting on agency percent bar columns for HTTPS

### DIFF
--- a/static/js/https/agencies.js
+++ b/static/js/https/agencies.js
@@ -6,11 +6,13 @@ $(document).ready(function () {
 
   var percentBar = function(field) {
     return function(data, type, row) {
-      if (type == "sort")
-        return null;
-      return Utils.progressBar(Utils.percent(
+      percent = Utils.percent(
         row.https[field], row.https.eligible
-      ));
+      );
+
+      if (type == "sort")
+        return percent;
+      return Utils.progressBar(percent);
     };
   }
 


### PR DESCRIPTION
This fixes the sorting function for columns listing percent status bars on the HTTPS page. 

I had already fixed this for DAP in 7df7b463dc27b6e43e3c64d1226ca50549dc8445, but apparently didn't think to port it to the HTTPS page.

Fixes #414.