### PR TITLE
Codeclimate config

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,0 +1,25 @@
+---
+engines:
+  duplication:
+    enabled: true
+    config:
+      languages:
+      - python
+  fixme:
+    enabled: true
+  radon:
+    enabled: true
+ratings:
+  paths:
+  - "**.css"
+  - "**.inc"
+  - "**.js"
+  - "**.jsx"
+  - "**.module"
+  - "**.php"
+  - "**.py"
+  - "**.rb"
+exclude_paths:
+  - "**/vendor/"
+  - "static/DataTables-1.10.12"
+  - "static/Responsive-2.1.0"

--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -9,16 +9,6 @@ engines:
     enabled: true
   radon:
     enabled: true
-ratings:
-  paths:
-  - "**.css"
-  - "**.inc"
-  - "**.js"
-  - "**.jsx"
-  - "**.module"
-  - "**.php"
-  - "**.py"
-  - "**.rb"
 exclude_paths:
   - "**/vendor/"
   - "static/DataTables-1.10.12"


### PR DESCRIPTION
Removes third party packages from the Code Climate score. This should clean up our score quite a bit.

I'm leaving in the complexity and duplication checks, because eventually it might be nice to go back and refactor to fix these, but they're not pressing at all.