### PR TITLE
Mobile menu tabindexes

### DIFF
--- a/static/js/main.js
+++ b/static/js/main.js
@@ -2,6 +2,14 @@ $(function(){
 
   $('#menu-btn, .overlay, .sliding-panel-close').on('click touchstart',function (e) {
     $('#menu-content, .overlay').toggleClass('is-visible');
+
+    if($('#menu-content').hasClass('is-visible')) {
+      $('#menu-content a').attr('tabindex', '0');
+    }
+    else {
+      $('#menu-content a').attr('tabindex', '-1');
+    }
+
     e.preventDefault();
   });
 

--- a/templates/includes/header.html
+++ b/templates/includes/header.html
@@ -33,18 +33,20 @@
 
   <nav id="menu-content" role="nav">
     <ul>
-      <li><a href="/">Home</a></li>
       <li>
-          <a href="/https/domains/">HTTPS</a>
+        <a tabindex="-1" href="/">Home</a>
       </li>
       <li>
-          <a href="/analytics/domains/">Analytics</a>
+          <a tabindex="-1" href="/https/domains/">HTTPS</a>
       </li>
       <li>
-          <a href="/about/">About</a>
+          <a tabindex="-1" href="/analytics/domains/">Analytics</a>
       </li>
       <li>
-          <a href="https://github.com/18f/pulse/issues">Feedback</a>
+          <a tabindex="-1" href="/about/">About</a>
+      </li>
+      <li>
+          <a tabindex="-1" href="https://github.com/18f/pulse/issues">Feedback</a>
       </li>
     </ul>
   </nav>


### PR DESCRIPTION
Set tabindexes to -1 on mobile menu items when the mobile menu is not open. When mobile menu is open, tabindexes are set to 0 to allow for tab through.

Fixes #436 