### PR TITLE
Fix scan name

### DIFF
--- a/data/update.py
+++ b/data/update.py
@@ -51,7 +51,7 @@ BUCKET_NAME = META['bucket']
 # domain-scan information
 SCAN_TARGET = os.path.join(this_dir, "./output/scan")
 SCAN_COMMAND = os.environ.get("DOMAIN_SCAN_PATH", None)
-SCANNERS = os.environ.get("SCANNERS", "pshtt,analytics,tls,ally,third_parties")
+SCANNERS = os.environ.get("SCANNERS", "pshtt,analytics,tls,a11y,third_parties")
 ANALYTICS_URL = os.environ.get("ANALYTICS_URL", META["data"]["analytics_url"])
 A11Y_CONFIG = os.environ.get("A11Y_CONFIG", "./a11y_config/pa11y_config.json")
 A11Y_REDIRECTS = os.environ.get("A11Y_REDIRECTS",


### PR DESCRIPTION
Pronouncing it "ally" in my head as opposed to "a-eleven-y" has lead to more typos in this app than anything else.