### PR TITLE
Makes the pulse@cio.gov contact email explicit

### DIFF
--- a/templates/https/guide.html
+++ b/templates/https/guide.html
@@ -20,7 +20,7 @@
 
     <div class="guide">
 
-      <h3>Below you will find some helpful tips to help guide you towards getting a better score on Pulse for your domain or agency. For any further questions, please visit our <a href="/about/">frequently asked questions</a>.</h3>
+      <h3>Below you will find some helpful tips to help guide you towards getting a better score on Pulse for your domain or agency. For any further questions, please visit our <a href="/about/">frequently asked questions</a> or email <strong><a href="mailto:pulse@cio.gov">pulse@cio.gov</a></strong>.</h3>
 
       <article>
 

--- a/templates/includes/https/header.html
+++ b/templates/includes/https/header.html
@@ -12,7 +12,7 @@
        This data measures how well federal web services support the HTTPS protocol (<code>https://</code>). HTTPS provides a secure connection across the internet between web services and their users. Federal agencies are required to enforce HTTPS and use <a href="https://https.cio.gov/guide/#options-for-hsts-compliance">HSTS</a> (HTTP Strict Transport Security) as part of the White House Office of Management and Budget's <a href="https://https.cio.gov">M-15-13</a> and the Department of Homeland Security's <a href="https://cyber.dhs.gov">Binding Operational Directive 18-01</a>. BOD 18-01 also requires that agencies <a href="https://cyber.dhs.gov/https/#moving-ahead">remove support for known-weak cryptography</a> by disabling the RC4 and 3DES ciphers, and the SSLv2 and SSLv3 protocols.
     </p>
     <p>
-      All data below is collected from <strong><a href="/https/guidance/#subdomains">publicly available data sources</a></strong> on <strong>{{ scan_date | date("%B %d, %Y") }}</strong>, and must be considered public. See <a href="/https/guidance/">the technical guidance</a> for more information on how this data is collected and measured.
+      All data below is collected from <strong><a href="/https/guidance/#subdomains">publicly available data sources</a></strong> on <strong>{{ scan_date | date("%B %d, %Y") }}</strong>, and must be considered public. See <a href="/https/guidance/">the technical guidance</a> for more information on how this data is collected and measured. Agencies with questions about their results shown here can contact <strong><a href="mailto:pulse@cio.gov">pulse@cio.gov</a></strong>.
     </p>
   </div>
 


### PR DESCRIPTION
Adds the `pulse@cio.gov` email explicitly to the HTTPS header and HTTPS guidance tabs, to help agencies figure out a contact address if they want to write us with questions.

cc @smarina04 