### PR TITLE
Fix DAP data display 

### DIFF
--- a/data/processing.py
+++ b/data/processing.py
@@ -348,16 +348,16 @@ def load_parent_scan_data(domains):
         # print("[analytics] Skipping %s, not a federal domain from domains.csv." % domain)
           continue
 
-      # If it didn't appear in the pshtt data, skip it, we need this.
-      # if not domains[domain].get('pshtt'):
-      #   print("[analytics] Skipping %s, did not appear in pshtt.csv." % domain)
-      #   continue
+        # If it didn't appear in the pshtt data, skip it, we need this.
+        # if not domains[domain].get('pshtt'):
+        #   print("[analytics] Skipping %s, did not appear in pshtt.csv." % domain)
+        #   continue
 
-      dict_row = {}
-      for i, cell in enumerate(row):
-        dict_row[headers[i]] = cell
+        dict_row = {}
+        for i, cell in enumerate(row):
+          dict_row[headers[i]] = cell
 
-      parent_scan_data[domain]['analytics'] = dict_row
+        parent_scan_data[domain]['analytics'] = dict_row
 
   # And a11y! Only try to load it if it exists, since scan is not yet automated.
   if os.path.isfile(os.path.join(PARENT_RESULTS, "a11y.csv")):


### PR DESCRIPTION
There was a regression in #750 that led to us showing only one result for DAP, the final entry `youthrules.gov`, and a success rate of 100%.

<img width="1018" alt="screen shot 2017-12-29 at 10 36 43 pm" src="https://user-images.githubusercontent.com/4592/34451066-c4588e68-ece8-11e7-847e-968827c7a99e.png">

This happened because only part of the analytics.csv-loading block was indented underneath the conditional that was added to allow processing when analytics.csv was missing in #750.

This was my fault, as I should have tested out #750 empirically before merging -- I eyeballed [the diff](https://github.com/18F/pulse/pull/750/files) and it looked fine, but the diff cuts off before showing the unindented lines.