### PR TITLE
Move a11y into the Pulse processing pipeline

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -200,7 +200,7 @@ class Agency:
   # An agency which had at least 1 eligible domain.
   def eligible(report_name):
     return db.table('agencies').search(
-      (Query()[report_name]['eligible'] > 0)
+      Query()[report_name]['eligible'] > 0
     )
 
   # Create a new Agency record with a given name, slug, and total domain count.

--- a/app/models.py
+++ b/app/models.py
@@ -200,8 +200,7 @@ class Agency:
   # An agency which had at least 1 eligible domain.
   def eligible(report_name):
     return db.table('agencies').search(
-      (Query()[report_name]['eligible'] > 0) |
-      (Query()[report_name]['pages_count'] > 0)
+      (Query()[report_name]['eligible'] > 0)
     )
 
   # Create a new Agency record with a given name, slug, and total domain count.

--- a/app/models.py
+++ b/app/models.py
@@ -200,7 +200,8 @@ class Agency:
   # An agency which had at least 1 eligible domain.
   def eligible(report_name):
     return db.table('agencies').search(
-      Query()[report_name]['eligible'] > 0
+      (Query()[report_name]['eligible'] > 0) |
+      (Query()[report_name]['pages_count'] > 0)
     )
 
   # Create a new Agency record with a given name, slug, and total domain count.

--- a/data/processing.py
+++ b/data/processing.py
@@ -430,6 +430,7 @@ def update_agency_totals():
     )
     agency_report = {
       'pages_count': pages_count,
+      'eligible': pages_count,
       'Average Errors per Page': avg_errors_per_page
     }
     if pages_count:


### PR DESCRIPTION
This adds the processing of a11y data from the domain-scan repo to the Pulse pipeline. Things it does not do (to come in follow-up PRs):

1) Actually turn on the automatic scanning of a11y data. There are some unresolved issues in the a11y scan that make me want to hold back for now.

2) Switch the presentation layer to use the newly processed data. This is a trivial task, but since the scan is not automatically running yet, it is premature.

3) Generate the data/domains/a11y.csv file. Same reason as above.

Next step is to pull the a11y processing stuff out of domain-scan and clear up the last scanning issues before switching it on. PRs in that repo to come.