### PR TITLE
Tweak use of setdefault to not collide with existing local variable

### DIFF
--- a/data/processing.py
+++ b/data/processing.py
@@ -460,8 +460,7 @@ def load_subdomain_scan_data(domains, parent_scan_data, gathered_subdomains):
       if boolean_for(dict_row['Live']):
 
         # Initialize subdomains obj if this is its first one.
-        subdomains = parent_scan_data[parent_domain].setdefault('subdomains', [])
-        subdomains.append(subdomain)
+        parent_scan_data[parent_domain].setdefault('subdomains', []).append(subdomain)
 
         # if there are dupes for some reason, they'll be overwritten
         subdomain_scan_data[subdomain] = {'pshtt': dict_row}


### PR DESCRIPTION
This tweaks the work from the PR @buckley-w-david filed in #795 to avoid colliding with the existing `subdomains` variable. The `setdefault` code works fine, but the use of a local variable named `subdomains` created problems, as it was already in use in that block.

Without this tweak, the `data.processing` module crashes during data import.