### PR TITLE
Improve branch detection logic to keep up with .gov list

### DIFF
--- a/data/processing.py
+++ b/data/processing.py
@@ -640,11 +640,18 @@ def branch_for(agency):
     "Library of Congress",
     "The Legislative Branch (Congress)",
     "Government Printing Office",
-    "Congressional Office of Compliance"
+    "Government Publishing Office",
+    "Congressional Office of Compliance",
+    "Stennis Center for Public Service",
+    "U.S. Capitol Police"
   ]:
     return "legislative"
 
-  if agency in ["The Judicial Branch (Courts)"]:
+  if agency in [
+    "The Judicial Branch (Courts)",
+    "The Supreme Court",
+    "U.S Courts"
+  ]:
     return "judicial"
 
   if agency in ["Non-Federal Agency"]:


### PR DESCRIPTION
This fixes the detection of legislative and judical branch domains. This will remove legislative and judicial branch domains more effectively for scans where they are not eligible (such as DAP compliance).