### PR TITLE
Use other-websites.csv when gathering hostnames

### DIFF
--- a/data/env.py
+++ b/data/env.py
@@ -42,13 +42,14 @@ GATHER_SUFFIXES = os.environ.get("GATHER_SUFFIXES", ".gov,.fed.us")
 # names and options must be in corresponding order
 GATHERER_NAMES = [
   "censys-snapshot", "rdns-snapshot",
-  "dap", "eot2016", "parents"
+  "dap", "eot2016", "other", "parents"
 ]
 GATHERER_OPTIONS = [
   "--censys-snapshot=%s" % META["data"]["censys_snapshot_url"],
   "--rdns-snapshot=%s" % META["data"]["rdns_snapshot_url"],
   "--dap=%s" % META["data"]["analytics_subdomains_url"],
   "--eot2016=%s" % META["data"]["eot_subdomains_url"],
+  "--other=%s" % META['data']['other_subdomains_url'],
   "--parents=%s" % DOMAINS
 ]
 

--- a/meta.yml
+++ b/meta.yml
@@ -30,6 +30,9 @@ data:
   # so this is relying on occasional snapshots which can be updated in-place in the repo.
   rdns_snapshot_url: https://github.com/GSA/data/raw/master/dotgov-websites/rdns-federal-snapshot.csv
 
+  # Some other websites, collected and curated by GSA and DHS.
+  other_subdomains_url: https://github.com/GSA/data/raw/master/dotgov-websites/other-websites.csv
+
 a11y:
   config: https://github.com/18F/pulse/raw/master/data/a11y_config/pa11y_config.json
   redirects: https://github.com/18F/pulse/raw/master/data/a11y_config/a11y_redirects.yml

--- a/templates/https/guide.html
+++ b/templates/https/guide.html
@@ -60,6 +60,10 @@
             <strong><a href="https://scans.io/study/sonar.rdns_v2">Rapid7 Reverse DNS data</a>:</strong>
             Rapid7 publishes a large bulk dataset of Reverse DNS data from the IPv4 space. Their data is updated roughly daily, but due to its size, Pulse uses a snapshot of their data, filtered down to just .gov and .fed.us hostnames, updated on an occasional basis. This snapshot is stored in a <a href="https://github.com/GSA/data/tree/master/dotgov-websites/">GSA GitHub repository</a>, and can be <a href="https://github.com/GSA/data/raw/master/dotgov-websites/rdns-federal-snapshot.csv">downloaded directly as a CSV here</a>.
           </li>
+          <li>
+            <strong><a href="https://github.com/GSA/data/tree/master/dotgov-websites">Other public .gov websites</a>:</strong>
+            Additional .gov hostnames of publicly accessible services, collected manually, typically by government staff at GSA or DHS. This data is stored in a <a href="https://github.com/GSA/data/tree/master/dotgov-websites">GSA GitHub repository</a>, and can be <a href="https://github.com/GSA/data/raw/master/dotgov-websites/other-websites.csv">downloaded directly as a CSV here</a>.
+          </li>
         </ul>
 
         <p>


### PR DESCRIPTION
This expands the gathered hostnames to use the `other-websites.csv` source, managed in https://github.com/GSA/data/tree/master/dotgov-websites, and newly contributed to by DHS NCATS via https://github.com/GSA/data/pull/119 and https://github.com/dhs-ncats/gatherer/issues/18.