### PR TITLE
Update analytics.yml

### DIFF
--- a/data/ineligible/analytics.yml
+++ b/data/ineligible/analytics.yml
@@ -1,6 +1,7 @@
 - america.gov
 - bam.gov
 - broadband.gov
+- cjis.gov
 - cpnireporting.gov
 - disasterhousing.gov
 - dod.gov
@@ -10,6 +11,8 @@
 - hud.gov
 - ich.gov
 - invasivespecies.gov
+- learnatf.gov
+- learndoj.gov
 - medalofvalor.gov
 - myfdicinsurance.gov
 - nationalbanknet.gov


### PR DESCRIPTION
Adding DOJ internal training sites as per https://github.com/18F/pulse/issues/650.

These sites do have public landing pages, but they are intended solely for DOJ employees, so I am removing them from the list.