### PR TITLE
Fix links to .gov domain list

### DIFF
--- a/templates/about.html
+++ b/templates/about.html
@@ -37,7 +37,7 @@
 				</li>
 				<!--<li>
 					<a href="#why-a11y">What is Accessibility, and why does Pulse measure it?</a>
-				</li>	-->			
+				</li>	-->
 				<li>
 					<a href="#fresh-data">When was the data last updated on Pulse?</a>
 				</li>
@@ -66,7 +66,7 @@
 					What federal domains are being measured?
 				</h4>
 				<p>
-					Currently, Pulse uses the <a href="https://github.com/GSA/data/tree/gh-pages/dotgov-domains">official <code>.gov</code> domain list</a> as a starting point, and focuses on domains owned by federal agencies. This also includes a few domains ending in <code>.fed.us</code>. Domains ending in other suffixes, such as <code>.mil</code> or <code>.us</code>, are not included at this time.
+					Currently, Pulse uses the <a href="https://github.com/GSA/data/tree/master/dotgov-domains">official <code>.gov</code> domain list</a> as a starting point, and focuses on domains owned by federal agencies. This also includes a few domains ending in <code>.fed.us</code>. Domains ending in other suffixes, such as <code>.mil</code> or <code>.us</code>, are not included at this time.
 				</p>
 
 				<p>
@@ -106,13 +106,13 @@
 					For websites, accessibility means that pages should be built according to certain standards that ensure, for example, that a visually impaired user accessing a government site through a screen reader will be able to navigate and access the same information available to a non-visually-impaired user.
 				</p>
 				<p>
-					The Accessibility Report measures adherence to best practices for implementing accessible websites in the federal government. 
+					The Accessibility Report measures adherence to best practices for implementing accessible websites in the federal government.
 				</p>
 				<p>
 					The US Government’s mission is to serve the needs of all its citizens, including the approximately 60 million who live with disabilities.
 				</p>
 			</li>-->
-			
+
 			<li id="fresh-data">
 				<h4>When was the data last updated on Pulse?</h4>
 
@@ -133,7 +133,7 @@
 				</p>
 				<p>
 					For questions specific to the Universal Accessibility and Design, you can open an issue on the <a href="https://github.com/18F/pulse/issues">Pulse GitHub repository</a>, or <a href="mailto:section.508@gsa.gov">email Section508.gov</a>.
-				</p>				
+				</p>
 				<!--<p>
 					For feedback or questions about Pulse, please <a href="https://github.com/18F/pulse/issues">open an issue on Pulse's GitHub repository</a>, or email <a href="mailto:pulse@cio.gov">pulse@cio.gov</a>.
 				</p>-->

--- a/templates/accessibility/guide.html
+++ b/templates/accessibility/guide.html
@@ -31,7 +31,7 @@
         This currently amounts to around 800 domains.
         </p>
         <p>
-        Pulse scans second-level federal .gov domains (e.g., agency.gov), checking the <a href="https://github.com/GSA/data/tree/gh-pages/dotgov-domains">official .gov domain list</a>.  Note that third-level federal domains (e.g., program.agency.gov), .mil, .edu, .us, and state, local, and Native Sovereign Nation (NSN) domains are NOT currently scanned by Pulse.
+        Pulse scans second-level federal .gov domains (e.g., agency.gov), checking the <a href="https://github.com/GSA/data/tree/master/dotgov-domains">official .gov domain list</a>.  Note that third-level federal domains (e.g., program.agency.gov), .mil, .edu, .us, and state, local, and Native Sovereign Nation (NSN) domains are NOT currently scanned by Pulse.
         </p>
       </article>
 


### PR DESCRIPTION
This fixes the broken link @sidewalkballet reported, and another one I found when I `grep`'d the templates directory.

Fixes #771.