### PR TITLE
Prevent NoneType() >= int()

### DIFF
--- a/data/processing.py
+++ b/data/processing.py
@@ -575,7 +575,7 @@ def https_behavior_for(pshtt):
   else:
 
     # HSTS is present for the canonical endpoint.
-    if (pshtt["HSTS"] == "True"):
+    if (pshtt["HSTS"] == "True") and hsts_age:
 
       # Say No for too-short max-age's, and note in the extended details.
       if hsts_age >= 31536000:


### PR DESCRIPTION
I encountered an edge case where the scanned domain used `maxage` instead of `max-age` in its HSTS header. This results in `pshtt` listing `True` in the `HSTS` column but having an empty `HSTS Max Age` column. This in turn gave a `TypeError: unorderable types: NoneType() >= int()` error caused by line 581. We can prevent this by checking if `hsts_age` is `True` in the `if`-statement leading up to that line.

This has the added advantage that HSTS headers with a `max-age` of 0 are also given an HSTS value of 0 (no HSTS) in Pulse instead of an HSTS value of 1 (HSTS with too low max-age). The [RFC specifies](https://tools.ietf.org/html/rfc6797#section-6.1.1) that a `max-age` of 0 means that the HSTS policy should be removed by the user agent. So the intended effect of the website is to have no HSTS. In a scan of 23k domains I actually got 44 domains listing a `max-age` of 0.