### PR TITLE
Update Pulse data loading to include fed.us, allow Lambda, and sync with domain-scan

### DIFF
--- a/data/env.py
+++ b/data/env.py
@@ -49,6 +49,9 @@ GATHERER_OPTIONS = [
 # Run these scanners over *all* (which is a lot) discovered subdomains.
 SUBDOMAIN_SCANNERS = "pshtt,sslyze"
 
+# Used if --lambda is enabled during the scan.
+LAMBDA_WORKERS = 900
+
 # Quick and dirty CLI options parser.
 def options():
   options = {}

--- a/data/env.py
+++ b/data/env.py
@@ -35,7 +35,7 @@ A11Y_REDIRECTS = META["a11y"]["redirects"]
 SCANNERS = os.environ.get("SCANNERS", "pshtt,sslyze,analytics,a11y,third_parties")
 
 ### subdomain gathering/scanning information
-GATHER_SUFFIX = os.environ.get("GATHER_SUFFIX", ".gov")
+GATHER_SUFFIXES = os.environ.get("GATHER_SUFFIXES", ".gov,.fed.us")
 
 # names and options must be in corresponding order
 GATHERER_NAMES = ["censys", "dap", "eot2016", "parents"]

--- a/data/processing.py
+++ b/data/processing.py
@@ -227,7 +227,21 @@ def load_domain_data():
       if branch != "executive":
         continue
 
+      # One-off exclusion for "fed.us", which is improperly included
+      # in current-federal.csv, despite being a public suffix and not
+      # a registerable domain.
+      if domain_name == "fed.us":
+        continue
+
       if domain_name not in domain_map:
+
+        # By assuming the domain name is the base domain if it appears
+        # in current-federal.csv, we automatically treat fed.us domains
+        # as base domains, without explicitly incorporating the Public
+        # Suffix List.
+        #
+        # And since we excluded "fed.us" itself above, this should
+        # cover all the bases.
         domain_map[domain_name] = {
           'domain': domain_name,
           'base_domain': domain_name,


### PR DESCRIPTION
This PR (which is to the still-open `measure-subdomains` branch, which will close soon) updates a few things:

* Includes `.fed.us` in the list of suffixes during subdomain discovery. This makes use of a new multi-suffix feature in domain-scan to discover domains with multiple suffixes simultaneously. 

* It also explicitly skips loading `fed.us` as its own Domain, since it's not actually a registerable domain. This wasn't causing an active problem, as there are no websites at `https://fed.us` (nor should there be), but I wanted to be more explicit in the code instead of it just accidentally working. I believe the .gov registry should probably exclude the row for `fed.us` as a domain from the .gov listings. (It should still include `fs.fed.us` and the other registered `fed.us` domains.)

* Updates the use of domain-scan flags with changes made as part of a recent refactor, such as moving from `--force` to `--cache`, and using `sslyze-certs=false` instead of `--sslyze-no-certs`.

* Adds support for passing through a `--lambda` flag to make use of Lambda for (subdomain-only) scanning with `pshtt` and `sslyze`. **Lambda is not used in production** and this flag isn't used in the cron-driven process, but it's there for development and testing, and there so the switch can easily be flipped in-future.
