### PR TITLE
Repair detection of SSLyze results where connection couldn't be established

### DIFF
--- a/data/processing.py
+++ b/data/processing.py
@@ -328,7 +328,7 @@ def load_parent_scan_data(domains):
 
       # If the scan was invalid, most fields will be empty strings.
       # It'd be nice to make this more semantic on the domain-scan side.
-      if dict_row["Scanned Hostname"] == "":
+      if dict_row["SSLv2"] == "":
         # print("[%s] Skipping, scan data was invalid." % subdomain)
         continue
 
@@ -486,7 +486,7 @@ def load_subdomain_scan_data(domains, parent_scan_data, gathered_subdomains):
 
       # If the scan was invalid, most fields will be empty strings.
       # It'd be nice to make this more semantic on the domain-scan side.
-      if dict_row["Scanned Hostname"] == "":
+      if dict_row["SSLv2"] == "":
         # print("[%s] Skipping, scan data was invalid." % subdomain)
         continue
 


### PR DESCRIPTION
The hacky workaround I was using in #748 and #751 to detect situations when connectivity was not established during SSLyze scanning stopped working. 

The better solution would be a field whose value was just true/false on whether connectivity was established, but in its absence, this fixes the hacky workaround so that affected agencies will see some relief ASAP.