### PR TITLE
Use new .gov domains (with permalink)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 How the .gov domain space is doing at best practices and federal requirements.
 
-Other forks of the project in use include:  
+Other forks of the project in use include:
 
 * https://nrkbeta.no/https-norge/
 * https://https.jetzt
@@ -29,6 +29,14 @@ gem install sass bourbon neat bitters
 ```bash
 make watch
 ```
+
+* And to run the app in development, use:
+
+```bash
+make debug
+```
+
+This will run the app with `DEBUG` mode on, showing full error messages in-browser when they occur.
 
 ### Initializing dataset
 

--- a/meta.yml
+++ b/meta.yml
@@ -7,10 +7,10 @@ name: Pulse
 title: "The pulse of the federal .gov space"
 description: "How federal government domains are meeting best practices on the web."
 
-# When the data we used was generated. Manually updated for now.
+# Data source URLs. They shouldn't require manual updates.
 data:
   # URL where we download the .gov domain list from.
-  domains_url: https://raw.githubusercontent.com/GSA/data/gh-pages/dotgov-domains/2016-01-19-federal.csv
+  domains_url: https://raw.githubusercontent.com/GSA/data/gh-pages/dotgov-domains/current-full.csv
 
   # URL where we download the participating DAP .gov list from.
   analytics_url: https://analytics.usa.gov/data/live/second-level-domains.csv


### PR DESCRIPTION
Uses the new consistent permalink to the latest .gov domains added in https://github.com/GSA/data/pull/32, so that the date of the .gov domain export doesn't have to be manually maintained.

Adds the `make debug` command to the README.