### PR TITLE
Added extra id attributes to allow deeper linking

### DIFF
--- a/templates/https/guide.html
+++ b/templates/https/guide.html
@@ -62,7 +62,7 @@
 
       <article>
 
-        <h4>Implementing HTTPS</h4>
+        <h4 id="implementing">Implementing HTTPS</h4>
 
         <p>
           The process of enabling and enforcing strong HTTPS for a web service can vary widely based on the technology, size, and age of the service.
@@ -76,7 +76,7 @@
 
       <article>
 
-        <h4>Measuring HTTPS</h4>
+        <h4 id="measuring">Measuring HTTPS</h4>
 
         <p>
           Pulse analyzes the behavior of four "endpoints" of every domain: <code>http://</code>, <code>http://www</code>, <code>https://</code>, and <code>https://www</code>. Data from these endpoints is used to characterize the overall behavior of a domain.
@@ -90,35 +90,35 @@
 
       <article>
 
-        <h4>Fields</h4>
+        <h4 id="fields">Fields</h4>
 
-        <ul>
+        <ul id="uses-https">
           <li><strong>Uses HTTPS</strong></li>
           <li><strong>Values:</strong> No, Yes</li>
           <li>Whether a site can be used over HTTPS, on either its bare domain or its <code>www</code> subdomain. Sites that appear to redirect "down" from HTTPS to HTTP are considered a "No".</li>
         </ul>
 
-        <ul>
+        <ul id="enforces-https">
           <li><strong>Enforces HTTPS</strong></li>
           <li><strong>Values:</strong> No, Yes</li>
           <li>Whether a domain appears to "default" to using HTTPS. This can be done either by redirecting its HTTP endpoints to HTTPS, or by only being available over HTTPS.</li>
         </ul>
 
-        <ul>
+        <ul id="uses-hsts">
           <li><strong>Strict Transport Security (HSTS)</strong></li>
           <li><strong>Values:</strong> No, Yes</li>
           <li>Whether a domain has implemented <a href="https://https.cio.gov/hsts/">HTTP Strict Transport Security</a>, which ensures that <a href="http://caniuse.com/#feat=stricttransportsecurity">supporting browsers</a> will only ever communicate with a domain over HTTPS (even if the user clicks or types in a plain HTTP link).</li>
           <li>"Yes" means that a valid <code>Strict-Transport-Security</code> header with a <code>max-age</code> value (in seconds) of at least <strong>1 year</strong> (31536000) is present on the domain's default endpoint.</li>
         </ul>
 
-        <ul>
+        <ul id="uses-preloading">
           <li><strong>Preloaded (recommended)</strong></li>
           <li><strong>Values:</strong> Ready, Yes</li>
           <li>"Ready" means that the domain has implemented a strong HSTS header on its <strong>bare domain</strong> whose policy covers all subdomains, and has indicated consent to <a href="https://hstspreload.appspot.com">preloading by all major browsers</a> as HTTPS-only.</li>
           <li>"Yes" means that the domain is actually in the publicly versioned <a href="https://chromium.googlesource.com/chromium/src/+/master/net/http/transport_security_state_static.json">Chrome preload list</a>, and has the <code>include_subdomains</code> flag enabled in that list. Reaching this step effectively means that a domain's namespace is permanently and fully committed to HTTPS.</li>
         </ul>
 
-        <ul>
+        <ul id="ssl-labs-grade">
           <li><strong>SSL Labs Grade</strong></li>
           <li><strong>Values:</strong> T, F, C, B, A-, A, A+</li>
           <li>A grade measuring the <em>quality</em> of HTTPS configuration, as calculated by <a href="https://www.ssllabs.com">SSL Labs</a>. SSL Labs operates a free and universally referenced benchmarking service.</li>


### PR DESCRIPTION
Was trying to link down specifically to the definition for "Preloaded", and noticed that some of the ``id`` attributes were missing in the guide.