### PR TITLE
Small improvements to production scanning and data archiving

### DIFF
--- a/app/views.py
+++ b/app/views.py
@@ -88,10 +88,10 @@ def register(app):
     # def a11ydomain(hostname=None):
     #   return render_template("a11y.html", domain=hostname)
 
-    # # Sanity-check RSS feed, shows the latest report.
-    # @app.route("/data/reports/feed/")
-    # def report_feed():
-    #     return render_template("feed.xml")
+    # Sanity-check RSS feed, shows the latest report.
+    @app.route("/data/reports/feed/")
+    def report_feed():
+        return render_template("feed.xml")
 
     # @app.route("/accessibility/domains/")
     # def accessibility_domains():

--- a/data/update.py
+++ b/data/update.py
@@ -39,6 +39,7 @@ DOMAINS = os.environ.get("DOMAINS", META["data"]["domains_url"])
 
 # post-processing and uploading information
 SCANNED_DATA = os.path.join(this_dir, "./output/scan/results")
+CACHE_DATA = os.path.join(this_dir, "./output/scan/cache")
 DB_DATA = os.path.join(this_dir, "./db.json")
 BUCKET_NAME = "pulse.cio.gov"
 
@@ -111,16 +112,22 @@ def run(options):
 # Upload the scan + processed data to /live/ and /archive/ locations by date.
 def upload(date):
   live_scanned = "s3://%s/live/scan/" % (BUCKET_NAME)
+  live_cached = "s3://%s/live/cache/" % (BUCKET_NAME)
   live_db = "s3://%s/live/db/" % (BUCKET_NAME)
   archive_scanned = "s3://%s/archive/%s/scan/" % (BUCKET_NAME, date)
+  archive_cached = "s3://%s/archive/%s/cache/" % (BUCKET_NAME, date)
   archive_db = "s3://%s/archive/%s/db/" % (BUCKET_NAME, date)
 
   acl = "--acl=public-read"
 
   shell_out(["aws", "s3", "sync", SCANNED_DATA, live_scanned, acl])
+  shell_out(["aws", "s3", "sync", CACHE_DATA, live_cached, acl])
   shell_out(["aws", "s3", "cp", DB_DATA, live_db, acl])
-  shell_out(["aws", "s3", "sync", SCANNED_DATA, archive_scanned, acl])
-  shell_out(["aws", "s3", "cp", DB_DATA, archive_db, acl])
+
+  # Ask S3 to do the copying, to save on time and bandwidth
+  shell_out(["aws", "s3", "sync", live_scanned, archive_scanned, acl])
+  shell_out(["aws", "s3", "sync", live_cached, archive_cached, acl])
+  shell_out(["aws", "s3", "cp", live_db, archive_db, acl])
 
 
 # Use domain-scan to scan .gov domains from the set domain URL.

--- a/data/update.py
+++ b/data/update.py
@@ -127,7 +127,7 @@ def upload(date):
   # Ask S3 to do the copying, to save on time and bandwidth
   shell_out(["aws", "s3", "sync", live_scanned, archive_scanned, acl])
   shell_out(["aws", "s3", "sync", live_cached, archive_cached, acl])
-  shell_out(["aws", "s3", "cp", live_db, archive_db, acl])
+  shell_out(["aws", "s3", "sync", live_db, archive_db, acl])
 
 
 # Use domain-scan to scan .gov domains from the set domain URL.

--- a/data/update.py
+++ b/data/update.py
@@ -45,7 +45,7 @@ BUCKET_NAME = "pulse.cio.gov"
 # domain-scan information
 SCAN_TARGET = os.path.join(this_dir, "./output/scan")
 SCAN_COMMAND = os.environ.get("DOMAIN_SCAN_PATH", None)
-SCANNERS = os.environ.get("SCANNERS", "inspect,tls,analytics,sslyze")
+SCANNERS = os.environ.get("SCANNERS", "inspect,analytics,sslyze,tls")
 ANALYTICS_URL = os.environ.get("ANALYTICS_URL", META["data"]["analytics_url"])
 
 # Options:


### PR DESCRIPTION
This updates the production scanning process to do a few new things:

* Saves the very detailed `cache/` data, which includes per-domain extended JSON data from each scan, alongside the other scan data.
* Tells Amazon S3 to sync from `live/` to `archive/` within S3 itself, rather than re-copying everything from disk to S3 to do so. This became more important once `cache/` was being synced, since that is a more expensive operation.
* Puts the `tls` (SSL Labs) scanner at the end, since it takes the longest. It's easier to see if anything goes wrong with the others if they happen first.
