### PR TITLE
adding another to the DAP exclusion list

### DIFF
--- a/data/ineligible/analytics.yml
+++ b/data/ineligible/analytics.yml
@@ -12,6 +12,7 @@
 - invasivespecies.gov
 - medalofvalor.gov
 - myfdicinsurance.gov
+- nationalbank.gov
 - nationalbanknet.gov
 - nationalbroadbandmap.gov
 - nationalhousing.gov


### PR DESCRIPTION
@tdlowden - this would add `nationalbank.gov` to the list since it redirects to https://www.banknet.gov/entrance/default.html.  
