### PR TITLE
Stop using inspect scanner, start using sslyze for subdomains

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,5 +55,6 @@ data_init:
 	curl https://s3.amazonaws.com/pulse.cio.gov/live/scan/analytics.csv > data/output/scan/results/analytics.csv
 	curl https://s3.amazonaws.com/pulse.cio.gov/live/scan/pshtt.csv > data/output/scan/results/pshtt.csv
 	curl https://s3.amazonaws.com/pulse.cio.gov/live/scan/tls.csv > data/output/scan/results/tls.csv
+	curl https://s3.amazonaws.com/pulse.cio.gov/live/scan/sslyze.csv > data/output/scan/results/sslyze.csv
 	curl https://s3.amazonaws.com/pulse.cio.gov/live/scan/meta.json > data/output/scan/results/meta.json
 	curl https://s3.amazonaws.com/pulse.cio.gov/live/db/db.json > data/db.json

--- a/data/update.py
+++ b/data/update.py
@@ -51,7 +51,7 @@ BUCKET_NAME = "pulse.cio.gov"
 # domain-scan information
 SCAN_TARGET = os.path.join(this_dir, "./output/scan")
 SCAN_COMMAND = os.environ.get("DOMAIN_SCAN_PATH", None)
-SCANNERS = os.environ.get("SCANNERS", "pshtt,analytics,sslyze,inspect,tls")
+SCANNERS = os.environ.get("SCANNERS", "pshtt,analytics,sslyze,tls")
 ANALYTICS_URL = os.environ.get("ANALYTICS_URL", META["data"]["analytics_url"])
 
 # subdomain gathering/scanning information

--- a/data/update.py
+++ b/data/update.py
@@ -65,7 +65,7 @@ GATHERERS = [
   ["url", "--url=%s" % GATHER_ANALYTICS_URL]
 ]
 SUBDOMAIN_SCAN_TARGET = os.path.join(this_dir, "./output/subdomains/scan")
-SUBDOMAIN_SCANNERS = "pshtt"
+SUBDOMAIN_SCANNERS = "pshtt,sslyze"
 
 
 # Options:


### PR DESCRIPTION
We haven't needed or used the old site-inspector scans, so removing them from the scan.

Adding sslyze, so we get coverage of subdomains for offline analysis.