### PR TITLE
Breaks out preloaded and HSTS columns

### DIFF
--- a/app/data.py
+++ b/app/data.py
@@ -14,6 +14,7 @@ LABELS = {
     'uses': 'Uses HTTPS',
     'enforces': 'Enforces HTTPS',
     'hsts': 'Strict Transport Security (HSTS)',
+    'preloaded': 'Preloaded (recommended)',
     'grade': 'SSL Labs Grade',
 
     'hsts_age': 'HSTS max-age',
@@ -48,19 +49,23 @@ FIELD_MAPPING = {
     },
 
     'enforces': {
-      0: "", # N/A (no HTTPS)
-      1: "No", # Present, not default
-      2: "Yes", # Defaults eventually to HTTPS
-      3: "Yes" # Defaults eventually + redirects immediately
+      0: "",  # N/A (no HTTPS)
+      1: "No",  # Present, not default
+      2: "Yes",  # Defaults eventually to HTTPS
+      3: "Yes"  # Defaults eventually + redirects immediately
     },
 
     'hsts': {
-      -1: "", # N/A
-      0: "No", # No
-      1: "Yes", # HSTS on only that domain
-      2: "Yes", # HSTS on subdomains
-      3: "Yes, and preload-ready", # HSTS on subdomains + preload flag
-      4: "Yes, and preloaded" # In the HSTS preload list
+      -1: "",  # N/A
+      0: "No",  # No
+      1: "No",  # No, HSTS with short max-age (for canonical endpoint)
+      2: "Yes",  # Yes, HSTS for >= 1 year (for canonical endpoint)
+    },
+
+    'preloaded': {
+      0: "No",  # No
+      1: "Ready for submission",  # Preload-ready
+      2: "Yes"  # Yes
     },
 
     'grade': {
@@ -85,6 +90,6 @@ FIELD_MAPPING = {
 
 CSV_FIELDS = {
   'common': ['domain', 'canonical', 'branch', 'agency_name', 'redirect'],
-  'https': ['uses',  'enforces', 'hsts', 'grade'],
+  'https': ['uses',  'enforces', 'hsts', 'preloaded', 'grade'],
   'analytics': ['participating']
 }

--- a/data/processing.py
+++ b/data/processing.py
@@ -320,8 +320,8 @@ def update_agency_totals():
       if report['enforces'] >= 2:
         agency_report['enforces'] += 1
 
-      # Needs to be at least partially present
-      if report['hsts'] >= 1:
+      # Needs to be present with >= 1 year max-age for canonical endpoint
+      if report['hsts'] >= 2:
         agency_report['hsts'] += 1
 
       # Needs to be A- or above
@@ -428,50 +428,36 @@ def https_report_for(domain_name, domain, scan_data):
 
   # Without HTTPS there can be no HSTS.
   if (https <= 0):
-    hsts = -1 # N/A (considered 'No')
+    hsts = -1  # N/A (considered 'No')
 
   else:
 
-    # HTTPS is there, but no HSTS header.
-    if (pshtt["HSTS"] == "False"):
-      hsts = 0 # No
+    # HSTS is present for the canonical endpoint.
+    if (pshtt["HSTS"] == "True"):
 
-    # HSTS preload ready already implies a minimum max-age, and
-    # may be fine on the root even if the canonical www is weak.
-    elif (pshtt["HSTS Preload Ready"] == "True"):
-
-      if pshtt["HSTS Preloaded"] == "True":
-        hsts = 4 # Yes, and preloaded
+      # Say No for too-short max-age's, and note in the extended details.
+      if hsts_age >= 31536000:
+        hsts = 2  # Yes
       else:
-        hsts = 3 # Yes, and preload-ready
-
-    # We'll make a judgment call here.
-    #
-    # The OMB policy wants a 1 year max-age (31536000).
-    # The HSTS preload list wants an 18 week max-age (10886400).
-    #
-    # We don't want to punish preload-ready domains that are between
-    # the two.
-    #
-    # So if you're below 18 weeks, that's a No.
-    # If you're between 18 weeks and 1 year, it's a Yes
-    # (but you'll get a warning in the extended text).
-    # 1 year and up is a yes.
-    elif (hsts_age < 10886400):
-      hsts = 0 # No, too weak
+        hsts = 1  # No
 
     else:
-      # This kind of "Partial" means `includeSubdomains`, but no `preload`.
-      if (pshtt["HSTS Entire Domain"] == "True"):
-        hsts = 2 # Yes
+      hsts = 0  # No
 
-      # This kind of "Partial" means HSTS, but not on subdomains.
-      else: # if (pshtt["HSTS"] == "True"):
-
-        hsts = 1 # Yes
+  # Separate preload status from HSTS status:
+  #
+  # * Domains can be preloaded through manual overrides.
+  # * Confusing to mix an endpoint-level decision with a domain-level decision.
+  if pshtt["HSTS Preloaded"] == "True":
+    preloaded = 2  # Yes
+  elif (pshtt["HSTS Preload Ready"] == "True"):
+    preloaded = 1  # Ready for submission
+  else:
+    preloaded = 0  # No
 
   report['hsts'] = hsts
   report['hsts_age'] = hsts_age
+  report['preloaded'] = preloaded
 
 
   ###
@@ -552,8 +538,8 @@ def latest_reports():
     if report['enforces'] >= 2:
       enforces += 1
 
-    # Needs to be at least partially present
-    if report['hsts'] >= 1:
+    # Needs to be present with >= 1 year max-age on canonical endpoint
+    if report['hsts'] >= 2:
       hsts += 1
 
   https_report = {

--- a/static/js/https/domains.js
+++ b/static/js/https/domains.js
@@ -31,11 +31,15 @@ $(document).ready(function () {
 
     hsts: {
       "-1": "", // N/A
-      0: "No", // No
-      1: "Yes", // HSTS on only that domain
-      2: "Yes", // HSTS on subdomains
-      3: "Yes, and preload-ready", // HSTS on subdomains + preload flag
-      4: "Yes, and preloaded" // In the HSTS preload list
+      0: "No",  // No
+      1: "No", // No, HSTS with short max-age (for canonical endpoint)
+      2: "Yes" // Yes, HSTS for >= 1 year (for canonical endpoint)
+    },
+
+    preloaded: {
+      0: "",  // No (don't display, since it's optional)
+      1: "Ready for submission",  // Preload-ready
+      2: "Yes"  // Yes
     },
 
     grade: {
@@ -95,25 +99,14 @@ $(document).ready(function () {
       else
         details = "This domain supports HTTPS, but does not enforce it. "
 
-      if (hsts == 0) {
-        // HSTS is considered a No *because* its max-age is too weak.
-        if ((hsts_age > 0) && (hsts_age < 10886400))
-          details += "The " + l("hsts", "HSTS") + " max-age (" + hsts_age + " seconds) is too short, and should be increased to at least 1 year (31536000 seconds).";
-        else
-          details += l("hsts", "HSTS") + " is not enabled.";
-      }
+      if (hsts == 0)
+        details += l("hsts", "HSTS") + " is not enabled.";
       else if (hsts == 1)
-        details += l("hsts", "HSTS") + " is enabled, but not for its subdomains and is not ready for " + l("preload", "preloading") + ".";
+        details += "The " + l("hsts", "HSTS") + " max-age (" + hsts_age + " seconds) is too short, and should be increased to at least 1 year (31536000 seconds).";
       else if (hsts == 2)
-        details += l("hsts", "HSTS") + " is enabled for all subdomains, but is not ready for " + l("preload", "preloading into browsers") + ".";
-      else if (hsts == 3)
-        details += l("hsts", "HSTS") + " is enabled for all subdomains, and can be " + l("preload", "preloaded into browsers") + ".";
-
-      // HSTS is strong enough to get a yes, but still less than a year.
-      if (hsts > 0 && (hsts_age < 31536000))
-        details += " The HSTS max-age (" + hsts_age + " seconds) should be increased to at least 1 year (31536000 seconds)."
-
-    } else if (https == 0)
+        details += l("hsts", "HSTS") + " is enabled.";
+    }
+    else if (https == 0)
       details = "This domain redirects visitors from HTTPS down to HTTP."
     else if (https == -1)
       details = "This domain does not support HTTPS."
@@ -212,6 +205,10 @@ $(document).ready(function () {
         {
           data: "https.hsts",
           render: display(names.hsts)
+        },
+        {
+          data: "https.preloaded",
+          render: display(names.preloaded)
         },
         {
           data: "https.grade",

--- a/templates/https/domains.html
+++ b/templates/https/domains.html
@@ -27,6 +27,7 @@
           <th class="min-tablet">Uses HTTPS</th>
           <th class="min-tablet">Enforces HTTPS</th>
           <th class="min-tablet-l">Strict Transport Security (HSTS)</th>
+          <th class="min-tablet-l">Preloaded (recommended)</th>
           <th class="min-tablet-l">SSL Labs Grade</th>
           <th class="none" scope="col">Details</th>
           <th class="none">TLS Issues</th>


### PR DESCRIPTION
This breaks out a domain's HSTS status and preloaded status. It looks like this:

![screenshot from 2016-08-21 21-31-40](https://cloud.githubusercontent.com/assets/4592/17841584/10159dbe-67e8-11e6-85f7-1bee06607e15.png)

And this:

![screenshot from 2016-08-21 21-32-23](https://cloud.githubusercontent.com/assets/4592/17841586/141a5e40-67e8-11e6-8b29-950d03f5b434.png)


This is for a few reasons:

* To call more attention to preloading, and a domain's lack of it (even though it's not required by M-15-13 [though it is [recommended](https://https.cio.gov/guide/#options-for-hsts-compliance)]).
* To call more attention to domains which are preload-ready, but not yet submitted. (This now says `Ready for submission` if it's ready to go.)
* HSTS is calculated on a per-endpoint basis, where preloading is necessarily a domain-wide calculation. They are measuring two different scopes, and mixing them is confusing.
* To allow for domains to be preloaded without actually being "preload ready". This would happen if the Chrome list makes a manual override, which could happen for several reasons. The Chrome list has about 25 of these right now, including `login.gov`.

This adds another column to the table, but it collapses on a narrow window just like the HSTS field does, so this shouldn't cause any issues.