### PR TITLE
Fix landing page links to not use canonical URL for permalink

### DIFF
--- a/static/js/utils.js
+++ b/static/js/utils.js
@@ -54,7 +54,7 @@ var Utils = {
 
     $.each(data, function(key, value) {
       if (value) {
-        errorListOutput += "<li><a href=\"/accessibility/domain/" + row['canonical'].replace(/http:\/\//i, '') + "#" + key.replace(/\s/g, '').replace(/\//i, '') + "\" target=\"_blank\">" + key + ": " + value + "</a></li>";
+        errorListOutput += "<li><a href=\"/accessibility/domain/" + row['domain'].replace(/http:\/\//i, '') + "#" + key.replace(/\s/g, '').replace(/\//i, '') + "\" target=\"_blank\">" + key + ": " + value + "</a></li>";
       }
     });
 
@@ -75,7 +75,7 @@ var Utils = {
           if (e.keyCode == 13 || e.type == "click") {
             var expanded = $(this).attr('aria-expanded') != "true",
               toggleText = expanded ? "hide" : "show";
-            
+
             $(this).attr('aria-expanded', expanded);
             $(this).attr('aria-label','Select to ' + toggleText + ' additional details about ' + content);
             var self = this;
@@ -84,10 +84,10 @@ var Utils = {
                 $(self).closest('tr')
                   .next('tr.child')
                   .attr('tabindex', '-1')
-                  .focus();  
+                  .focus();
               }, 100)
             }
-            
+
           }
         })
     });


### PR DESCRIPTION
The error buttons were using the canonical URL instead of the domain to form permalinks, so it was going to `/accessibility/domain/www.data.gov` instead of `/accessibility/domain/data.gov`, which caused it to not be able to look up the data by domain in `a11y.json`.

This fixes the error buttons to always use the base domain. The canonical URL is only useful when forming links to the website itself. (Which clicking the domain link itself on the table does do.)