### PR TITLE
Updating ineligible DAP domains

### DIFF
--- a/data/ineligible/analytics.yml
+++ b/data/ineligible/analytics.yml
@@ -12,8 +12,6 @@
 - broadband.gov
 - nationalbroadbandmap.gov
 - america.gov
-- 9-11commission.gov
-- 911commission.gov
 - dod.gov
 - ich.gov
 - invasivespecies.gov

--- a/data/ineligible/analytics.yml
+++ b/data/ineligible/analytics.yml
@@ -11,3 +11,5 @@
 - segurosocial.gov
 - broadband.gov
 - america.gov
+- 9-11commission.gov
+- 911commission.gov

--- a/data/ineligible/analytics.yml
+++ b/data/ineligible/analytics.yml
@@ -1,2 +1,13 @@
 - fdms.gov
 - bam.gov
+- disasterhousing.gov
+- homesales.gov
+- hud.gov
+- nationalhousing.gov
+- nationalhousinglocator.gov
+- nhl.gov
+- nls.gov
+- medalofvalor.gov
+- segurosocial.gov
+- broadband.gov
+- america.gov

--- a/data/ineligible/analytics.yml
+++ b/data/ineligible/analytics.yml
@@ -13,3 +13,13 @@
 - america.gov
 - 9-11commission.gov
 - 911commission.gov
+- dod.gov
+- ich.gov
+- invasivespecies.gov
+- myfdicinsurance.gov
+- nationalbanknet.gov
+- nbc.gov
+- onhir.gov
+- nbm.gov
+- tvaoig.gov
+- usembassy-mexico.gov

--- a/data/ineligible/analytics.yml
+++ b/data/ineligible/analytics.yml
@@ -10,6 +10,7 @@
 - medalofvalor.gov
 - segurosocial.gov
 - broadband.gov
+- nationalbroadbandmap.gov
 - america.gov
 - 9-11commission.gov
 - 911commission.gov

--- a/data/ineligible/analytics.yml
+++ b/data/ineligible/analytics.yml
@@ -20,6 +20,5 @@
 - nationalbanknet.gov
 - nbc.gov
 - onhir.gov
-- nbm.gov
 - tvaoig.gov
 - usembassy-mexico.gov


### PR DESCRIPTION
FYI, hud.gov and america.gov have no 2nd level domain endpoint. They redirect to subdomains. Not a best practice, but it is impossible for them to have DAP code on those hostnames, regardless.