### PR TITLE
Parse branches and organizations in .gov data

### DIFF
--- a/data/processing.py
+++ b/data/processing.py
@@ -222,8 +222,10 @@ def load_domain_data():
       domain_name = dict_row["Domain Name"].lower().strip()
       domain_type = dict_row["Domain Type"].strip()
       agency_name = dict_row["Agency"].strip()
-      org_name = dict_row["Organization"].strip()
       agency_slug = slugify.slugify(agency_name)
+
+      # Unused and not stored for now, but noting here.
+      # org_name = dict_row["Organization"].strip()
 
       # Exclude cities, counties, tribes, etc.
       if not (domain_type.startswith("Federal Agency")):


### PR DESCRIPTION
With the update of the official .gov domain list in https://github.com/GSA/data/pull/136 to include branch name and organization name, this revamps the .gov domain parsing code to handle those fields properly. It also gets rid of some old and hard-to-maintain branch detection code in favor of relying on upstream determination.