### PR TITLE
Add third-party and a11y to normal scan

### DIFF
--- a/data/update.py
+++ b/data/update.py
@@ -51,8 +51,11 @@ BUCKET_NAME = META['bucket']
 # domain-scan information
 SCAN_TARGET = os.path.join(this_dir, "./output/scan")
 SCAN_COMMAND = os.environ.get("DOMAIN_SCAN_PATH", None)
-SCANNERS = os.environ.get("SCANNERS", "pshtt,analytics,tls")
+SCANNERS = os.environ.get("SCANNERS", "pshtt,analytics,tls,ally,third_parties")
 ANALYTICS_URL = os.environ.get("ANALYTICS_URL", META["data"]["analytics_url"])
+A11Y_CONFIG = os.environ.get("A11Y_CONFIG", "./a11y_config/pa11y_config.json")
+A11Y_REDIRECTS = os.environ.get("A11Y_REDIRECTS",
+                                "./a11y_config/a11y_redirects.yml")
 
 # subdomain gathering/scanning information
 GATHER_TARGET = os.path.join(this_dir, "./output/subdomains/gather")
@@ -167,10 +170,12 @@ def scan(options):
   scanners = "--scan=%s" % SCANNERS
   analytics = "--analytics=%s" % ANALYTICS_URL
   output = "--output=%s" % SCAN_TARGET
+  a11y_redirects = "--a11y_redirects=%s" % A11Y_REDIRECTS
+  a11y_config = "--a11y_config=%s" % A11Y_CONFIG
 
   full_command =[
     SCAN_COMMAND, DOMAINS,
-    scanners, analytics, output,
+    scanners, analytics, output, a11y_config, a11y_redirects
     "--debug",
     "--sort"
   ]


### PR DESCRIPTION
I reverted the previous PR because I forgot the a11y config files. These
two scans take ~45 minutes combined, so this _shouldn't_ impact things
too much. Once we've confirmed that the data looks good, we'll switch
back to the normal scan and only run a11y and customer satisfaction on
the first of the month.