### PR TITLE
Update oneself during scan-deploy process

### DIFF
--- a/deploy/cron.sh
+++ b/deploy/cron.sh
@@ -14,6 +14,9 @@ cd $PULSE_HOME
 # Load environment
 source $HOME/.bashrc
 
+# Update one's own code (TODO: devops)
+git pull
+
 # run the relevant env-specific data update path
 make update_$PULSE_ENV
 

--- a/deploy/cron.sh
+++ b/deploy/cron.sh
@@ -18,9 +18,14 @@ source $HOME/.bashrc
 git pull
 
 # run the relevant env-specific data update path
+# Takes ~25 hours
 make update_$PULSE_ENV
 
-# scan data was turned into db.json, and all data has been uploaded to S3.
+# scan data was turned into db.json,
+# and all data has been uploaded to S3.
+
+# Update one's own code again before deploy (TODO: devops)
+git pull
 
 # Finally, deploy the production website.
 make cg_production_autodeploy

--- a/deploy/cron.sh
+++ b/deploy/cron.sh
@@ -18,7 +18,7 @@ source $HOME/.bashrc
 git pull
 
 # run the relevant env-specific data update path
-# Takes ~25 hours
+# Takes ~40 hours
 make update_$PULSE_ENV
 
 # scan data was turned into db.json,


### PR DESCRIPTION
While we still have the scanning living on a persistent box, make sure its auto-deploy process is always taking into account the latest code. This runs a `git pull` before _and_ after the ~40 hour scanning process.