### PR TITLE
Fix sort order on HTTPS table

### DIFF
--- a/app/views.py
+++ b/app/views.py
@@ -28,6 +28,7 @@ def register(app):
     @app.route("/data/domains/<report_name>.<ext>")
     def domain_report(report_name, ext):
         domains = models.Domain.eligible(report_name)
+        domains = sorted(domains, key=lambda k: k['domain'])
 
         if ext == "json":
           response = Response(ujson.dumps({'data': domains}))

--- a/static/js/https/domains.js
+++ b/static/js/https/domains.js
@@ -57,7 +57,7 @@ $(document).ready(function () {
   var display = function(set) {
     return function(data, type, row) {
       if (type == "sort")
-        return data;
+        return data.toString();
       else
         return set[data.toString()];
     }


### PR DESCRIPTION
The HTTPS columns were getting sorted with the `0` values before the `-1` values, for reasons I don't totally understand. However, converting all values to strings before sorting fixes this, and makes more conceptual sense besides.