### PR TITLE
Addressing 'Agency' vs 'agency' bug

### DIFF
--- a/static/data/tables/accessibility/agencies.json
+++ b/static/data/tables/accessibility/agencies.json
@@ -6,7 +6,7 @@
       "Color Contrast Errors": 0,
       "Alt Tag Errors": 0,
       "pages_count": 1,
-      "Agency": "National Capital Planning Commission",
+      "agency": "National Capital Planning Commission",
       "HTML Attribute Errors": 0
     },
     {
@@ -15,7 +15,7 @@
       "Color Contrast Errors": 2.46,
       "Alt Tag Errors": 1.22,
       "pages_count": 54,
-      "Agency": "Department of Justice",
+      "agency": "Department of Justice",
       "HTML Attribute Errors": 0.69
     },
     {
@@ -24,7 +24,7 @@
       "Color Contrast Errors": 12,
       "Alt Tag Errors": 0,
       "pages_count": 1,
-      "Agency": "Council of Inspector General on Integrity and Efficiency",
+      "agency": "Council of Inspector General on Integrity and Efficiency",
       "HTML Attribute Errors": 8
     },
     {
@@ -33,7 +33,7 @@
       "Color Contrast Errors": 11.23,
       "Alt Tag Errors": 0.23,
       "pages_count": 13,
-      "Agency": "Office of Personnel Management",
+      "agency": "Office of Personnel Management",
       "HTML Attribute Errors": 0.85
     },
     {
@@ -42,7 +42,7 @@
       "Color Contrast Errors": 6.05,
       "Alt Tag Errors": 1.05,
       "pages_count": 21,
-      "Agency": "Department of Defense",
+      "agency": "Department of Defense",
       "HTML Attribute Errors": 2.38
     },
     {
@@ -51,7 +51,7 @@
       "Color Contrast Errors": 2,
       "Alt Tag Errors": 1,
       "pages_count": 1,
-      "Agency": "National Nanotechnology Coordination Office",
+      "agency": "National Nanotechnology Coordination Office",
       "HTML Attribute Errors": 1
     },
     {
@@ -60,7 +60,7 @@
       "Color Contrast Errors": 5,
       "Alt Tag Errors": 2,
       "pages_count": 1,
-      "Agency": "Millennium Challenge Corporation",
+      "agency": "Millennium Challenge Corporation",
       "HTML Attribute Errors": 1
     },
     {
@@ -69,7 +69,7 @@
       "Color Contrast Errors": 0,
       "Alt Tag Errors": 0,
       "pages_count": 1,
-      "Agency": "Armed Forces Retirement Home",
+      "agency": "Armed Forces Retirement Home",
       "HTML Attribute Errors": 0
     },
     {
@@ -78,7 +78,7 @@
       "Color Contrast Errors": 2,
       "Alt Tag Errors": 5,
       "pages_count": 1,
-      "Agency": "National Indian Gaming Commission",
+      "agency": "National Indian Gaming Commission",
       "HTML Attribute Errors": 8
     },
     {
@@ -87,7 +87,7 @@
       "Color Contrast Errors": 19,
       "Alt Tag Errors": 0,
       "pages_count": 1,
-      "Agency": "Marine Mammal Commission",
+      "agency": "Marine Mammal Commission",
       "HTML Attribute Errors": 1
     },
     {
@@ -96,7 +96,7 @@
       "Color Contrast Errors": 2.86,
       "Alt Tag Errors": 1.57,
       "pages_count": 63,
-      "Agency": "Department of the Interior",
+      "agency": "Department of the Interior",
       "HTML Attribute Errors": 0.9
     },
     {
@@ -105,7 +105,7 @@
       "Color Contrast Errors": 6,
       "Alt Tag Errors": 0,
       "pages_count": 1,
-      "Agency": "Federal Labor Relations Authority",
+      "agency": "Federal Labor Relations Authority",
       "HTML Attribute Errors": 1
     },
     {
@@ -114,7 +114,7 @@
       "Color Contrast Errors": 0,
       "Alt Tag Errors": 0,
       "pages_count": 3,
-      "Agency": "Department of Veterans Affairs",
+      "agency": "Department of Veterans Affairs",
       "HTML Attribute Errors": 0.67
     },
     {
@@ -123,7 +123,7 @@
       "Color Contrast Errors": 0,
       "Alt Tag Errors": 5,
       "pages_count": 2,
-      "Agency": "Federal Energy Regulatory Commission",
+      "agency": "Federal Energy Regulatory Commission",
       "HTML Attribute Errors": 1
     },
     {
@@ -132,7 +132,7 @@
       "Color Contrast Errors": 1,
       "Alt Tag Errors": 0,
       "pages_count": 1,
-      "Agency": "U. S. Office of Special Counsel",
+      "agency": "U. S. Office of Special Counsel",
       "HTML Attribute Errors": 1
     },
     {
@@ -141,7 +141,7 @@
       "Color Contrast Errors": 0,
       "Alt Tag Errors": 0,
       "pages_count": 2,
-      "Agency": "Farm Credit Administration",
+      "agency": "Farm Credit Administration",
       "HTML Attribute Errors": 0
     },
     {
@@ -150,7 +150,7 @@
       "Color Contrast Errors": 5.05,
       "Alt Tag Errors": 3.42,
       "pages_count": 19,
-      "Agency": "Department of State",
+      "agency": "Department of State",
       "HTML Attribute Errors": 1.79
     },
     {
@@ -159,7 +159,7 @@
       "Color Contrast Errors": 10,
       "Alt Tag Errors": 1,
       "pages_count": 1,
-      "Agency": "Harry S. Truman Scholarship Foundation",
+      "agency": "Harry S. Truman Scholarship Foundation",
       "HTML Attribute Errors": 1
     },
     {
@@ -168,7 +168,7 @@
       "Color Contrast Errors": 2,
       "Alt Tag Errors": 0,
       "pages_count": 1,
-      "Agency": "AMTRAK",
+      "agency": "AMTRAK",
       "HTML Attribute Errors": 2
     },
     {
@@ -177,7 +177,7 @@
       "Color Contrast Errors": 7.5,
       "Alt Tag Errors": 0,
       "pages_count": 4,
-      "Agency": "Court Services and Offender Supervision",
+      "agency": "Court Services and Offender Supervision",
       "HTML Attribute Errors": 5.25
     },
     {
@@ -186,7 +186,7 @@
       "Color Contrast Errors": 13,
       "Alt Tag Errors": 1,
       "pages_count": 1,
-      "Agency": "Postal Rate Commission",
+      "agency": "Postal Rate Commission",
       "HTML Attribute Errors": 1
     },
     {
@@ -195,7 +195,7 @@
       "Color Contrast Errors": 0,
       "Alt Tag Errors": 0,
       "pages_count": 1,
-      "Agency": "Inter-American Foundation",
+      "agency": "Inter-American Foundation",
       "HTML Attribute Errors": 0
     },
     {
@@ -204,7 +204,7 @@
       "Color Contrast Errors": 0,
       "Alt Tag Errors": 0,
       "pages_count": 1,
-      "Agency": "The United States World War One Centennial Commission",
+      "agency": "The United States World War One Centennial Commission",
       "HTML Attribute Errors": 0
     },
     {
@@ -213,7 +213,7 @@
       "Color Contrast Errors": 15.5,
       "Alt Tag Errors": 5.5,
       "pages_count": 2,
-      "Agency": "United Stated Global Change Research Program",
+      "agency": "United Stated Global Change Research Program",
       "HTML Attribute Errors": 1
     },
     {
@@ -222,7 +222,7 @@
       "Color Contrast Errors": 1.44,
       "Alt Tag Errors": 0.11,
       "pages_count": 9,
-      "Agency": "Environmental Protection Agency",
+      "agency": "Environmental Protection Agency",
       "HTML Attribute Errors": 0.44
     },
     {
@@ -231,7 +231,7 @@
       "Color Contrast Errors": 0,
       "Alt Tag Errors": 0,
       "pages_count": 1,
-      "Agency": "Administrative Conference of the United States",
+      "agency": "Administrative Conference of the United States",
       "HTML Attribute Errors": 5
     },
     {
@@ -240,7 +240,7 @@
       "Color Contrast Errors": 1.09,
       "Alt Tag Errors": 0.73,
       "pages_count": 11,
-      "Agency": "National Archives and Records Administration",
+      "agency": "National Archives and Records Administration",
       "HTML Attribute Errors": 1.55
     },
     {
@@ -249,7 +249,7 @@
       "Color Contrast Errors": 6.57,
       "Alt Tag Errors": 3.57,
       "pages_count": 7,
-      "Agency": "Corporation for National & Community Service",
+      "agency": "Corporation for National & Community Service",
       "HTML Attribute Errors": 2.57
     },
     {
@@ -258,7 +258,7 @@
       "Color Contrast Errors": 6,
       "Alt Tag Errors": 0,
       "pages_count": 1,
-      "Agency": "Overseas Private Investment Corporation",
+      "agency": "Overseas Private Investment Corporation",
       "HTML Attribute Errors": 5
     },
     {
@@ -267,7 +267,7 @@
       "Color Contrast Errors": 1,
       "Alt Tag Errors": 0,
       "pages_count": 1,
-      "Agency": "National Transportation Safety Board",
+      "agency": "National Transportation Safety Board",
       "HTML Attribute Errors": 3
     },
     {
@@ -276,7 +276,7 @@
       "Color Contrast Errors": 17,
       "Alt Tag Errors": 0,
       "pages_count": 1,
-      "Agency": "Federal Mine Safety and Health Review Company",
+      "agency": "Federal Mine Safety and Health Review Company",
       "HTML Attribute Errors": 1
     },
     {
@@ -285,7 +285,7 @@
       "Color Contrast Errors": 33,
       "Alt Tag Errors": 0,
       "pages_count": 1,
-      "Agency": "U. S. International Trade Commission",
+      "agency": "U. S. International Trade Commission",
       "HTML Attribute Errors": 6
     },
     {
@@ -294,7 +294,7 @@
       "Color Contrast Errors": 0,
       "Alt Tag Errors": 0,
       "pages_count": 1,
-      "Agency": "U. S. Access Board",
+      "agency": "U. S. Access Board",
       "HTML Attribute Errors": 0
     },
     {
@@ -303,7 +303,7 @@
       "Color Contrast Errors": 0.5,
       "Alt Tag Errors": 3.5,
       "pages_count": 2,
-      "Agency": "National Credit Union Administration",
+      "agency": "National Credit Union Administration",
       "HTML Attribute Errors": 1
     },
     {
@@ -312,7 +312,7 @@
       "Color Contrast Errors": 8.5,
       "Alt Tag Errors": 0.5,
       "pages_count": 2,
-      "Agency": "National Endowment for the Humanities",
+      "agency": "National Endowment for the Humanities",
       "HTML Attribute Errors": 1.5
     },
     {
@@ -321,7 +321,7 @@
       "Color Contrast Errors": 5,
       "Alt Tag Errors": 0.85,
       "pages_count": 13,
-      "Agency": "Federal Trade Commission",
+      "agency": "Federal Trade Commission",
       "HTML Attribute Errors": 1.15
     },
     {
@@ -330,7 +330,7 @@
       "Color Contrast Errors": 2.82,
       "Alt Tag Errors": 3.09,
       "pages_count": 11,
-      "Agency": "Executive Office of the President",
+      "agency": "Executive Office of the President",
       "HTML Attribute Errors": 1.64
     },
     {
@@ -339,7 +339,7 @@
       "Color Contrast Errors": 4,
       "Alt Tag Errors": 0,
       "pages_count": 1,
-      "Agency": "National Nuclear Security Administration",
+      "agency": "National Nuclear Security Administration",
       "HTML Attribute Errors": 10
     },
     {
@@ -348,7 +348,7 @@
       "Color Contrast Errors": 0,
       "Alt Tag Errors": 0,
       "pages_count": 1,
-      "Agency": "Office of Government Ethics",
+      "agency": "Office of Government Ethics",
       "HTML Attribute Errors": 0
     },
     {
@@ -357,7 +357,7 @@
       "Color Contrast Errors": 1,
       "Alt Tag Errors": 0,
       "pages_count": 2,
-      "Agency": "Federal Retirement Thrift Investment Board",
+      "agency": "Federal Retirement Thrift Investment Board",
       "HTML Attribute Errors": 0.5
     },
     {
@@ -366,7 +366,7 @@
       "Color Contrast Errors": 0,
       "Alt Tag Errors": 0,
       "pages_count": 1,
-      "Agency": "Surface Transportation Board (STB)",
+      "agency": "Surface Transportation Board (STB)",
       "HTML Attribute Errors": 1
     },
     {
@@ -375,7 +375,7 @@
       "Color Contrast Errors": 3.67,
       "Alt Tag Errors": 2.94,
       "pages_count": 18,
-      "Agency": "Department of Homeland Security",
+      "agency": "Department of Homeland Security",
       "HTML Attribute Errors": 1.78
     },
     {
@@ -384,7 +384,7 @@
       "Color Contrast Errors": 7.19,
       "Alt Tag Errors": 0.25,
       "pages_count": 16,
-      "Agency": "Department of Transportation",
+      "agency": "Department of Transportation",
       "HTML Attribute Errors": 1.25
     },
     {
@@ -393,7 +393,7 @@
       "Color Contrast Errors": 0,
       "Alt Tag Errors": 0,
       "pages_count": 1,
-      "Agency": "Defense Nuclear Facilities Safety Board",
+      "agency": "Defense Nuclear Facilities Safety Board",
       "HTML Attribute Errors": 0
     },
     {
@@ -402,7 +402,7 @@
       "Color Contrast Errors": 2,
       "Alt Tag Errors": 1,
       "pages_count": 1,
-      "Agency": "International Broadcasting Bureau",
+      "agency": "International Broadcasting Bureau",
       "HTML Attribute Errors": 14
     },
     {
@@ -411,7 +411,7 @@
       "Color Contrast Errors": 28,
       "Alt Tag Errors": 1,
       "pages_count": 1,
-      "Agency": "Export/Import Bank of the U.S.",
+      "agency": "Export/Import Bank of the U.S.",
       "HTML Attribute Errors": 3
     },
     {
@@ -420,7 +420,7 @@
       "Color Contrast Errors": 3.33,
       "Alt Tag Errors": 0,
       "pages_count": 6,
-      "Agency": "Federal Reserve System",
+      "agency": "Federal Reserve System",
       "HTML Attribute Errors": 0.83
     },
     {
@@ -429,7 +429,7 @@
       "Color Contrast Errors": 5.41,
       "Alt Tag Errors": 2.39,
       "pages_count": 46,
-      "Agency": "Department of Energy",
+      "agency": "Department of Energy",
       "HTML Attribute Errors": 3.3
     },
     {
@@ -438,7 +438,7 @@
       "Color Contrast Errors": 6,
       "Alt Tag Errors": 0,
       "pages_count": 1,
-      "Agency": "Smithsonian Institution",
+      "agency": "Smithsonian Institution",
       "HTML Attribute Errors": 1
     },
     {
@@ -447,7 +447,7 @@
       "Color Contrast Errors": 7,
       "Alt Tag Errors": 0,
       "pages_count": 1,
-      "Agency": "United States Office of Government Ethics",
+      "agency": "United States Office of Government Ethics",
       "HTML Attribute Errors": 1
     },
     {
@@ -456,7 +456,7 @@
       "Color Contrast Errors": 3.55,
       "Alt Tag Errors": 1.16,
       "pages_count": 31,
-      "Agency": "Department of Agriculture",
+      "agency": "Department of Agriculture",
       "HTML Attribute Errors": 1.65
     },
     {
@@ -465,7 +465,7 @@
       "Color Contrast Errors": 0,
       "Alt Tag Errors": 0,
       "pages_count": 1,
-      "Agency": "Appalachian Regional Commission",
+      "agency": "Appalachian Regional Commission",
       "HTML Attribute Errors": 0
     },
     {
@@ -474,7 +474,7 @@
       "Color Contrast Errors": 0,
       "Alt Tag Errors": 0.2,
       "pages_count": 10,
-      "Agency": "Department of Housing And Urban Development",
+      "agency": "Department of Housing And Urban Development",
       "HTML Attribute Errors": 0.3
     },
     {
@@ -483,7 +483,7 @@
       "Color Contrast Errors": 0,
       "Alt Tag Errors": 0,
       "pages_count": 1,
-      "Agency": "Occupational Safety & Health Review Commission",
+      "agency": "Occupational Safety & Health Review Commission",
       "HTML Attribute Errors": 1
     },
     {
@@ -492,7 +492,7 @@
       "Color Contrast Errors": 8.5,
       "Alt Tag Errors": 17,
       "pages_count": 2,
-      "Agency": "National Aeronautics and Space Administration",
+      "agency": "National Aeronautics and Space Administration",
       "HTML Attribute Errors": 15.5
     },
     {
@@ -501,7 +501,7 @@
       "Color Contrast Errors": 0,
       "Alt Tag Errors": 0,
       "pages_count": 1,
-      "Agency": "Nuclear Regulatory Commission",
+      "agency": "Nuclear Regulatory Commission",
       "HTML Attribute Errors": 0
     },
     {
@@ -510,7 +510,7 @@
       "Color Contrast Errors": 0,
       "Alt Tag Errors": 0,
       "pages_count": 1,
-      "Agency": "National Endowment for the Arts",
+      "agency": "National Endowment for the Arts",
       "HTML Attribute Errors": 3
     },
     {
@@ -519,7 +519,7 @@
       "Color Contrast Errors": 4,
       "Alt Tag Errors": 0,
       "pages_count": 1,
-      "Agency": "Legal Services Corporation",
+      "agency": "Legal Services Corporation",
       "HTML Attribute Errors": 1
     },
     {
@@ -528,7 +528,7 @@
       "Color Contrast Errors": 7.5,
       "Alt Tag Errors": 7,
       "pages_count": 2,
-      "Agency": "US Interagency Council on Homelessness",
+      "agency": "US Interagency Council on Homelessness",
       "HTML Attribute Errors": 4
     },
     {
@@ -537,7 +537,7 @@
       "Color Contrast Errors": 3.8,
       "Alt Tag Errors": 0.3,
       "pages_count": 10,
-      "Agency": "Department of Education",
+      "agency": "Department of Education",
       "HTML Attribute Errors": 0.6
     },
     {
@@ -546,7 +546,7 @@
       "Color Contrast Errors": 3,
       "Alt Tag Errors": 0,
       "pages_count": 1,
-      "Agency": "Medical Payment Advisory Commission",
+      "agency": "Medical Payment Advisory Commission",
       "HTML Attribute Errors": 1
     },
     {
@@ -555,7 +555,7 @@
       "Color Contrast Errors": 0,
       "Alt Tag Errors": 3,
       "pages_count": 1,
-      "Agency": "Federal Housing Finance Agency Office of Inspector General",
+      "agency": "Federal Housing Finance Agency Office of Inspector General",
       "HTML Attribute Errors": 1
     },
     {
@@ -564,7 +564,7 @@
       "Color Contrast Errors": 0,
       "Alt Tag Errors": 0,
       "pages_count": 1,
-      "Agency": "Equal Employment Opportunity Commission",
+      "agency": "Equal Employment Opportunity Commission",
       "HTML Attribute Errors": 0
     },
     {
@@ -573,7 +573,7 @@
       "Color Contrast Errors": 4.19,
       "Alt Tag Errors": 3.5,
       "pages_count": 42,
-      "Agency": "Department of Commerce",
+      "agency": "Department of Commerce",
       "HTML Attribute Errors": 1.52
     },
     {
@@ -582,7 +582,7 @@
       "Color Contrast Errors": 0,
       "Alt Tag Errors": 0,
       "pages_count": 1,
-      "Agency": "Appraisal Subcommittee",
+      "agency": "Appraisal Subcommittee",
       "HTML Attribute Errors": 0
     },
     {
@@ -591,7 +591,7 @@
       "Color Contrast Errors": 3.52,
       "Alt Tag Errors": 1.21,
       "pages_count": 56,
-      "Agency": "Department of the Treasury",
+      "agency": "Department of the Treasury",
       "HTML Attribute Errors": 1.11
     },
     {
@@ -600,7 +600,7 @@
       "Color Contrast Errors": 6,
       "Alt Tag Errors": 0.5,
       "pages_count": 2,
-      "Agency": "Small Business Administration",
+      "agency": "Small Business Administration",
       "HTML Attribute Errors": 2
     },
     {
@@ -609,7 +609,7 @@
       "Color Contrast Errors": 15,
       "Alt Tag Errors": 0,
       "pages_count": 1,
-      "Agency": "U.S. Commission on Civil Rights",
+      "agency": "U.S. Commission on Civil Rights",
       "HTML Attribute Errors": 2
     },
     {
@@ -618,7 +618,7 @@
       "Color Contrast Errors": 0,
       "Alt Tag Errors": 0,
       "pages_count": 2,
-      "Agency": "National Security Agency",
+      "agency": "National Security Agency",
       "HTML Attribute Errors": 0
     },
     {
@@ -627,7 +627,7 @@
       "Color Contrast Errors": 0,
       "Alt Tag Errors": 0,
       "pages_count": 1,
-      "Agency": "Department of State OIG",
+      "agency": "Department of State OIG",
       "HTML Attribute Errors": 0
     },
     {
@@ -636,7 +636,7 @@
       "Color Contrast Errors": 9,
       "Alt Tag Errors": 3,
       "pages_count": 1,
-      "Agency": "Social Security Advisory Board",
+      "agency": "Social Security Advisory Board",
       "HTML Attribute Errors": 5
     },
     {
@@ -645,7 +645,7 @@
       "Color Contrast Errors": 0,
       "Alt Tag Errors": 0,
       "pages_count": 3,
-      "Agency": "Federal Communications Commission",
+      "agency": "Federal Communications Commission",
       "HTML Attribute Errors": 0
     },
     {
@@ -654,7 +654,7 @@
       "Color Contrast Errors": 0.67,
       "Alt Tag Errors": 2.67,
       "pages_count": 3,
-      "Agency": "U. S. Postal Service",
+      "agency": "U. S. Postal Service",
       "HTML Attribute Errors": 1
     },
     {
@@ -663,7 +663,7 @@
       "Color Contrast Errors": 9,
       "Alt Tag Errors": 0,
       "pages_count": 1,
-      "Agency": "Federal Mediation and Conciliation Service",
+      "agency": "Federal Mediation and Conciliation Service",
       "HTML Attribute Errors": 4
     },
     {
@@ -672,7 +672,7 @@
       "Color Contrast Errors": 0,
       "Alt Tag Errors": 0,
       "pages_count": 1,
-      "Agency": "Pension Benefit Guaranty Corporation",
+      "agency": "Pension Benefit Guaranty Corporation",
       "HTML Attribute Errors": 1
     },
     {
@@ -681,7 +681,7 @@
       "Color Contrast Errors": 0,
       "Alt Tag Errors": 12.67,
       "pages_count": 3,
-      "Agency": "Central Intelligence Agency",
+      "agency": "Central Intelligence Agency",
       "HTML Attribute Errors": 1.33
     },
     {
@@ -690,7 +690,7 @@
       "Color Contrast Errors": 19,
       "Alt Tag Errors": 0,
       "pages_count": 1,
-      "Agency": "Medicaid and CHIP Payment and Access Commission",
+      "agency": "Medicaid and CHIP Payment and Access Commission",
       "HTML Attribute Errors": 1
     },
     {
@@ -699,7 +699,7 @@
       "Color Contrast Errors": 9,
       "Alt Tag Errors": 0,
       "pages_count": 1,
-      "Agency": "National Council on Disability",
+      "agency": "National Council on Disability",
       "HTML Attribute Errors": 2
     },
     {
@@ -708,7 +708,7 @@
       "Color Contrast Errors": 0.92,
       "Alt Tag Errors": 0.15,
       "pages_count": 13,
-      "Agency": "Department of Labor",
+      "agency": "Department of Labor",
       "HTML Attribute Errors": 0.62
     },
     {
@@ -717,7 +717,7 @@
       "Color Contrast Errors": 5.67,
       "Alt Tag Errors": 2.45,
       "pages_count": 66,
-      "Agency": "General Services Administration",
+      "agency": "General Services Administration",
       "HTML Attribute Errors": 1.48
     },
     {
@@ -726,7 +726,7 @@
       "Color Contrast Errors": 3,
       "Alt Tag Errors": 0,
       "pages_count": 2,
-      "Agency": "Securities and Exchange Commission",
+      "agency": "Securities and Exchange Commission",
       "HTML Attribute Errors": 1.5
     },
     {
@@ -735,7 +735,7 @@
       "Color Contrast Errors": 12,
       "Alt Tag Errors": 0,
       "pages_count": 1,
-      "Agency": "Gulf Coast Ecosystem Restoration Council (GCERC)",
+      "agency": "Gulf Coast Ecosystem Restoration Council (GCERC)",
       "HTML Attribute Errors": 9
     },
     {
@@ -744,7 +744,7 @@
       "Color Contrast Errors": 4,
       "Alt Tag Errors": 1.33,
       "pages_count": 3,
-      "Agency": "Commodity Futures Trading Commission",
+      "agency": "Commodity Futures Trading Commission",
       "HTML Attribute Errors": 0.67
     },
     {
@@ -753,7 +753,7 @@
       "Color Contrast Errors": 5,
       "Alt Tag Errors": 0,
       "pages_count": 1,
-      "Agency": "U. S. Peace Corps",
+      "agency": "U. S. Peace Corps",
       "HTML Attribute Errors": 21
     },
     {
@@ -762,7 +762,7 @@
       "Color Contrast Errors": 0,
       "Alt Tag Errors": 0,
       "pages_count": 1,
-      "Agency": "Consumer Financial Protection Bureau",
+      "agency": "Consumer Financial Protection Bureau",
       "HTML Attribute Errors": 0
     },
     {
@@ -771,7 +771,7 @@
       "Color Contrast Errors": 50,
       "Alt Tag Errors": 6,
       "pages_count": 1,
-      "Agency": "National Labor Relations Board",
+      "agency": "National Labor Relations Board",
       "HTML Attribute Errors": 5
     },
     {
@@ -780,7 +780,7 @@
       "Color Contrast Errors": 0,
       "Alt Tag Errors": 0,
       "pages_count": 2,
-      "Agency": "Civil Air Patrol",
+      "agency": "Civil Air Patrol",
       "HTML Attribute Errors": 0
     },
     {
@@ -789,7 +789,7 @@
       "Color Contrast Errors": 28,
       "Alt Tag Errors": 0,
       "pages_count": 1,
-      "Agency": "National Gallery of Art",
+      "agency": "National Gallery of Art",
       "HTML Attribute Errors": 1
     },
     {
@@ -798,7 +798,7 @@
       "Color Contrast Errors": 5.5,
       "Alt Tag Errors": 5.17,
       "pages_count": 6,
-      "Agency": "Federal Deposit Insurance Corporation",
+      "agency": "Federal Deposit Insurance Corporation",
       "HTML Attribute Errors": 8.83
     },
     {
@@ -807,7 +807,7 @@
       "Color Contrast Errors": 0,
       "Alt Tag Errors": 0,
       "pages_count": 1,
-      "Agency": "National Mediation Board",
+      "agency": "National Mediation Board",
       "HTML Attribute Errors": 0
     },
     {
@@ -816,7 +816,7 @@
       "Color Contrast Errors": 0.5,
       "Alt Tag Errors": 6.5,
       "pages_count": 2,
-      "Agency": "Advisory Council on Historic Preservation",
+      "agency": "Advisory Council on Historic Preservation",
       "HTML Attribute Errors": 1
     },
     {
@@ -825,7 +825,7 @@
       "Color Contrast Errors": 19,
       "Alt Tag Errors": 0,
       "pages_count": 1,
-      "Agency": "Merit Systems Protection Board",
+      "agency": "Merit Systems Protection Board",
       "HTML Attribute Errors": 1
     },
     {
@@ -834,7 +834,7 @@
       "Color Contrast Errors": 4.5,
       "Alt Tag Errors": 7,
       "pages_count": 2,
-      "Agency": "U.S. Postal Service, Office of Inspector General",
+      "agency": "U.S. Postal Service, Office of Inspector General",
       "HTML Attribute Errors": 2.5
     },
     {
@@ -843,7 +843,7 @@
       "Color Contrast Errors": 2.57,
       "Alt Tag Errors": 3.71,
       "pages_count": 7,
-      "Agency": "National Science Foundation",
+      "agency": "National Science Foundation",
       "HTML Attribute Errors": 4
     },
     {
@@ -852,7 +852,7 @@
       "Color Contrast Errors": 3.27,
       "Alt Tag Errors": 0.55,
       "pages_count": 73,
-      "Agency": "Department of Health And Human Services",
+      "agency": "Department of Health And Human Services",
       "HTML Attribute Errors": 1.12
     },
     {
@@ -861,7 +861,7 @@
       "Color Contrast Errors": 7,
       "Alt Tag Errors": 3.5,
       "pages_count": 2,
-      "Agency": "Denali Commission",
+      "agency": "Denali Commission",
       "HTML Attribute Errors": 0.5
     },
     {
@@ -870,7 +870,7 @@
       "Color Contrast Errors": 0,
       "Alt Tag Errors": 0,
       "pages_count": 1,
-      "Agency": "Railroad Retirement Board",
+      "agency": "Railroad Retirement Board",
       "HTML Attribute Errors": 0
     },
     {
@@ -879,7 +879,7 @@
       "Color Contrast Errors": 1.67,
       "Alt Tag Errors": 0.22,
       "pages_count": 9,
-      "Agency": "Director of National Intelligence",
+      "agency": "Director of National Intelligence",
       "HTML Attribute Errors": 9.22
     },
     {
@@ -888,7 +888,7 @@
       "Color Contrast Errors": 0,
       "Alt Tag Errors": 21,
       "pages_count": 1,
-      "Agency": "Delta Regional Authority",
+      "agency": "Delta Regional Authority",
       "HTML Attribute Errors": 7
     },
     {
@@ -897,7 +897,7 @@
       "Color Contrast Errors": 1.5,
       "Alt Tag Errors": 0,
       "pages_count": 2,
-      "Agency": "African Development Foundation",
+      "agency": "African Development Foundation",
       "HTML Attribute Errors": 2.5
     },
     {
@@ -906,7 +906,7 @@
       "Color Contrast Errors": 0,
       "Alt Tag Errors": 1,
       "pages_count": 1,
-      "Agency": "Federal Elections Commission",
+      "agency": "Federal Elections Commission",
       "HTML Attribute Errors": 1
     },
     {
@@ -915,7 +915,7 @@
       "Color Contrast Errors": 11,
       "Alt Tag Errors": 10,
       "pages_count": 1,
-      "Agency": "U.S. Trade and Development Agency",
+      "agency": "U.S. Trade and Development Agency",
       "HTML Attribute Errors": 13
     },
     {
@@ -924,7 +924,7 @@
       "Color Contrast Errors": 30,
       "Alt Tag Errors": 0,
       "pages_count": 1,
-      "Agency": "Morris K. Udall Foundation",
+      "agency": "Morris K. Udall Foundation",
       "HTML Attribute Errors": 1
     },
     {
@@ -933,7 +933,7 @@
       "Color Contrast Errors": 0,
       "Alt Tag Errors": 0,
       "pages_count": 1,
-      "Agency": "Selective Service System",
+      "agency": "Selective Service System",
       "HTML Attribute Errors": 0
     },
     {
@@ -942,7 +942,7 @@
       "Color Contrast Errors": 0,
       "Alt Tag Errors": 19,
       "pages_count": 1,
-      "Agency": "Networking Information Technology Research and Development (NITRD)",
+      "agency": "Networking Information Technology Research and Development (NITRD)",
       "HTML Attribute Errors": 6
     },
     {
@@ -951,7 +951,7 @@
       "Color Contrast Errors": 6.8,
       "Alt Tag Errors": 3.2,
       "pages_count": 5,
-      "Agency": "Consumer Product Safety Commission",
+      "agency": "Consumer Product Safety Commission",
       "HTML Attribute Errors": 4.8
     },
     {
@@ -960,7 +960,7 @@
       "Color Contrast Errors": 7.89,
       "Alt Tag Errors": 0.22,
       "pages_count": 9,
-      "Agency": "U.S. Agency for International Development",
+      "agency": "U.S. Agency for International Development",
       "HTML Attribute Errors": 1.56
     },
     {
@@ -969,7 +969,7 @@
       "Color Contrast Errors": 4,
       "Alt Tag Errors": 0,
       "pages_count": 1,
-      "Agency": "Institute of Museum and Library Services",
+      "agency": "Institute of Museum and Library Services",
       "HTML Attribute Errors": 1
     },
     {
@@ -978,7 +978,7 @@
       "Color Contrast Errors": 20,
       "Alt Tag Errors": 1,
       "pages_count": 1,
-      "Agency": "Federal Maritime Commission",
+      "agency": "Federal Maritime Commission",
       "HTML Attribute Errors": 1
     },
     {
@@ -987,7 +987,7 @@
       "Color Contrast Errors": 0,
       "Alt Tag Errors": 13,
       "pages_count": 1,
-      "Agency": "U.S. Chemical Safety and Hazard Investigation Board",
+      "agency": "U.S. Chemical Safety and Hazard Investigation Board",
       "HTML Attribute Errors": 20
     },
     {
@@ -996,7 +996,7 @@
       "Color Contrast Errors": 0,
       "Alt Tag Errors": 0,
       "pages_count": 2,
-      "Agency": "Social Security Administration",
+      "agency": "Social Security Administration",
       "HTML Attribute Errors": 0
     },
     {
@@ -1005,7 +1005,7 @@
       "Color Contrast Errors": 0,
       "Alt Tag Errors": 0,
       "pages_count": 1,
-      "Agency": "American Battle Monuments Commission",
+      "agency": "American Battle Monuments Commission",
       "HTML Attribute Errors": 0
     },
     {
@@ -1014,7 +1014,7 @@
       "Color Contrast Errors": 5,
       "Alt Tag Errors": 9,
       "pages_count": 1,
-      "Agency": "Christopher Columbus Fellowship Foundation",
+      "agency": "Christopher Columbus Fellowship Foundation",
       "HTML Attribute Errors": 1
     },
     {
@@ -1023,7 +1023,7 @@
       "Color Contrast Errors": 0,
       "Alt Tag Errors": 0,
       "pages_count": 2,
-      "Agency": "Federal Housing Finance Agency",
+      "agency": "Federal Housing Finance Agency",
       "HTML Attribute Errors": 0
     },
     {
@@ -1032,7 +1032,7 @@
       "Color Contrast Errors": 0,
       "Alt Tag Errors": 0,
       "pages_count": 1,
-      "Agency": "U.S. Commission of Fine Arts",
+      "agency": "U.S. Commission of Fine Arts",
       "HTML Attribute Errors": 0
     },
     {
@@ -1041,7 +1041,7 @@
       "Color Contrast Errors": 21,
       "Alt Tag Errors": 0,
       "pages_count": 2,
-      "Agency": "Tennessee Valley Authority",
+      "agency": "Tennessee Valley Authority",
       "HTML Attribute Errors": 1.5
     }
   ]

--- a/static/js/accessibility/agencies.js
+++ b/static/js/accessibility/agencies.js
@@ -13,7 +13,7 @@ $(document).ready(function () {
 
       columns: [
         {
-          data: "Agency",
+          data: "agency",
           cellType: "th"
         },
         {


### PR DESCRIPTION
The scripts that generate the a11y agencies.json file result in an `agency` field, but the site breaks if the field isn't edited to be `Agency` instead.  I've gotten around this by doing a simple find and replace to the data before it's updated but it'll be better for it to not be an issue.  

This PR makes the site happy with a lowercase `agency` field name and reverts the data to its original form.  
