### PR TITLE
Fix link to a11y section on 'About Pulse'

### DIFF
--- a/templates/about.html
+++ b/templates/about.html
@@ -98,7 +98,7 @@
 				</p>
 			</li>
 
-			<li id="why-ally">
+			<li id="why-a11y">
 				<h4>
 					What is Accessibility, and why does Pulse measure it?
 				</h4>


### PR DESCRIPTION
Link to "What is Accessibility, and why does Pulse measure it?" uses #why-a11y but section id is defined as #why-ally (lower case L). Changing to why-a11y.