### PR TITLE
Disable sslyze scan for now

### DIFF
--- a/data/update.py
+++ b/data/update.py
@@ -51,7 +51,7 @@ BUCKET_NAME = META['bucket']
 # domain-scan information
 SCAN_TARGET = os.path.join(this_dir, "./output/scan")
 SCAN_COMMAND = os.environ.get("DOMAIN_SCAN_PATH", None)
-SCANNERS = os.environ.get("SCANNERS", "pshtt,analytics,sslyze,tls")
+SCANNERS = os.environ.get("SCANNERS", "pshtt,analytics,tls")
 ANALYTICS_URL = os.environ.get("ANALYTICS_URL", META["data"]["analytics_url"])
 
 # subdomain gathering/scanning information

--- a/data/update.py
+++ b/data/update.py
@@ -65,7 +65,7 @@ GATHERERS = [
   ["url", "--url=%s" % GATHER_ANALYTICS_URL]
 ]
 SUBDOMAIN_SCAN_TARGET = os.path.join(this_dir, "./output/subdomains/scan")
-SUBDOMAIN_SCANNERS = "pshtt,sslyze"
+SUBDOMAIN_SCANNERS = "pshtt"
 
 
 # Options:


### PR DESCRIPTION
As mentioned in https://github.com/18F/domain-scan/issues/138, sslyze is stalling out for unknown reasons. This is the main reason the scans have stalled for the last month on Pulse. Since we're not even using sslyze for actual Pulse stuff, but instead capture it during the scan for other off-band purposes, I'm yanking it from the Pulse pipeline at least temporarily. 

We can do these scans from a separate DotGov server if need be for the near future, while https://github.com/18F/domain-scan/issues/138 is resolved.