### PR TITLE
Switch to Censys snapshot, add Reverse DNS snapshot data

### DIFF
--- a/data/env.py
+++ b/data/env.py
@@ -40,11 +40,12 @@ SCANNERS = scanner_string.split(",")
 GATHER_SUFFIXES = os.environ.get("GATHER_SUFFIXES", ".gov,.fed.us")
 
 # names and options must be in corresponding order
-GATHERER_NAMES = ["censys", "dap", "eot2016", "parents"]
+GATHERER_NAMES = ["censys-snapshot", "dap", "eot2016", "rdns-snapshot", "parents"]
 GATHERER_OPTIONS = [
-  "--export",
+  "--censys-snapshot=%s" % META["data"]["censys_subdomains_url"],
   "--dap=%s" % META["data"]["analytics_subdomains_url"],
   "--eot2016=%s" % META["data"]["eot_subdomains_url"],
+  "--rdns-snapshot=%s" % META["data"]["rdns_subdomains_url"],
   "--parents=%s" % DOMAINS
 ]
 

--- a/data/processing.py
+++ b/data/processing.py
@@ -276,8 +276,12 @@ def load_domain_data():
         # check each source
         sources = []
         for i, source in enumerate(GATHERER_NAMES):
-          if boolean_for(row[i+2]):
-            sources.append(source)
+          try:
+            if boolean_for(row[i+2]):
+              sources.append(source)
+          except IndexError:
+            print("ERROR: Likely mismatch between sources in gathered.csv, and in data/env.py.")
+            exit(1)
 
         gathered_subdomain_map[subdomain_name] = sources
 

--- a/data/update.py
+++ b/data/update.py
@@ -48,6 +48,9 @@ import data.processing
 # --gather=[skip,here]
 #     skip: skip gathering, assume CSVs are locally cached
 #     here: run the default full gather
+#
+# --just-download: Download the latest result data from S3 and stop.
+# --just-gather: Gather domains and then stop. (Useful for debugging.)
 
 def run(options):
   # If this is just being used to download production data, do that.
@@ -73,6 +76,11 @@ def run(options):
       print()
       print("Subdomain gathering complete.")
       print()
+
+      if options.get("just-gather", False):
+        print("Asked for gathering only, stopping.")
+        exit(0)
+
     elif gather_mode == "skip":
       print("Skipping subdomain gathering.")
       print()

--- a/meta.yml
+++ b/meta.yml
@@ -19,7 +19,13 @@ data:
   analytics_subdomains_url: "https://analytics.usa.gov/data/live/sites-extended.csv"
 
   # Preprocessed CSV where we source End of Term Archive data from.
-  eot_subdomains_url: https://github.com/GSA/data/raw/master/end-of-term-archive-csv/eot-2016-seeds.csv
+  eot_subdomains_url: https://github.com/GSA/data/raw/master/dotgov-websites/eot-2016-snapshot.csv
+
+  # Preprocessed CSV with a snapshot of filtered Censys.io search result data.
+  censys_subdomains_url: https://github.com/GSA/data/raw/master/dotgov-websites/censys-federal-snapshot.csv
+
+  # Preprocessed CSV with a snapshot of filtered Rapid7 Reverse DNS data.
+  rdns_subdomains_url: https://github.com/GSA/data/raw/master/dotgov-websites/rdns-federal-snapshot.csv
 
 a11y:
   config: https://github.com/18F/pulse/raw/master/data/a11y_config/pa11y_config.json


### PR DESCRIPTION
This switches us to a snapshot of data from a recent Censys.io export (as we will be on a hiatus from using their service until we set up a Google Cloud account to bill BigQuery queries to), and adds a new subdomain source: [Reverse DNS data collected by Rapid7](https://scans.io/study/sonar.rdns_v2). 

The Reverse DNS data is also a snapshot, as the full dataset is a 130GB [JSON Lines](http://jsonlines.org) file that is non-trivial to parse and filter. I expect eventually we'll get more sophisticated at processing this data automatically, but for now, it's updated "whenever". It adds 2,850 unique hostnames that respond to HTTP/HTTPS and which don't appear in other sources.