### PR TITLE
Split out use of --parents and use "dotgov" for source name

### DIFF
--- a/data/env.py
+++ b/data/env.py
@@ -42,7 +42,7 @@ GATHER_SUFFIXES = os.environ.get("GATHER_SUFFIXES", ".gov,.fed.us")
 # names and options must be in corresponding order
 GATHERER_NAMES = [
   "censys-snapshot", "rdns-snapshot",
-  "dap", "eot2016", "other", "parents"
+  "dap", "eot2016", "other", "dotgov"
 ]
 GATHERER_OPTIONS = [
   "--censys-snapshot=%s" % META["data"]["censys_snapshot_url"],
@@ -50,7 +50,7 @@ GATHERER_OPTIONS = [
   "--dap=%s" % META["data"]["analytics_subdomains_url"],
   "--eot2016=%s" % META["data"]["eot_subdomains_url"],
   "--other=%s" % META['data']['other_subdomains_url'],
-  "--parents=%s" % DOMAINS
+  "--dotgov=%s" % DOMAINS
 ]
 
 # Run these scanners over *all* (which is a lot) discovered subdomains.

--- a/data/update.py
+++ b/data/update.py
@@ -243,6 +243,7 @@ def gather_subdomains(options):
   full_command += [
     "--output=%s" % SUBDOMAIN_DATA_GATHERED,
     "--suffix=%s" % GATHER_SUFFIXES,
+    "--parents=%s" % DOMAINS,
     "--ignore-www",
     "--sort",
     "--debug" # always capture full output


### PR DESCRIPTION
The domain-scan `gather` command is now stricter about option parsing, and we can't get away with `--parents` doing two things at once anymore. It's better to use `dotgov` as the source name, and let `--parents` be used for supplying the parent domains under which all source results should be scoped.