### PR TITLE
Gemnasium has been discontinued. We use Snyk at GSA now.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
-[![Code Climate](https://codeclimate.com/github/18F/pulse/badges/gpa.svg)](https://codeclimate.com/github/18F/pulse) [![Dependency Status](https://gemnasium.com/badges/github.com/18F/pulse.svg)](https://gemnasium.com/github.com/18F/pulse)
+[![Code Climate](https://codeclimate.com/github/18F/pulse/badges/gpa.svg)](https://codeclimate.com/github/18F/pulse) 
+[![Known Vulnerabilities](https://snyk.io/test/github/18F/pulse/badge.svg)](https://snyk.io/test/github/18F/pulse)
 
 
 ## The pulse of the federal .gov webspace


### PR DESCRIPTION
- Removed Gemnasium from README
- Add Snyk from README