### PR TITLE
Set pulse environment to a non-default value.

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -17,6 +17,7 @@ applications:
     NEW_RELIC_APP_NAME: Pulse | Staging
     NEW_RELIC_ENV: staging
 services:
-  - pulse-creds-prod
+- pulse-creds-prod
 env:
   NEW_RELIC_CONFIG_FILE: newrelic.ini
+  PULSE_ENV: prod


### PR DESCRIPTION
Always serve application with waitress and run with debug mode off on
cloud foundry.

Looks like this was the issue affecting @jeremy-gillikin's fork.