### PR TITLE
Was using wrong variable name to sanity check eligible reports

### DIFF
--- a/data/processing.py
+++ b/data/processing.py
@@ -581,7 +581,7 @@ def process_domains(domains, agencies, subdomains, parent_scan_data, subdomain_s
 
     # For SSLv2/SSLv3/RC4/3DES, sslyze-eligible parent + subdomains.
     subdomain_names = parent_scan_data[domain_name].get('subdomains', [])
-    eligible_reports = [subdomains[name]['https'] for name in subdomain_names if subdomains[subdomain_name].get('https') and subdomains[subdomain_name]['https'].get('rc4') is not None]
+    eligible_reports = [subdomains[name]['https'] for name in subdomain_names if subdomains[name].get('https') and subdomains[name]['https'].get('rc4') is not None]
     if https_parent and https_parent.get('rc4') is not None:
       eligible_reports = [https_parent] + eligible_reports
     totals['crypto'] = total_crypto_report(eligible_reports)


### PR DESCRIPTION
The `data/processing.py` script was using `subdomain_name` instead of `name` to index reports when sanity-checking them during processing. The `subdomain_name` variable would have referred to the result of unrelated use prior.

It seems to have been practically harmless (the sanity checking was just out of an abundance of caution), and this change doesn't affect the calculated numbers (or create/remove any new warning or exceptions) during data processing at all. It's good to fix it though, since it could have been the cause of new unexpected bugs if the `subdomain_name` value had ever changed, or if another change would have made the sanity-checking necessary or useful.