### PR TITLE
Add Reverse DNS snapshot data and use Censys snapshot data

### DIFF
--- a/data/env.py
+++ b/data/env.py
@@ -40,9 +40,13 @@ SCANNERS = scanner_string.split(",")
 GATHER_SUFFIXES = os.environ.get("GATHER_SUFFIXES", ".gov,.fed.us")
 
 # names and options must be in corresponding order
-GATHERER_NAMES = ["censys", "dap", "eot2016", "parents"]
+GATHERER_NAMES = [
+  "censys-snapshot", "rdns-snapshot",
+  "dap", "eot2016", "parents"
+]
 GATHERER_OPTIONS = [
-  "--export",
+  "--censys-snapshot" % META["data"]["censys_snapshot_url"],
+  "--rdns-snapshot" % META["data"]["rdns_snapshot_url"],
   "--dap=%s" % META["data"]["analytics_subdomains_url"],
   "--eot2016=%s" % META["data"]["eot_subdomains_url"],
   "--parents=%s" % DOMAINS

--- a/data/env.py
+++ b/data/env.py
@@ -45,8 +45,8 @@ GATHERER_NAMES = [
   "dap", "eot2016", "parents"
 ]
 GATHERER_OPTIONS = [
-  "--censys-snapshot" % META["data"]["censys_snapshot_url"],
-  "--rdns-snapshot" % META["data"]["rdns_snapshot_url"],
+  "--censys-snapshot=%s" % META["data"]["censys_snapshot_url"],
+  "--rdns-snapshot=%s" % META["data"]["rdns_snapshot_url"],
   "--dap=%s" % META["data"]["analytics_subdomains_url"],
   "--eot2016=%s" % META["data"]["eot_subdomains_url"],
   "--parents=%s" % DOMAINS

--- a/meta.yml
+++ b/meta.yml
@@ -21,6 +21,15 @@ data:
   # Preprocessed CSV where we source End of Term Archive data from.
   eot_subdomains_url: https://github.com/GSA/data/raw/master/end-of-term-archive-csv/eot-2016-seeds.csv
 
+  # Snapshot of Censys.io data from late November 2017, interim while we
+  # re-establish use of their APIs.
+  censys_snapshot_url: https://github.com/GSA/data/raw/master/dotgov-websites/censys-federal-snapshot.csv
+
+  # Snapshot of Rapid7 Reverse DNS data from Scans.io in late 2017. The data
+  # is too big to automatically process each time with our current infrastructure,
+  # so this is relying on occasional snapshots which can be updated in-place in the repo.
+  rdns_snapshot_url: https://github.com/GSA/data/raw/master/dotgov-websites/rdns-federal-snapshot.csv
+
 a11y:
   config: https://github.com/18F/pulse/raw/master/data/a11y_config/pa11y_config.json
   redirects: https://github.com/18F/pulse/raw/master/data/a11y_config/a11y_redirects.yml


### PR DESCRIPTION
This uses the data in https://github.com/GSA/data/tree/master/dotgov-websites to pull in Reverse DNS data from Rapid7 via scans.io, and to use a November 2017 snapshot of Censys.io data, for Pulse's gathering process.