### PR TITLE
Be even more explicit with the pulse@cio.gov contact address

### DIFF
--- a/static/js/https/domains.js
+++ b/static/js/https/domains.js
@@ -146,6 +146,7 @@ $(function () {
       var discoveryLink = l("/https/guidance/#subdomains", "publicly discoverable services");
       var link = "Showing data for " + number + " " + discoveryLink + " within " + base_domain + ".&nbsp;&nbsp;";
       link += l(csv, "Download all " + base_domain + " data as a CSV") + ".";
+      link += " Email " + l("mailto:pulse@cio.gov", "pulse@cio.gov") + " with questions.";
       var download = $("<tr></tr>").addClass("subdomain").html("<td class=\"link\" colspan=6>" + link + "</td>");
       all.push(download);
     }


### PR DESCRIPTION
This adds a mention of the pulse@cio.gov email contact as part of the instructions given to agencies as they expand the list of services within their domains. This seemed like the least repetitive place to put it so as to have it appear in the table where agency staff are looking, and to those who are the most invested in looking at individual data.

<img width="995" alt="screen shot 2018-03-11 at 9 47 13 pm" src="https://user-images.githubusercontent.com/4592/37261864-cedb4f54-2575-11e8-8c62-11c1316d354f.png">
