### PR TITLE
Deploy/S3 fixes for new scanning process

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -58,18 +58,4 @@ update_development:
 # Pending cloud.gov backup bucket:
 # cg-72ce4caf-d81b-4771-9b96-3624b5554587
 data_init:
-	mkdir -p data/output/parents/results/
-	mkdir -p data/output/subdomains/scan/results/
-	mkdir -p data/output/subdomains/gather/results/
-	curl https://s3-us-gov-west-1.amazonaws.com/cg-4adefb86-dadb-4ecf-be3e-f1c7b4f6d084/live/parents/analytics.csv > data/output/parents/results/analytics.csv
-	curl https://s3-us-gov-west-1.amazonaws.com/cg-4adefb86-dadb-4ecf-be3e-f1c7b4f6d084/live/parents/pshtt.csv > data/output/parents/results/pshtt.csv
-	curl https://s3-us-gov-west-1.amazonaws.com/cg-4adefb86-dadb-4ecf-be3e-f1c7b4f6d084/live/parents/sslyze.csv > data/output/parents/results/sslyze.csv
-	curl https://s3-us-gov-west-1.amazonaws.com/cg-4adefb86-dadb-4ecf-be3e-f1c7b4f6d084/live/parents/third_parties.csv > data/output/parents/results/third_parties.csv
-	curl https://s3-us-gov-west-1.amazonaws.com/cg-4adefb86-dadb-4ecf-be3e-f1c7b4f6d084/live/parents/a11y.csv > data/output/parents/results/a11y.csv
-	curl https://s3-us-gov-west-1.amazonaws.com/cg-4adefb86-dadb-4ecf-be3e-f1c7b4f6d084/live/parents/meta.json > data/output/parents/results/meta.json
-	curl https://s3-us-gov-west-1.amazonaws.com/cg-4adefb86-dadb-4ecf-be3e-f1c7b4f6d084/live/subdomains/gather/gathered.csv > data/output/subdomains/gather/results/gathered.csv
-	curl https://s3-us-gov-west-1.amazonaws.com/cg-4adefb86-dadb-4ecf-be3e-f1c7b4f6d084/live/subdomains/gather/meta.json > data/output/subdomains/gather/results/meta.json
-	curl https://s3-us-gov-west-1.amazonaws.com/cg-4adefb86-dadb-4ecf-be3e-f1c7b4f6d084/live/subdomains/scan/pshtt.csv > data/output/subdomains/scan/results/pshtt.csv
-	curl https://s3-us-gov-west-1.amazonaws.com/cg-4adefb86-dadb-4ecf-be3e-f1c7b4f6d084/live/subdomains/scan/sslyze.csv > data/output/subdomains/scan/results/sslyze.csv
-	curl https://s3-us-gov-west-1.amazonaws.com/cg-4adefb86-dadb-4ecf-be3e-f1c7b4f6d084/live/subdomains/scan/meta.json > data/output/subdomains/scan/results/meta.json
-	curl https://s3-us-gov-west-1.amazonaws.com/cg-4adefb86-dadb-4ecf-be3e-f1c7b4f6d084/live/db/db.json > data/db.json
+	python -m data.update --just-download

--- a/data/env.py
+++ b/data/env.py
@@ -2,10 +2,10 @@ import os
 import sys
 import yaml
 
-this_dir = os.path.dirname(__file__)
+DATA_DIR = os.path.dirname(__file__)
 
 # App-level metadata.
-META = yaml.safe_load(open(os.path.join(this_dir, "../meta.yml")))
+META = yaml.safe_load(open(os.path.join(DATA_DIR, "../meta.yml")))
 DOMAINS = os.environ.get("DOMAINS", META["data"]["domains_url"])
 
 # domain-scan paths (MUST be set in env)
@@ -14,13 +14,13 @@ GATHER_COMMAND = os.environ.get("DOMAIN_GATHER_PATH", None)
 
 
 # post-processing and uploading information
-PARENTS_DATA = os.path.join(this_dir, "./output/parents")
-PARENTS_RESULTS = os.path.join(this_dir, "./output/parents/results")
-SUBDOMAIN_DATA = os.path.join(this_dir, "./output/subdomains")
-SUBDOMAIN_DATA_GATHERED = os.path.join(this_dir, "./output/subdomains/gather")
-SUBDOMAIN_DATA_SCANNED = os.path.join(this_dir, "./output/subdomains/scan")
+PARENTS_DATA = os.path.join(DATA_DIR, "./output/parents")
+PARENTS_RESULTS = os.path.join(DATA_DIR, "./output/parents/results")
+SUBDOMAIN_DATA = os.path.join(DATA_DIR, "./output/subdomains")
+SUBDOMAIN_DATA_GATHERED = os.path.join(DATA_DIR, "./output/subdomains/gather")
+SUBDOMAIN_DATA_SCANNED = os.path.join(DATA_DIR, "./output/subdomains/scan")
 
-DB_DATA = os.path.join(this_dir, "./db.json")
+DB_DATA = os.path.join(DATA_DIR, "./db.json")
 BUCKET_NAME = META['bucket']
 
 # DAP source data
@@ -32,7 +32,7 @@ A11Y_REDIRECTS = META["a11y"]["redirects"]
 
 ### Parent domain scanning information
 #
-SCANNERS = os.environ.get("SCANNERS", "pshtt,sslyze,analytics,a11y,third_parties")
+SCANNERS = os.environ.get("SCANNERS", ["pshtt", "sslyze", "analytics", "a11y", "third_parties"])
 
 ### subdomain gathering/scanning information
 GATHER_SUFFIXES = os.environ.get("GATHER_SUFFIXES", ".gov,.fed.us")
