### PR TITLE
Add logger module

### DIFF
--- a/data/logger.py
+++ b/data/logger.py
@@ -1,0 +1,25 @@
+import logging
+
+
+def unwrap_exception_message(exc: BaseException, join: str = ' - ') -> str:
+    if exc.__context__:
+        if exc.args:
+            return f'{exc}{join}{unwrap_exception_message(exc.__context__)}'
+        return f'{unwrap_exception_message(exc.__context__)}'
+    return f'{exc}'
+
+
+def get_logger(name: str) -> logging.Logger:
+    logger = logging.getLogger(name)
+    logger.setLevel(logging.INFO)
+
+    if not logger.hasHandlers():
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(
+            fmt='%(asctime)s - %(levelname)s - %(name)s: %(message)s',
+            datefmt='%Y-%m-%dT%H:%M:%S%z'
+        )
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    return logger

--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -1,0 +1,11 @@
+from data import logger
+
+
+def test_unwrap_exception_message() -> None:
+    try:
+        try:
+            raise ZeroDivisionError('ZeroDivisionError Message')
+        except ZeroDivisionError as exc:
+            raise ValueError('ValueError Message') from exc
+    except ValueError as exc:
+        assert logger.unwrap_exception_message(exc, ' - ') == 'ValueError Message - ZeroDivisionError Message'


### PR DESCRIPTION
This PR introduces a very basic logging module that CDS has used on another project. Actually using this module is in a later, separate, PR.

Fairly simple addition, a `get_logger` function that just wraps `logging. getLogger` with some formatting, and a function to extract exception messages from chained exceptions.