### PR TITLE
Sort boolean fields properly when using Tables.boolean

### DIFF
--- a/static/js/tables.js
+++ b/static/js/tables.js
@@ -54,8 +54,9 @@ var Tables = {
 
   // common render function for displaying booleans as Yes/No
   boolean: function(data, type) {
-    if (type == "sort") return data;
-    else return {false: "No", true: "Yes"}[data];
+    // Note: return "No"/"Yes" for sorting as well,
+    // as sorting by raw boolean values doesn't seem to work right.
+    return {false: "No", true: "Yes"}[data];
   },
 
   // common render function for linking domains to canonical URLs


### PR DESCRIPTION
This sorts boolean fields on `"Yes"` and `"No"` instead of by `true` and `false`, which apparently doesn't work correctly.

This affected the Customer Satisfaction and DAP tables (which used `Tables.boolean`), but not the HTTPS tables, which is complicated enough to merit its own rendering.