### PR TITLE
Document the HSTS/preload field split

### DIFF
--- a/templates/https/guide.html
+++ b/templates/https/guide.html
@@ -82,12 +82,16 @@
 
         <ul>
           <li><strong>Strict Transport Security (HSTS)</strong></li>
-          <li><strong>Values:</strong> No, Yes, "Yes, and preload-ready", "Yes, and preloaded"</li>
+          <li><strong>Values:</strong> No, Yes</li>
           <li>Whether a domain has implemented <a href="https://https.cio.gov/hsts/">HTTP Strict Transport Security</a>, which ensures that <a href="http://caniuse.com/#search=hsts">supporting browsers</a> will only ever communicate with a domain over HTTPS (even if the user clicks or types in a plain HTTP link).</li>
-          <li>"Yes" means that a valid <code>Strict-Transport-Security</code> header with a non-zero <code>max-age</code> is present on the domain's default endpoint.</li>
-          <li>"Yes, and preload-ready" means that the domain has implemented a strong HSTS header on its <strong>bare domain</strong> whose policy covers all subdomains, and has indicated consent to <a href="https://hstspreload.appspot.com">preloading by all major browsers</a> as HTTPS-only.</li>
-          <li>"Yes, and preloaded" means that the domain is visibly preload-ready (meets the above criteria), <strong>and</strong> that the domain is actually in the publicly versioned <a href="https://chromium.googlesource.com/chromium/src/+/master/net/http/transport_security_state_static.json">Chrome preload list</a>. Reaching this step effectively means that a domain's namespace is permanently and fully committed to HTTPS.
-          </li>
+          <li>"Yes" means that a valid <code>Strict-Transport-Security</code> header with a <code>max-age</code> value (in seconds) of at least <strong>1 year</strong> (31536000) is present on the domain's default endpoint.</li>
+        </ul>
+
+        <ul>
+          <li><strong>Preloaded (recommended)</strong></li>
+          <li><strong>Values:</strong> Ready, Yes</li>
+          <li>"Ready" means that the domain has implemented a strong HSTS header on its <strong>bare domain</strong> whose policy covers all subdomains, and has indicated consent to <a href="https://hstspreload.appspot.com">preloading by all major browsers</a> as HTTPS-only.</li>
+          <li>"Yes" means that the domain is actually in the publicly versioned <a href="https://chromium.googlesource.com/chromium/src/+/master/net/http/transport_security_state_static.json">Chrome preload list</a>, and has the <code>include_subdomains</code> flag enabled in that list. Reaching this step effectively means that a domain's namespace is permanently and fully committed to HTTPS.</li>
         </ul>
 
         <ul>


### PR DESCRIPTION
Update the documentation at `/https/guidance/` to reflect the changes made in #517, where we split out HSTS and preloading into two separate fields and columns.