### PR TITLE
Update analytics.yml with dotgov.gov

### DIFF
--- a/data/ineligible/analytics.yml
+++ b/data/ineligible/analytics.yml
@@ -5,6 +5,7 @@
 - cjis.gov
 - cpnireporting.gov
 - disasterhousing.gov
+- dotgov.gov
 - dod.gov
 - fdms.gov
 - homesales.gov


### PR DESCRIPTION
Since now dotgov.gov is a redirect, adding to the exclude list.