### PR TITLE
Turn on Lambda in production

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,8 +37,9 @@ clean:
 # Production data update process:
 #
 # Run a fresh scan, update the database, and upload data to S3.
+# Enable Lambda mode, using Lambda AWS profile set up in production.
 update_production:
-	python -m data.update --scan=here --upload
+	python -m data.update --scan=here --upload --lambda --lambda-profile=lambda
 
 # Staging data update process:
 #

--- a/data/update.py
+++ b/data/update.py
@@ -224,14 +224,8 @@ def scan_parents(options):
 
   # Until third_parties and a11y are moved to Lambda, can't
   # do Lambda-sized worker count. Stick with default (10).
-  # if options.get("workers"):
-  #   full_command += ["--workers=%s" % str(options.get("workers"))]
-
-  # Can't yet use Lambda with parents, since Lambda only works
-  # with a set of scanners that all use Lambda.
-  # If Lambda mode is on, use way more workers.
-  if options.get("lambda"):
-    full_command += ["--workers=%i" % LAMBDA_WORKERS]
+  # if options.get("lambda"):
+  #   full_command += ["--workers=%i" % LAMBDA_WORKERS]
 
   shell_out(full_command)
 

--- a/data/update.py
+++ b/data/update.py
@@ -217,18 +217,21 @@ def scan_parents(options):
 
   # Allow some options passed to python -m data.update to go
   # through to domain-scan.
-  for flag in ["cache", "serial"]:  # , "lambda"]:
-    if options.get(flag):
-      full_command += ["--%s" % flag]
+  for flag in ["cache", "serial", "lambda", "lambda-profile"]:
+    value = options.get(flag)
+    if value:
+      full_command += ["--%s=%s" % (flag, str(value))]
 
-  if options.get("workers"):
-    full_command += ["--workers=%s" % str(options.get("workers"))]
+  # Until third_parties and a11y are moved to Lambda, can't
+  # do Lambda-sized worker count. Stick with default (10).
+  # if options.get("workers"):
+  #   full_command += ["--workers=%s" % str(options.get("workers"))]
 
   # Can't yet use Lambda with parents, since Lambda only works
   # with a set of scanners that all use Lambda.
   # If Lambda mode is on, use way more workers.
-  # if options.get("lambda"):
-  #   full_command += ["--workers=%i" % LAMBDA_WORKERS]
+  if options.get("lambda"):
+    full_command += ["--workers=%i" % LAMBDA_WORKERS]
 
   shell_out(full_command)
 
@@ -278,9 +281,10 @@ def scan_subdomains(options):
 
   # Allow some options passed to python -m data.update to go
   # through to domain-scan.
-  for flag in ["cache", "serial", "lambda"]:
-    if options.get(flag):
-      full_command += ["--%s" % flag]
+  for flag in ["cache", "serial", "lambda", "lambda-profile"]:
+    value = options.get(flag)
+    if value:
+      full_command += ["--%s=%s" % (flag, str(value))]
 
   # If Lambda mode is on, use way more workers.
   if options.get("lambda"):

--- a/data/update.py
+++ b/data/update.py
@@ -287,7 +287,7 @@ def scan_subdomains(options):
       full_command += ["--%s=%s" % (flag, str(value))]
 
   # If Lambda mode is on, use way more workers.
-  if options.get("lambda"):
+  if options.get("lambda") and (options.get("serial", None) is None):
     full_command += ["--workers=%i" % LAMBDA_WORKERS]
 
   shell_out(full_command)

--- a/templates/https/guide.html
+++ b/templates/https/guide.html
@@ -56,6 +56,10 @@
             <strong><a href="https://analytics.usa.gov">Digital Analytics Program</a>:</strong>
             The Digital Analytics Program (DAP) publishes <a href="https://analytics.usa.gov/data/live/sites-extended.csv">a dataset of federal hostnames</a>, updated nightly. This includes hostnames for which the DAP observed at least one recorded visit in the previous 14 days.
           </li>
+          <li>
+            <strong><a href="https://scans.io/study/sonar.rdns_v2">Rapid7 Reverse DNS data</a>:</strong>
+            Rapid7 publishes a large bulk dataset of Reverse DNS data from the IPv4 space. Their data is updated roughly daily, but due to its size, Pulse uses a snapshot of their data, filtered down to just .gov and .fed.us hostnames, updated on an occasional basis. This snapshot is stored in a <a href="https://github.com/GSA/data/tree/master/dotgov-websites/">GSA GitHub repository</a>, and can be <a href="https://github.com/GSA/data/raw/master/dotgov-websites/rdns-federal-snapshot.csv">downloaded directly as a CSV here</a>.
+          </li>
         </ul>
 
         <p>


### PR DESCRIPTION
This enables `--lambda` mode for `pshtt` and `sslyze` scans in production. It relies on the `--lambda-profile` flag recently added to domain-scan, to use a separate AWS named profile from the one used to speak to the cloud.gov S3 bucket.

It also documents the use of the Rapid7 Reverse DNS data source for subdomains.