### PR TITLE
Swap out site-inspector for pshtt

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,7 @@ update_development:
 data_init:
 	mkdir -p data/output/scan/results/
 	curl https://s3.amazonaws.com/pulse.cio.gov/live/scan/analytics.csv > data/output/scan/results/analytics.csv
-	curl https://s3.amazonaws.com/pulse.cio.gov/live/scan/inspect.csv > data/output/scan/results/inspect.csv
+	curl https://s3.amazonaws.com/pulse.cio.gov/live/scan/pshtt.csv > data/output/scan/results/pshtt.csv
 	curl https://s3.amazonaws.com/pulse.cio.gov/live/scan/tls.csv > data/output/scan/results/tls.csv
 	curl https://s3.amazonaws.com/pulse.cio.gov/live/scan/meta.json > data/output/scan/results/meta.json
 	curl https://s3.amazonaws.com/pulse.cio.gov/live/db/db.json > data/db.json

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ python -m data.update
 
 Download and set up `domain-scan` [from GitHub](https://github.com/18F/domain-scan).
 
-`domain-scan` in turn requires [`site-inspector`](https://rubygems.org/gems/site-inspector) **1.0.2** (not 2.0) and [`ssllabs-scan`](https://github.com/ssllabs/ssllabs-scan).
+`domain-scan` in turn requires [`pshtt`](https://github.com/dhs-ncat/pshtt) and [`ssllabs-scan`](https://github.com/ssllabs/ssllabs-scan). These currently both need to be cloned from GitHub and set up individually.
 
 Pulse requires you to set one environment variable:
 
@@ -92,7 +92,7 @@ Pulse requires you to set one environment variable:
 
 However, `domain-scan` may need you to set a couple others if the binaries it uses aren't on your path:
 
-* `SITE_INSPECTOR_PATH`: Path to the `site-inspector` binary.
+* `PSHTT_PATH`: Path to the `pshtt_cli` binary.
 * `SSLLABS_PATH`: Path to the `ssllabs-scan` binary.
 
 ### Configure the AWS CLI

--- a/data/update.py
+++ b/data/update.py
@@ -46,7 +46,7 @@ BUCKET_NAME = "pulse.cio.gov"
 # domain-scan information
 SCAN_TARGET = os.path.join(this_dir, "./output/scan")
 SCAN_COMMAND = os.environ.get("DOMAIN_SCAN_PATH", None)
-SCANNERS = os.environ.get("SCANNERS", "inspect,analytics,sslyze,tls")
+SCANNERS = os.environ.get("SCANNERS", "pshtt,analytics,sslyze,inspect,tls")
 ANALYTICS_URL = os.environ.get("ANALYTICS_URL", META["data"]["analytics_url"])
 
 # Options:

--- a/deploy/cron.sh
+++ b/deploy/cron.sh
@@ -3,6 +3,9 @@
 # Set the path to domain-scan.
 export DOMAIN_SCAN_PATH=/opt/scan/domain-scan/scan
 
+# Set the path to the pshtt CLI.
+export PSHTT_PATH=/opt/scan/pshtt/pshtt_cli
+
 # go to pulse environment home
 cd $HOME/pulse/$PULSE_ENV/current
 

--- a/templates/https/guide.html
+++ b/templates/https/guide.html
@@ -59,7 +59,7 @@
         </p>
 
         <p>
-          These measurements are performed using <a href="https://github.com/benbalter/site-inspector">open source</a> <a href="https://github.com/18F/domain-scan">tools</a> and the <a href="https://www.ssllabs.com">SSL Labs</a> <a href="https://github.com/ssllabs/ssllabs-scan/blob/stable/ssllabs-api-docs.md">API</a>.
+          These measurements are performed using <a href="https://github.com/dhs-ncats/pshtt">open source</a> <a href="https://github.com/18F/domain-scan">tools</a> and the <a href="https://www.ssllabs.com">SSL Labs</a> <a href="https://github.com/ssllabs/ssllabs-scan/blob/stable/ssllabs-api-docs.md">API</a>.
         </p>
 
       </article>


### PR DESCRIPTION
This is to the `production` branch, because the `staging` branch is in a state of flux while accessibility work is done. (I may soon do a "catch up" merge of `staging` into `production` and then re-hide the accessibility URLs, so that the branches don't get far afield.)

This uses @dhs-ncats' [`pshtt`](https://github.com/dhs-ncats/pshtt) tool for HTTP scanning. It's meant to be an (almost) drop-in replacement for `site-inspector`. However, it is a standalone tool that only does this one function, it is written in Python (2.X, [for now](https://github.com/dhs-ncats/pshtt/issues/4)), and sees use by others in the federal government.

There are no visible changes to the data, and this should result in nearly the same determination, though the README is different and I swapped out a link in the HTTPS guide page to link to `pshtt` instead.

While right now `site-inspector` and `pshtt` give nearly identical results, there are some differences. One example is that `pshtt` does not grant "HSTS Preload" status to domains which don't have the `include_subdomains` flag turned on in the Chrome HSTS preload list (e.g. `healthcare.gov`). This difference is currently obscured right now on display because Pulse won't display that a domain is preloaded unless it's preload-ready, but this will change in a near-term PR (since Chrome is now auto-removing domains that drop the header, like Firefox).

cc @garrettr @gbinal @h-m-f-t