@@ -47,7 +47,7 @@ GATHERER_OPTIONS = [
 ]
 
 # Run these scanners over *all* (which is a lot) discovered subdomains.
-SUBDOMAIN_SCANNERS = "pshtt,sslyze"
+SUBDOMAIN_SCANNERS = ["pshtt", "sslyze"]
 
 # Used if --lambda is enabled during the scan.
 LAMBDA_WORKERS = 900

--- a/data/update.py
+++ b/data/update.py
@@ -121,14 +121,18 @@ def run(options):
 
 # Upload the scan + processed data to /live/ and /archive/ locations by date.
 def upload_s3(date):
+  # Used for all operations.
   acl = "--acl=public-read"
+
+  # Used when uploading to the live/ dir.
+  delete = "--delete"
 
   live_parents = "s3://%s/live/parents/" % BUCKET_NAME
   live_subdomains = "s3://%s/live/subdomains/" % BUCKET_NAME
   live_db = "s3://%s/live/db/" % BUCKET_NAME
 
-  shell_out(["aws", "s3", "sync", PARENTS_DATA, live_parents, acl])
-  shell_out(["aws", "s3", "sync", SUBDOMAIN_DATA, live_subdomains, acl])
+  shell_out(["aws", "s3", "sync", PARENTS_DATA, live_parents, acl, delete])
+  shell_out(["aws", "s3", "sync", SUBDOMAIN_DATA, live_subdomains, acl, delete])
   shell_out(["aws", "s3", "cp", DB_DATA, live_db, acl])
 
   # Then copy the entire live directory to a dated archive.

--- a/data/update.py
+++ b/data/update.py
@@ -117,23 +117,21 @@ def run(options):
 
 # Upload the scan + processed data to /live/ and /archive/ locations by date.
 def upload(date):
-  live_parents = "s3://%s/live/parents/" % (BUCKET_NAME)
-  live_subdomains = "s3://%s/live/subdomains/" % (BUCKET_NAME)
-  live_db = "s3://%s/live/db/" % (BUCKET_NAME)
-  archive_subdomains = "s3://%s/archive/%s/subdomains/" % (BUCKET_NAME, date)
-  archive_parents = "s3://%s/archive/%s/parents/" % (BUCKET_NAME, date)
-  archive_db = "s3://%s/archive/%s/db/" % (BUCKET_NAME, date)
-
   acl = "--acl=public-read"
 
-  shell_out(["aws", "s3", "sync", PARENTS_DATA, live_scanned, acl])
+  live_parents = "s3://%s//live/parents/" % BUCKET_NAME
+  live_subdomains = "s3://%s/live/subdomains/" % BUCKET_NAME
+  live_db = "s3://%s/live/db/" % BUCKET_NAME
+
+  shell_out(["aws", "s3", "sync", PARENTS_DATA, live_parents, acl])
   shell_out(["aws", "s3", "sync", SUBDOMAIN_DATA, live_subdomains, acl])
   shell_out(["aws", "s3", "cp", DB_DATA, live_db, acl])
 
-  # Ask S3 to do the copying, to save on time and bandwidth
-  shell_out(["aws", "s3", "sync", live_scanned, archive_scanned, acl])
-  shell_out(["aws", "s3", "sync", live_subdomains, archive_subdomains, acl])
-  shell_out(["aws", "s3", "sync", live_db, archive_db, acl])
+  # Then copy the entire live directory to a dated archive.
+  # Ask S3 to do the copying, to save on time and bandwidth.
+  live = "s3://%s/live/" % (BUCKET_NAME)
+  archive = "s3://%s/archive/%s/" % (BUCKET_NAME, date)
+  shell_out(["aws", "s3", "sync", live, archive, acl])
 
 
 # Use domain-scan to scan .gov domains from the set domain URL.

--- a/data/update.py
+++ b/data/update.py
@@ -123,7 +123,7 @@ def run(options):
 def upload_s3(date):
   acl = "--acl=public-read"
 
-  live_parents = "s3://%s//live/parents/" % BUCKET_NAME
+  live_parents = "s3://%s/live/parents/" % BUCKET_NAME
   live_subdomains = "s3://%s/live/subdomains/" % BUCKET_NAME
   live_db = "s3://%s/live/db/" % BUCKET_NAME
 

--- a/manifest.yml
+++ b/manifest.yml
@@ -1,7 +1,7 @@
 ---
 applications:
 - name: pulse
-  memory: 512M
+  memory: 768M
   instances: 2
   buildpack: python_buildpack
   env:
@@ -9,7 +9,7 @@ applications:
     NEW_RELIC_APP_NAME: Pulse | Prod
     NEW_RELIC_ENV: production
 - name: pulse-staging
-  memory: 512M
+  memory: 256M
   instances: 1
   buildpack: python_buildpack
   env:


### PR DESCRIPTION
This does two main things:

* Updates the S3 uploading/archiving process to account for the new directory structure and overall processing pipeline.

* Updates the S3 _downloading_ process (whether done via `make data_init` or via `python -m data.update --scan=download`) to also account for the new directory structure. It also moves all the logic in one place inside `make data_init`, and has it hinge on the defined scanners for parent domains and subdomains, so that there's less duplication of code and the S3 logic is defined in one place.

There's also a tweak to the production and staging memory sizes, to account for increased vuln scanning to the production site that may have been leading to increased crashes.