### PR TITLE
Fix sorting of the RC4/3DES/SSLv2/SSLv3 column

### DIFF
--- a/static/js/https/agencies.js
+++ b/static/js/https/agencies.js
@@ -18,24 +18,29 @@ $(document).ready(function () {
         },
         {
           data: "https.compliant",
+          type: "numeric",
           render: Tables.percent("https", "compliant"),
           className: "compliant",
           width: "100px"
         },
         {
           data: "https.enforces",
+          type: "numeric",
           render: Tables.percent("https", "enforces")
         },
         {
           data: "https.hsts",
+          type: "numeric",
           render: Tables.percent("https", "hsts")
         },
         {
           data: "crypto.bod_crypto",
+          type: "numeric",
           render: Tables.percent("crypto", "bod_crypto")
         },
         {
           data: "preloading.preloaded",
+          type: "numeric",
           render: Tables.percent("preloading", "preloaded")
         }
       ]

--- a/static/js/https/domains.js
+++ b/static/js/https/domains.js
@@ -39,20 +39,24 @@ $(function () {
         {data: "agency_name"}, // here for filtering/sorting
         {
           data: "totals.https.compliant",
+          type: "numeric",
           render: Tables.percentTotals("https", "compliant"),
           width: "100px",
           className: "compliant"
         },
         {
           data: "totals.https.enforces",
+          type: "numeric",
           render: Tables.percentTotals("https", "enforces")
         },
         {
           data: "totals.https.hsts",
+          type: "numeric",
           render: Tables.percentTotals("https", "hsts")
         },
         {
           data: "totals.crypto.bod_crypto",
+          type: "numeric",
           render: Tables.percentTotals("crypto", "bod_crypto")
         },
         {


### PR DESCRIPTION
Explicitly forcing a sorting `type` of `numeric`. The crypto field was sorting as a string instead of a number, despite returning a number from the `render` function, likely due to the use of a string value (`--`) for non-connectivity via SSLyze.

<img width="982" alt="screen shot 2018-06-20 at 1 07 44 pm" src="https://user-images.githubusercontent.com/4592/41673443-f33ae206-748a-11e8-88d1-223f1b8d3b04.png">

This fixes that, and also adds `type: "numeric"` to the other columns for good measure.