### PR TITLE
[deps] Bumps pyyaml to 3.13

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ setuptools.setup(
         'flask==0.12',
         'gunicorn==19.6.0',
         'newrelic==2.86.2.68',
-        'pyyaml==3.12',
+        'pyyaml==3.13',
         'python-slugify==1.2.1',
         'tinydb==3.2.1',
         'ujson==1.35',


### PR DESCRIPTION
- 3.12 does not work with python 3.7.2

```Installing collected packages: pyyaml, Unidecode, python-slugify, tinydb, ujson, waitress, flask-compress, pulse
  Running setup.py install for pyyaml ... error
    Complete output from command /home/nemo/.virtualenvs/pulse/bin/python -u -c "import setuptools, tokenize;__file__='/tmp/pip-install-ky841ksc/pyyaml/setup.py';f=getattr(tokenize, 'open', open)(__file__);code=f.read().replace('\r\n', '\n');f.close();exec(compile(code, __file__, 'exec'))" install --record /tmp/pip-record-6qqi9nir/install-record.txt --single-version-externally-managed --compile --install-headers /home/nemo/.virtualenvs/pulse/include/site/python3.7/pyyaml:
    running install
    running build
    running build_py
    creating build
    creating build/lib.linux-x86_64-3.7
    creating build/lib.linux-x86_64-3.7/yaml
    copying lib3/yaml/tokens.py -> build/lib.linux-x86_64-3.7/yaml
    copying lib3/yaml/composer.py -> build/lib.linux-x86_64-3.7/yaml
    copying lib3/yaml/nodes.py -> build/lib.linux-x86_64-3.7/yaml
    copying lib3/yaml/loader.py -> build/lib.linux-x86_64-3.7/yaml
    copying lib3/yaml/parser.py -> build/lib.linux-x86_64-3.7/yaml
    copying lib3/yaml/reader.py -> build/lib.linux-x86_64-3.7/yaml
    copying lib3/yaml/cyaml.py -> build/lib.linux-x86_64-3.7/yaml
    copying lib3/yaml/constructor.py -> build/lib.linux-x86_64-3.7/yaml
    copying lib3/yaml/representer.py -> build/lib.linux-x86_64-3.7/yaml
    copying lib3/yaml/serializer.py -> build/lib.linux-x86_64-3.7/yaml
    copying lib3/yaml/emitter.py -> build/lib.linux-x86_64-3.7/yaml
    copying lib3/yaml/events.py -> build/lib.linux-x86_64-3.7/yaml
    copying lib3/yaml/scanner.py -> build/lib.linux-x86_64-3.7/yaml
    copying lib3/yaml/resolver.py -> build/lib.linux-x86_64-3.7/yaml
    copying lib3/yaml/dumper.py -> build/lib.linux-x86_64-3.7/yaml
    copying lib3/yaml/__init__.py -> build/lib.linux-x86_64-3.7/yaml
    copying lib3/yaml/error.py -> build/lib.linux-x86_64-3.7/yaml
    running build_ext
    creating build/temp.linux-x86_64-3.7
    checking if libyaml is compilable
    gcc -pthread -Wno-unused-result -Wsign-compare -DNDEBUG -g -fwrapv -O3 -Wall -march=x86-64 -mtune=generic -O3 -pipe -fstack-protector-strong -fno-plt -march=x86-64 -mtune=generic -O3 -pipe -fstack-protector-strong -fno-plt -march=x86-64 -mtune=generic -O3 -pipe -fstack-protector-strong -fno-plt -fPIC -I/usr/include/python3.7m -c build/temp.linux-x86_64-3.7/check_libyaml.c -o build/temp.linux-x86_64-3.7/check_libyaml.o
    checking if libyaml is linkable
    gcc -pthread build/temp.linux-x86_64-3.7/check_libyaml.o -L/usr/lib -lyaml -o build/temp.linux-x86_64-3.7/check_libyaml
    building '_yaml' extension
    creating build/temp.linux-x86_64-3.7/ext
    gcc -pthread -Wno-unused-result -Wsign-compare -DNDEBUG -g -fwrapv -O3 -Wall -march=x86-64 -mtune=generic -O3 -pipe -fstack-protector-strong -fno-plt -march=x86-64 -mtune=generic -O3 -pipe -fstack-protector-strong -fno-plt -march=x86-64 -mtune=generic -O3 -pipe -fstack-protector-strong -fno-plt -fPIC -I/usr/include/python3.7m -c ext/_yaml.c -o build/temp.linux-x86_64-3.7/ext/_yaml.o
    In file included from ext/_yaml.c:271:
    ext/_yaml.h:10: warning: "PyString_CheckExact" redefined
     #define PyString_CheckExact PyBytes_CheckExact
    
    ext/_yaml.c:139: note: this is the location of the previous definition
       #define PyString_CheckExact          PyUnicode_CheckExact
    
    ext/_yaml.c: In function ‘__pyx_pf_5_yaml_get_version_string’:
    ext/_yaml.c:1410:17: warning: assignment discards ‘const’ qualifier from pointer target type [-Wdiscarded-qualifiers]
       __pyx_v_value = yaml_get_version_string();
                     ^
    ext/_yaml.c: In function ‘__pyx_pf_5_yaml_7CParser___init__’:
    ext/_yaml.c:2577:52: warning: passing argument 2 of ‘yaml_parser_set_input’ from incompatible pointer type [-Wincompatible-pointer-types]
         yaml_parser_set_input((&__pyx_v_self->parser), __pyx_f_5_yaml_input_handler, ((void *)__pyx_v_self));
                                                        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
    In file included from ext/_yaml.h:2,
                     from ext/_yaml.c:271:
    /usr/include/yaml.h:1370:30: note: expected ‘int (*)(void *, unsigned char *, size_t,  size_t *)’ {aka ‘int (*)(void *, unsigned char *, long unsigned int,  long unsigned int *)’} but argument is of type ‘int (*)(void *, char *, size_t,  size_t *)’ {aka ‘int (*)(void *, char *, long unsigned int,  long unsigned int *)’}
             yaml_read_handler_t *handler, void *data);
             ~~~~~~~~~~~~~~~~~~~~~^~~~~~~
    In file included from /usr/include/python3.7m/Python.h:88,
                     from ext/_yaml.c:4:
    /usr/include/python3.7m/bytesobject.h:87:57: warning: pointer targets in passing argument 2 of ‘yaml_parser_set_input_string’ differ in signedness [-Wpointer-sign]
     #define PyBytes_AS_STRING(op) (assert(PyBytes_Check(op)), \
                                   ~~~~~~~~~~~~~~~~~~~~~~~~~~^~~
                                     (((PyBytesObject *)(op))->ob_sval))
                                     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    ext/_yaml.h:11:29: note: in expansion of macro ‘PyBytes_AS_STRING’
     #define PyString_AS_STRING  PyBytes_AS_STRING
                                 ^~~~~~~~~~~~~~~~~
    ext/_yaml.c:2818:59: note: in expansion of macro ‘PyString_AS_STRING’
         yaml_parser_set_input_string((&__pyx_v_self->parser), PyString_AS_STRING(__pyx_v_stream), PyString_GET_SIZE(__pyx_v_stream));
                                                               ^~~~~~~~~~~~~~~~~~
    In file included from ext/_yaml.h:2,
                     from ext/_yaml.c:271:
    /usr/include/yaml.h:1343:1: note: expected ‘const unsigned char *’ but argument is of type ‘char *’
     yaml_parser_set_input_string(yaml_parser_t *parser,
     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
    ext/_yaml.c: In function ‘__pyx_f_5_yaml_7CParser__token_to_object’:
    ext/_yaml.c:4572:71: warning: pointer targets in passing argument 1 of ‘PyUnicode_FromString’ differ in signedness [-Wpointer-sign]
         __pyx_t_2 = PyUnicode_FromString(__pyx_v_token->data.tag_directive.handle); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 417, __pyx_L1_error)
                                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~
    In file included from /usr/include/python3.7m/Python.h:89,
                     from ext/_yaml.c:4:
    /usr/include/python3.7m/unicodeobject.h:702:23: note: expected ‘const char *’ but argument is of type ‘yaml_char_t *’ {aka ‘unsigned char *’}
     PyAPI_FUNC(PyObject*) PyUnicode_FromString(
                           ^~~~~~~~~~~~~~~~~~~~
    ext/_yaml.c:4584:71: warning: pointer targets in passing argument 1 of ‘PyUnicode_FromString’ differ in signedness [-Wpointer-sign]
         __pyx_t_2 = PyUnicode_FromString(__pyx_v_token->data.tag_directive.prefix); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 418, __pyx_L1_error)
                                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~
    In file included from /usr/include/python3.7m/Python.h:89,
                     from ext/_yaml.c:4:
    /usr/include/python3.7m/unicodeobject.h:702:23: note: expected ‘const char *’ but argument is of type ‘yaml_char_t *’ {aka ‘unsigned char *’}
     PyAPI_FUNC(PyObject*) PyUnicode_FromString(
                           ^~~~~~~~~~~~~~~~~~~~
    ext/_yaml.c:5444:63: warning: pointer targets in passing argument 1 of ‘PyUnicode_FromString’ differ in signedness [-Wpointer-sign]
         __pyx_t_2 = PyUnicode_FromString(__pyx_v_token->data.alias.value); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 448, __pyx_L1_error)
                                          ~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~
    In file included from /usr/include/python3.7m/Python.h:89,
                     from ext/_yaml.c:4:
    /usr/include/python3.7m/unicodeobject.h:702:23: note: expected ‘const char *’ but argument is of type ‘yaml_char_t *’ {aka ‘unsigned char *’}
     PyAPI_FUNC(PyObject*) PyUnicode_FromString(
                           ^~~~~~~~~~~~~~~~~~~~
    ext/_yaml.c:5518:64: warning: pointer targets in passing argument 1 of ‘PyUnicode_FromString’ differ in signedness [-Wpointer-sign]
         __pyx_t_2 = PyUnicode_FromString(__pyx_v_token->data.anchor.value); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 451, __pyx_L1_error)
                                          ~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~
    In file included from /usr/include/python3.7m/Python.h:89,
                     from ext/_yaml.c:4:
    /usr/include/python3.7m/unicodeobject.h:702:23: note: expected ‘const char *’ but argument is of type ‘yaml_char_t *’ {aka ‘unsigned char *’}
     PyAPI_FUNC(PyObject*) PyUnicode_FromString(
                           ^~~~~~~~~~~~~~~~~~~~
    ext/_yaml.c:5592:61: warning: pointer targets in passing argument 1 of ‘PyUnicode_FromString’ differ in signedness [-Wpointer-sign]
         __pyx_t_2 = PyUnicode_FromString(__pyx_v_token->data.tag.handle); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 454, __pyx_L1_error)
                                          ~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~
    In file included from /usr/include/python3.7m/Python.h:89,
                     from ext/_yaml.c:4:
    /usr/include/python3.7m/unicodeobject.h:702:23: note: expected ‘const char *’ but argument is of type ‘yaml_char_t *’ {aka ‘unsigned char *’}
     PyAPI_FUNC(PyObject*) PyUnicode_FromString(
                           ^~~~~~~~~~~~~~~~~~~~
    ext/_yaml.c:5604:61: warning: pointer targets in passing argument 1 of ‘PyUnicode_FromString’ differ in signedness [-Wpointer-sign]
         __pyx_t_2 = PyUnicode_FromString(__pyx_v_token->data.tag.suffix); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 455, __pyx_L1_error)
                                          ~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~
    In file included from /usr/include/python3.7m/Python.h:89,
                     from ext/_yaml.c:4:
    /usr/include/python3.7m/unicodeobject.h:702:23: note: expected ‘const char *’ but argument is of type ‘yaml_char_t *’ {aka ‘unsigned char *’}
     PyAPI_FUNC(PyObject*) PyUnicode_FromString(
                           ^~~~~~~~~~~~~~~~~~~~
    ext/_yaml.c:5716:64: warning: pointer targets in passing argument 1 of ‘PyUnicode_DecodeUTF8’ differ in signedness [-Wpointer-sign]
         __pyx_t_2 = PyUnicode_DecodeUTF8(__pyx_v_token->data.scalar.value, __pyx_v_token->data.scalar.length, ((char *)"strict")); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 460, __pyx_L1_error)
                                          ~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~
    In file included from /usr/include/python3.7m/Python.h:89,
                     from ext/_yaml.c:4:
    /usr/include/python3.7m/unicodeobject.h:1298:23: note: expected ‘const char *’ but argument is of type ‘yaml_char_t *’ {aka ‘unsigned char *’}
     PyAPI_FUNC(PyObject*) PyUnicode_DecodeUTF8(
                           ^~~~~~~~~~~~~~~~~~~~
    ext/_yaml.c: In function ‘__pyx_f_5_yaml_7CParser__event_to_object’:
    ext/_yaml.c:7424:63: warning: pointer targets in passing argument 1 of ‘PyUnicode_FromString’ differ in signedness [-Wpointer-sign]
             __pyx_t_4 = PyUnicode_FromString(__pyx_v_tag_directive->handle); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 574, __pyx_L1_error)
                                              ~~~~~~~~~~~~~~~~~~~~~^~~~~~~~
    In file included from /usr/include/python3.7m/Python.h:89,
                     from ext/_yaml.c:4:
    /usr/include/python3.7m/unicodeobject.h:702:23: note: expected ‘const char *’ but argument is of type ‘yaml_char_t *’ {aka ‘unsigned char *’}
     PyAPI_FUNC(PyObject*) PyUnicode_FromString(
                           ^~~~~~~~~~~~~~~~~~~~
    ext/_yaml.c:7436:63: warning: pointer targets in passing argument 1 of ‘PyUnicode_FromString’ differ in signedness [-Wpointer-sign]
             __pyx_t_4 = PyUnicode_FromString(__pyx_v_tag_directive->prefix); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 575, __pyx_L1_error)
                                              ~~~~~~~~~~~~~~~~~~~~~^~~~~~~~
    In file included from /usr/include/python3.7m/Python.h:89,
                     from ext/_yaml.c:4:
    /usr/include/python3.7m/unicodeobject.h:702:23: note: expected ‘const char *’ but argument is of type ‘yaml_char_t *’ {aka ‘unsigned char *’}
     PyAPI_FUNC(PyObject*) PyUnicode_FromString(
                           ^~~~~~~~~~~~~~~~~~~~
    ext/_yaml.c:7655:63: warning: pointer targets in passing argument 1 of ‘PyUnicode_FromString’ differ in signedness [-Wpointer-sign]
         __pyx_t_4 = PyUnicode_FromString(__pyx_v_event->data.alias.anchor); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 586, __pyx_L1_error)
                                          ~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~
    In file included from /usr/include/python3.7m/Python.h:89,
                     from ext/_yaml.c:4:
    /usr/include/python3.7m/unicodeobject.h:702:23: note: expected ‘const char *’ but argument is of type ‘yaml_char_t *’ {aka ‘unsigned char *’}
     PyAPI_FUNC(PyObject*) PyUnicode_FromString(
                           ^~~~~~~~~~~~~~~~~~~~
    ext/_yaml.c:7749:66: warning: pointer targets in passing argument 1 of ‘PyUnicode_FromString’ differ in signedness [-Wpointer-sign]
           __pyx_t_4 = PyUnicode_FromString(__pyx_v_event->data.scalar.anchor); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 591, __pyx_L1_error)
                                            ~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~
    In file included from /usr/include/python3.7m/Python.h:89,
                     from ext/_yaml.c:4:
    /usr/include/python3.7m/unicodeobject.h:702:23: note: expected ‘const char *’ but argument is of type ‘yaml_char_t *’ {aka ‘unsigned char *’}
     PyAPI_FUNC(PyObject*) PyUnicode_FromString(
                           ^~~~~~~~~~~~~~~~~~~~
    ext/_yaml.c:7790:66: warning: pointer targets in passing argument 1 of ‘PyUnicode_FromString’ differ in signedness [-Wpointer-sign]
           __pyx_t_4 = PyUnicode_FromString(__pyx_v_event->data.scalar.tag); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 594, __pyx_L1_error)
                                            ~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~
    In file included from /usr/include/python3.7m/Python.h:89,
                     from ext/_yaml.c:4:
    /usr/include/python3.7m/unicodeobject.h:702:23: note: expected ‘const char *’ but argument is of type ‘yaml_char_t *’ {aka ‘unsigned char *’}
     PyAPI_FUNC(PyObject*) PyUnicode_FromString(
                           ^~~~~~~~~~~~~~~~~~~~
    ext/_yaml.c:7811:64: warning: pointer targets in passing argument 1 of ‘PyUnicode_DecodeUTF8’ differ in signedness [-Wpointer-sign]
         __pyx_t_4 = PyUnicode_DecodeUTF8(__pyx_v_event->data.scalar.value, __pyx_v_event->data.scalar.length, ((char *)"strict")); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 595, __pyx_L1_error)
                                          ~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~
    In file included from /usr/include/python3.7m/Python.h:89,
                     from ext/_yaml.c:4:
    /usr/include/python3.7m/unicodeobject.h:1298:23: note: expected ‘const char *’ but argument is of type ‘yaml_char_t *’ {aka ‘unsigned char *’}
     PyAPI_FUNC(PyObject*) PyUnicode_DecodeUTF8(
                           ^~~~~~~~~~~~~~~~~~~~
    ext/_yaml.c:8179:74: warning: pointer targets in passing argument 1 of ‘PyUnicode_FromString’ differ in signedness [-Wpointer-sign]
           __pyx_t_4 = PyUnicode_FromString(__pyx_v_event->data.sequence_start.anchor); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 620, __pyx_L1_error)
                                            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~
    In file included from /usr/include/python3.7m/Python.h:89,
                     from ext/_yaml.c:4:
    /usr/include/python3.7m/unicodeobject.h:702:23: note: expected ‘const char *’ but argument is of type ‘yaml_char_t *’ {aka ‘unsigned char *’}
     PyAPI_FUNC(PyObject*) PyUnicode_FromString(
                           ^~~~~~~~~~~~~~~~~~~~
    ext/_yaml.c:8220:74: warning: pointer targets in passing argument 1 of ‘PyUnicode_FromString’ differ in signedness [-Wpointer-sign]
           __pyx_t_4 = PyUnicode_FromString(__pyx_v_event->data.sequence_start.tag); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 623, __pyx_L1_error)
                                            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~
    In file included from /usr/include/python3.7m/Python.h:89,
                     from ext/_yaml.c:4:
    /usr/include/python3.7m/unicodeobject.h:702:23: note: expected ‘const char *’ but argument is of type ‘yaml_char_t *’ {aka ‘unsigned char *’}
     PyAPI_FUNC(PyObject*) PyUnicode_FromString(
                           ^~~~~~~~~~~~~~~~~~~~
    ext/_yaml.c:8449:73: warning: pointer targets in passing argument 1 of ‘PyUnicode_FromString’ differ in signedness [-Wpointer-sign]
           __pyx_t_4 = PyUnicode_FromString(__pyx_v_event->data.mapping_start.anchor); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 637, __pyx_L1_error)
                                            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~
    In file included from /usr/include/python3.7m/Python.h:89,
                     from ext/_yaml.c:4:
    /usr/include/python3.7m/unicodeobject.h:702:23: note: expected ‘const char *’ but argument is of type ‘yaml_char_t *’ {aka ‘unsigned char *’}
     PyAPI_FUNC(PyObject*) PyUnicode_FromString(
                           ^~~~~~~~~~~~~~~~~~~~
    ext/_yaml.c:8490:73: warning: pointer targets in passing argument 1 of ‘PyUnicode_FromString’ differ in signedness [-Wpointer-sign]
           __pyx_t_4 = PyUnicode_FromString(__pyx_v_event->data.mapping_start.tag); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 640, __pyx_L1_error)
                                            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~
    In file included from /usr/include/python3.7m/Python.h:89,
                     from ext/_yaml.c:4:
    /usr/include/python3.7m/unicodeobject.h:702:23: note: expected ‘const char *’ but argument is of type ‘yaml_char_t *’ {aka ‘unsigned char *’}
     PyAPI_FUNC(PyObject*) PyUnicode_FromString(
                           ^~~~~~~~~~~~~~~~~~~~
    ext/_yaml.c: In function ‘__pyx_f_5_yaml_7CParser__compose_node’:
    ext/_yaml.c:10094:75: warning: pointer targets in passing argument 1 of ‘PyUnicode_FromString’ differ in signedness [-Wpointer-sign]
         __pyx_t_3 = PyUnicode_FromString(__pyx_v_self->parsed_event.data.alias.anchor); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 734, __pyx_L1_error)
                                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~
    In file included from /usr/include/python3.7m/Python.h:89,
                     from ext/_yaml.c:4:
    /usr/include/python3.7m/unicodeobject.h:702:23: note: expected ‘const char *’ but argument is of type ‘yaml_char_t *’ {aka ‘unsigned char *’}
     PyAPI_FUNC(PyObject*) PyUnicode_FromString(
                           ^~~~~~~~~~~~~~~~~~~~
    ext/_yaml.c:10378:76: warning: pointer targets in passing argument 1 of ‘PyUnicode_FromString’ differ in signedness [-Wpointer-sign]
         __pyx_t_6 = PyUnicode_FromString(__pyx_v_self->parsed_event.data.scalar.anchor); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 750, __pyx_L1_error)
                                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~
    In file included from /usr/include/python3.7m/Python.h:89,
                     from ext/_yaml.c:4:
    /usr/include/python3.7m/unicodeobject.h:702:23: note: expected ‘const char *’ but argument is of type ‘yaml_char_t *’ {aka ‘unsigned char *’}
     PyAPI_FUNC(PyObject*) PyUnicode_FromString(
                           ^~~~~~~~~~~~~~~~~~~~
    ext/_yaml.c:10434:84: warning: pointer targets in passing argument 1 of ‘PyUnicode_FromString’ differ in signedness [-Wpointer-sign]
         __pyx_t_6 = PyUnicode_FromString(__pyx_v_self->parsed_event.data.sequence_start.anchor); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 753, __pyx_L1_error)
                                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~
    In file included from /usr/include/python3.7m/Python.h:89,
                     from ext/_yaml.c:4:
    /usr/include/python3.7m/unicodeobject.h:702:23: note: expected ‘const char *’ but argument is of type ‘yaml_char_t *’ {aka ‘unsigned char *’}
     PyAPI_FUNC(PyObject*) PyUnicode_FromString(
                           ^~~~~~~~~~~~~~~~~~~~
    ext/_yaml.c:10490:83: warning: pointer targets in passing argument 1 of ‘PyUnicode_FromString’ differ in signedness [-Wpointer-sign]
         __pyx_t_6 = PyUnicode_FromString(__pyx_v_self->parsed_event.data.mapping_start.anchor); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 756, __pyx_L1_error)
                                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~
    In file included from /usr/include/python3.7m/Python.h:89,
                     from ext/_yaml.c:4:
    /usr/include/python3.7m/unicodeobject.h:702:23: note: expected ‘const char *’ but argument is of type ‘yaml_char_t *’ {aka ‘unsigned char *’}
     PyAPI_FUNC(PyObject*) PyUnicode_FromString(
                           ^~~~~~~~~~~~~~~~~~~~
    ext/_yaml.c: In function ‘__pyx_f_5_yaml_7CParser__compose_scalar_node’:
    ext/_yaml.c:11109:74: warning: pointer targets in passing argument 1 of ‘PyUnicode_DecodeUTF8’ differ in signedness [-Wpointer-sign]
       __pyx_t_2 = PyUnicode_DecodeUTF8(__pyx_v_self->parsed_event.data.scalar.value, __pyx_v_self->parsed_event.data.scalar.length, ((char *)"strict")); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 791, __pyx_L1_error)
                                        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~
    In file included from /usr/include/python3.7m/Python.h:89,
                     from ext/_yaml.c:4:
    /usr/include/python3.7m/unicodeobject.h:1298:23: note: expected ‘const char *’ but argument is of type ‘yaml_char_t *’ {aka ‘unsigned char *’}
     PyAPI_FUNC(PyObject*) PyUnicode_DecodeUTF8(
                           ^~~~~~~~~~~~~~~~~~~~
    ext/_yaml.c:11310:76: warning: pointer targets in passing argument 1 of ‘PyUnicode_FromString’ differ in signedness [-Wpointer-sign]
         __pyx_t_2 = PyUnicode_FromString(__pyx_v_self->parsed_event.data.scalar.tag); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 804, __pyx_L1_error)
                                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~
    In file included from /usr/include/python3.7m/Python.h:89,
                     from ext/_yaml.c:4:
    /usr/include/python3.7m/unicodeobject.h:702:23: note: expected ‘const char *’ but argument is of type ‘yaml_char_t *’ {aka ‘unsigned char *’}
     PyAPI_FUNC(PyObject*) PyUnicode_FromString(
                           ^~~~~~~~~~~~~~~~~~~~
    ext/_yaml.c: In function ‘__pyx_f_5_yaml_7CParser__compose_sequence_node’:
    ext/_yaml.c:11841:84: warning: pointer targets in passing argument 1 of ‘PyUnicode_FromString’ differ in signedness [-Wpointer-sign]
         __pyx_t_3 = PyUnicode_FromString(__pyx_v_self->parsed_event.data.sequence_start.tag); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 837, __pyx_L1_error)
                                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~
    In file included from /usr/include/python3.7m/Python.h:89,
                     from ext/_yaml.c:4:
    /usr/include/python3.7m/unicodeobject.h:702:23: note: expected ‘const char *’ but argument is of type ‘yaml_char_t *’ {aka ‘unsigned char *’}
     PyAPI_FUNC(PyObject*) PyUnicode_FromString(
                           ^~~~~~~~~~~~~~~~~~~~
    ext/_yaml.c: In function ‘__pyx_f_5_yaml_7CParser__compose_mapping_node’:
    ext/_yaml.c:12435:83: warning: pointer targets in passing argument 1 of ‘PyUnicode_FromString’ differ in signedness [-Wpointer-sign]
         __pyx_t_3 = PyUnicode_FromString(__pyx_v_self->parsed_event.data.mapping_start.tag); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 876, __pyx_L1_error)
                                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~
    In file included from /usr/include/python3.7m/Python.h:89,
                     from ext/_yaml.c:4:
    /usr/include/python3.7m/unicodeobject.h:702:23: note: expected ‘const char *’ but argument is of type ‘yaml_char_t *’ {aka ‘unsigned char *’}
     PyAPI_FUNC(PyObject*) PyUnicode_FromString(
                           ^~~~~~~~~~~~~~~~~~~~
    ext/_yaml.c: In function ‘__pyx_f_5_yaml_input_handler’:
    ext/_yaml.c:13141:87: warning: comparison of integer expressions of different signedness: ‘int’ and ‘size_t’ {aka ‘long unsigned int’} [-Wsign-compare]
       __pyx_t_3 = (((__pyx_v_parser->stream_cache_len - __pyx_v_parser->stream_cache_pos) < __pyx_v_size) != 0);
                                                                                           ^
    ext/_yaml.c: In function ‘__pyx_pf_5_yaml_8CEmitter___init__’:
    ext/_yaml.c:13630:53: warning: passing argument 2 of ‘yaml_emitter_set_output’ from incompatible pointer type [-Wincompatible-pointer-types]
       yaml_emitter_set_output((&__pyx_v_self->emitter), __pyx_f_5_yaml_output_handler, ((void *)__pyx_v_self));
                                                         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    In file included from ext/_yaml.h:2,
                     from ext/_yaml.c:271:
    /usr/include/yaml.h:1832:31: note: expected ‘int (*)(void *, unsigned char *, size_t)’ {aka ‘int (*)(void *, unsigned char *, long unsigned int)’} but argument is of type ‘int (*)(void *, char *, size_t)’ {aka ‘int (*)(void *, char *, long unsigned int)’}
             yaml_write_handler_t *handler, void *data);
             ~~~~~~~~~~~~~~~~~~~~~~^~~~~~~
    ext/_yaml.c: In function ‘__pyx_f_5_yaml_8CEmitter__object_to_event’:
    ext/_yaml.c:15002:44: warning: pointer targets in assignment from ‘char *’ to ‘yaml_char_t *’ {aka ‘unsigned char *’} differ in signedness [-Wpointer-sign]
             __pyx_v_tag_directives_end->handle = PyString_AS_STRING(__pyx_v_handle);
                                                ^
    ext/_yaml.c:15117:44: warning: pointer targets in assignment from ‘char *’ to ‘yaml_char_t *’ {aka ‘unsigned char *’} differ in signedness [-Wpointer-sign]
             __pyx_v_tag_directives_end->prefix = PyString_AS_STRING(__pyx_v_prefix);
                                                ^
    ext/_yaml.c:15454:62: warning: pointer targets in passing argument 2 of ‘yaml_alias_event_initialize’ differ in signedness [-Wpointer-sign]
         __pyx_t_2 = ((yaml_alias_event_initialize(__pyx_v_event, __pyx_v_anchor) == 0) != 0);
                                                                  ^~~~~~~~~~~~~~
    In file included from ext/_yaml.h:2,
                     from ext/_yaml.c:271:
    /usr/include/yaml.h:555:1: note: expected ‘yaml_char_t *’ {aka ‘unsigned char *’} but argument is of type ‘char *’
     yaml_alias_event_initialize(yaml_event_t *event, yaml_char_t *anchor);
     ^~~~~~~~~~~~~~~~~~~~~~~~~~~
    ext/_yaml.c:16169:63: warning: pointer targets in passing argument 2 of ‘yaml_scalar_event_initialize’ differ in signedness [-Wpointer-sign]
         __pyx_t_2 = ((yaml_scalar_event_initialize(__pyx_v_event, __pyx_v_anchor, __pyx_v_tag, __pyx_v_value, __pyx_v_length, __pyx_v_plain_implicit, __pyx_v_quoted_implicit, __pyx_v_scalar_style) == 0) != 0);
                                                                   ^~~~~~~~~~~~~~
    In file included from ext/_yaml.h:2,
                     from ext/_yaml.c:271:
    /usr/include/yaml.h:580:1: note: expected ‘yaml_char_t *’ {aka ‘unsigned char *’} but argument is of type ‘char *’
     yaml_scalar_event_initialize(yaml_event_t *event,
     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
    ext/_yaml.c:16169:79: warning: pointer targets in passing argument 3 of ‘yaml_scalar_event_initialize’ differ in signedness [-Wpointer-sign]
         __pyx_t_2 = ((yaml_scalar_event_initialize(__pyx_v_event, __pyx_v_anchor, __pyx_v_tag, __pyx_v_value, __pyx_v_length, __pyx_v_plain_implicit, __pyx_v_quoted_implicit, __pyx_v_scalar_style) == 0) != 0);
                                                                                   ^~~~~~~~~~~
    In file included from ext/_yaml.h:2,
                     from ext/_yaml.c:271:
    /usr/include/yaml.h:580:1: note: expected ‘yaml_char_t *’ {aka ‘unsigned char *’} but argument is of type ‘char *’
     yaml_scalar_event_initialize(yaml_event_t *event,
     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
    ext/_yaml.c:16169:92: warning: pointer targets in passing argument 4 of ‘yaml_scalar_event_initialize’ differ in signedness [-Wpointer-sign]
         __pyx_t_2 = ((yaml_scalar_event_initialize(__pyx_v_event, __pyx_v_anchor, __pyx_v_tag, __pyx_v_value, __pyx_v_length, __pyx_v_plain_implicit, __pyx_v_quoted_implicit, __pyx_v_scalar_style) == 0) != 0);
                                                                                                ^~~~~~~~~~~~~
    In file included from ext/_yaml.h:2,
                     from ext/_yaml.c:271:
    /usr/include/yaml.h:580:1: note: expected ‘yaml_char_t *’ {aka ‘unsigned char *’} but argument is of type ‘char *’
     yaml_scalar_event_initialize(yaml_event_t *event,
     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
    ext/_yaml.c:16603:71: warning: pointer targets in passing argument 2 of ‘yaml_sequence_start_event_initialize’ differ in signedness [-Wpointer-sign]
         __pyx_t_3 = ((yaml_sequence_start_event_initialize(__pyx_v_event, __pyx_v_anchor, __pyx_v_tag, __pyx_v_implicit, __pyx_v_sequence_style) == 0) != 0);
                                                                           ^~~~~~~~~~~~~~
    In file included from ext/_yaml.h:2,
                     from ext/_yaml.c:271:
    /usr/include/yaml.h:603:1: note: expected ‘yaml_char_t *’ {aka ‘unsigned char *’} but argument is of type ‘char *’
     yaml_sequence_start_event_initialize(yaml_event_t *event,
     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    ext/_yaml.c:16603:87: warning: pointer targets in passing argument 3 of ‘yaml_sequence_start_event_initialize’ differ in signedness [-Wpointer-sign]
         __pyx_t_3 = ((yaml_sequence_start_event_initialize(__pyx_v_event, __pyx_v_anchor, __pyx_v_tag, __pyx_v_implicit, __pyx_v_sequence_style) == 0) != 0);
                                                                                           ^~~~~~~~~~~
    In file included from ext/_yaml.h:2,
                     from ext/_yaml.c:271:
    /usr/include/yaml.h:603:1: note: expected ‘yaml_char_t *’ {aka ‘unsigned char *’} but argument is of type ‘char *’
     yaml_sequence_start_event_initialize(yaml_event_t *event,
     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    ext/_yaml.c:17037:70: warning: pointer targets in passing argument 2 of ‘yaml_mapping_start_event_initialize’ differ in signedness [-Wpointer-sign]
         __pyx_t_2 = ((yaml_mapping_start_event_initialize(__pyx_v_event, __pyx_v_anchor, __pyx_v_tag, __pyx_v_implicit, __pyx_v_mapping_style) == 0) != 0);
                                                                          ^~~~~~~~~~~~~~
    In file included from ext/_yaml.h:2,
                     from ext/_yaml.c:271:
    /usr/include/yaml.h:635:1: note: expected ‘yaml_char_t *’ {aka ‘unsigned char *’} but argument is of type ‘char *’
     yaml_mapping_start_event_initialize(yaml_event_t *event,
     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    ext/_yaml.c:17037:86: warning: pointer targets in passing argument 3 of ‘yaml_mapping_start_event_initialize’ differ in signedness [-Wpointer-sign]
         __pyx_t_2 = ((yaml_mapping_start_event_initialize(__pyx_v_event, __pyx_v_anchor, __pyx_v_tag, __pyx_v_implicit, __pyx_v_mapping_style) == 0) != 0);
                                                                                          ^~~~~~~~~~~
    In file included from ext/_yaml.h:2,
                     from ext/_yaml.c:271:
    /usr/include/yaml.h:635:1: note: expected ‘yaml_char_t *’ {aka ‘unsigned char *’} but argument is of type ‘char *’
     yaml_mapping_start_event_initialize(yaml_event_t *event,
     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    ext/_yaml.c: In function ‘__pyx_pf_5_yaml_8CEmitter_12serialize’:
    ext/_yaml.c:18516:42: warning: pointer targets in assignment from ‘char *’ to ‘yaml_char_t *’ {aka ‘unsigned char *’} differ in signedness [-Wpointer-sign]
           __pyx_v_tag_directives_end->handle = PyString_AS_STRING(__pyx_v_handle);
                                              ^
    ext/_yaml.c:18631:42: warning: pointer targets in assignment from ‘char *’ to ‘yaml_char_t *’ {aka ‘unsigned char *’} differ in signedness [-Wpointer-sign]
           __pyx_v_tag_directives_end->prefix = PyString_AS_STRING(__pyx_v_prefix);
                                              ^
    ext/_yaml.c: In function ‘__pyx_f_5_yaml_8CEmitter__serialize_node’:
    ext/_yaml.c:19491:65: warning: pointer targets in passing argument 2 of ‘yaml_alias_event_initialize’ differ in signedness [-Wpointer-sign]
         __pyx_t_2 = ((yaml_alias_event_initialize((&__pyx_v_event), __pyx_v_anchor) == 0) != 0);
                                                                     ^~~~~~~~~~~~~~
    In file included from ext/_yaml.h:2,
                     from ext/_yaml.c:271:
    /usr/include/yaml.h:555:1: note: expected ‘yaml_char_t *’ {aka ‘unsigned char *’} but argument is of type ‘char *’
     yaml_alias_event_initialize(yaml_event_t *event, yaml_char_t *anchor);
     ^~~~~~~~~~~~~~~~~~~~~~~~~~~
    ext/_yaml.c:20240:68: warning: pointer targets in passing argument 2 of ‘yaml_scalar_event_initialize’ differ in signedness [-Wpointer-sign]
           __pyx_t_2 = ((yaml_scalar_event_initialize((&__pyx_v_event), __pyx_v_anchor, __pyx_v_tag, __pyx_v_value, __pyx_v_length, __pyx_v_plain_implicit, __pyx_v_quoted_implicit, __pyx_v_scalar_style) == 0) != 0);
                                                                        ^~~~~~~~~~~~~~
    In file included from ext/_yaml.h:2,
                     from ext/_yaml.c:271:
    /usr/include/yaml.h:580:1: note: expected ‘yaml_char_t *’ {aka ‘unsigned char *’} but argument is of type ‘char *’
     yaml_scalar_event_initialize(yaml_event_t *event,
     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
    ext/_yaml.c:20240:84: warning: pointer targets in passing argument 3 of ‘yaml_scalar_event_initialize’ differ in signedness [-Wpointer-sign]
           __pyx_t_2 = ((yaml_scalar_event_initialize((&__pyx_v_event), __pyx_v_anchor, __pyx_v_tag, __pyx_v_value, __pyx_v_length, __pyx_v_plain_implicit, __pyx_v_quoted_implicit, __pyx_v_scalar_style) == 0) != 0);
                                                                                        ^~~~~~~~~~~
    In file included from ext/_yaml.h:2,
                     from ext/_yaml.c:271:
    /usr/include/yaml.h:580:1: note: expected ‘yaml_char_t *’ {aka ‘unsigned char *’} but argument is of type ‘char *’
     yaml_scalar_event_initialize(yaml_event_t *event,
     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
    ext/_yaml.c:20240:97: warning: pointer targets in passing argument 4 of ‘yaml_scalar_event_initialize’ differ in signedness [-Wpointer-sign]
           __pyx_t_2 = ((yaml_scalar_event_initialize((&__pyx_v_event), __pyx_v_anchor, __pyx_v_tag, __pyx_v_value, __pyx_v_length, __pyx_v_plain_implicit, __pyx_v_quoted_implicit, __pyx_v_scalar_style) == 0) != 0);
                                                                                                     ^~~~~~~~~~~~~
    In file included from ext/_yaml.h:2,
                     from ext/_yaml.c:271:
    /usr/include/yaml.h:580:1: note: expected ‘yaml_char_t *’ {aka ‘unsigned char *’} but argument is of type ‘char *’
     yaml_scalar_event_initialize(yaml_event_t *event,
     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
    ext/_yaml.c:20605:76: warning: pointer targets in passing argument 2 of ‘yaml_sequence_start_event_initialize’ differ in signedness [-Wpointer-sign]
           __pyx_t_2 = ((yaml_sequence_start_event_initialize((&__pyx_v_event), __pyx_v_anchor, __pyx_v_tag, __pyx_v_implicit, __pyx_v_sequence_style) == 0) != 0);
                                                                                ^~~~~~~~~~~~~~
    In file included from ext/_yaml.h:2,
                     from ext/_yaml.c:271:
    /usr/include/yaml.h:603:1: note: expected ‘yaml_char_t *’ {aka ‘unsigned char *’} but argument is of type ‘char *’
     yaml_sequence_start_event_initialize(yaml_event_t *event,
     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    ext/_yaml.c:20605:92: warning: pointer targets in passing argument 3 of ‘yaml_sequence_start_event_initialize’ differ in signedness [-Wpointer-sign]
           __pyx_t_2 = ((yaml_sequence_start_event_initialize((&__pyx_v_event), __pyx_v_anchor, __pyx_v_tag, __pyx_v_implicit, __pyx_v_sequence_style) == 0) != 0);
                                                                                                ^~~~~~~~~~~
    In file included from ext/_yaml.h:2,
                     from ext/_yaml.c:271:
    /usr/include/yaml.h:603:1: note: expected ‘yaml_char_t *’ {aka ‘unsigned char *’} but argument is of type ‘char *’
     yaml_sequence_start_event_initialize(yaml_event_t *event,
     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    ext/_yaml.c:21113:75: warning: pointer targets in passing argument 2 of ‘yaml_mapping_start_event_initialize’ differ in signedness [-Wpointer-sign]
           __pyx_t_2 = ((yaml_mapping_start_event_initialize((&__pyx_v_event), __pyx_v_anchor, __pyx_v_tag, __pyx_v_implicit, __pyx_v_mapping_style) == 0) != 0);
                                                                               ^~~~~~~~~~~~~~
    In file included from ext/_yaml.h:2,
                     from ext/_yaml.c:271:
    /usr/include/yaml.h:635:1: note: expected ‘yaml_char_t *’ {aka ‘unsigned char *’} but argument is of type ‘char *’
     yaml_mapping_start_event_initialize(yaml_event_t *event,
     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    ext/_yaml.c:21113:91: warning: pointer targets in passing argument 3 of ‘yaml_mapping_start_event_initialize’ differ in signedness [-Wpointer-sign]
           __pyx_t_2 = ((yaml_mapping_start_event_initialize((&__pyx_v_event), __pyx_v_anchor, __pyx_v_tag, __pyx_v_implicit, __pyx_v_mapping_style) == 0) != 0);
                                                                                               ^~~~~~~~~~~
    In file included from ext/_yaml.h:2,
                     from ext/_yaml.c:271:
    /usr/include/yaml.h:635:1: note: expected ‘yaml_char_t *’ {aka ‘unsigned char *’} but argument is of type ‘char *’
     yaml_mapping_start_event_initialize(yaml_event_t *event,
     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    ext/_yaml.c: In function ‘__Pyx__ExceptionSave’:
    ext/_yaml.c:24143:21: error: ‘PyThreadState’ {aka ‘struct _ts’} has no member named ‘exc_type’; did you mean ‘curexc_type’?
         *type = tstate->exc_type;
                         ^~~~~~~~
                         curexc_type
    ext/_yaml.c:24144:22: error: ‘PyThreadState’ {aka ‘struct _ts’} has no member named ‘exc_value’; did you mean ‘curexc_value’?
         *value = tstate->exc_value;
                          ^~~~~~~~~
                          curexc_value
    ext/_yaml.c:24145:19: error: ‘PyThreadState’ {aka ‘struct _ts’} has no member named ‘exc_traceback’; did you mean ‘curexc_traceback’?
         *tb = tstate->exc_traceback;
                       ^~~~~~~~~~~~~
                       curexc_traceback
    ext/_yaml.c: In function ‘__Pyx__ExceptionReset’:
    ext/_yaml.c:24152:24: error: ‘PyThreadState’ {aka ‘struct _ts’} has no member named ‘exc_type’; did you mean ‘curexc_type’?
         tmp_type = tstate->exc_type;
                            ^~~~~~~~
                            curexc_type
    ext/_yaml.c:24153:25: error: ‘PyThreadState’ {aka ‘struct _ts’} has no member named ‘exc_value’; did you mean ‘curexc_value’?
         tmp_value = tstate->exc_value;
                             ^~~~~~~~~
                             curexc_value
    ext/_yaml.c:24154:22: error: ‘PyThreadState’ {aka ‘struct _ts’} has no member named ‘exc_traceback’; did you mean ‘curexc_traceback’?
         tmp_tb = tstate->exc_traceback;
                          ^~~~~~~~~~~~~
                          curexc_traceback
    ext/_yaml.c:24155:13: error: ‘PyThreadState’ {aka ‘struct _ts’} has no member named ‘exc_type’; did you mean ‘curexc_type’?
         tstate->exc_type = type;
                 ^~~~~~~~
                 curexc_type
    ext/_yaml.c:24156:13: error: ‘PyThreadState’ {aka ‘struct _ts’} has no member named ‘exc_value’; did you mean ‘curexc_value’?
         tstate->exc_value = value;
                 ^~~~~~~~~
                 curexc_value
    ext/_yaml.c:24157:13: error: ‘PyThreadState’ {aka ‘struct _ts’} has no member named ‘exc_traceback’; did you mean ‘curexc_traceback’?
         tstate->exc_traceback = tb;
                 ^~~~~~~~~~~~~
                 curexc_traceback
    ext/_yaml.c: In function ‘__Pyx__GetException’:
    ext/_yaml.c:24212:24: error: ‘PyThreadState’ {aka ‘struct _ts’} has no member named ‘exc_type’; did you mean ‘curexc_type’?
         tmp_type = tstate->exc_type;
                            ^~~~~~~~
                            curexc_type
    ext/_yaml.c:24213:25: error: ‘PyThreadState’ {aka ‘struct _ts’} has no member named ‘exc_value’; did you mean ‘curexc_value’?
         tmp_value = tstate->exc_value;
                             ^~~~~~~~~
                             curexc_value
    ext/_yaml.c:24214:22: error: ‘PyThreadState’ {aka ‘struct _ts’} has no member named ‘exc_traceback’; did you mean ‘curexc_traceback’?
         tmp_tb = tstate->exc_traceback;
                          ^~~~~~~~~~~~~
                          curexc_traceback
    ext/_yaml.c:24215:13: error: ‘PyThreadState’ {aka ‘struct _ts’} has no member named ‘exc_type’; did you mean ‘curexc_type’?
         tstate->exc_type = local_type;
                 ^~~~~~~~
                 curexc_type
    ext/_yaml.c:24216:13: error: ‘PyThreadState’ {aka ‘struct _ts’} has no member named ‘exc_value’; did you mean ‘curexc_value’?
         tstate->exc_value = local_value;
```

Bumping to 3.13 fixes the issue.