### PR TITLE
Anchor tag scroll on a11y page

### DIFF
--- a/static/js/accessibility/a11y.js
+++ b/static/js/accessibility/a11y.js
@@ -41,6 +41,13 @@ $(document).ready(function () {
       $element.html('No results found for ' + domain);
     }
 
+  }).done(function () {
+
+    // if url hash present, scroll to div
+    if (window.location.hash) {
+      $('html, body').scrollTop(parseInt($(location.hash).offset().top));
+    }
+
   });
 
 });


### PR DESCRIPTION
A11y pages with a url hash will load with the error div scrolled to the top:

<img width="1012" alt="screen shot 2016-05-31 at 11 26 27 am" src="https://cloud.githubusercontent.com/assets/24054/15685862/94755ff6-2722-11e6-9134-01cac4cb291c.png">

Fixes #416