### PR TITLE
TST: Bump CI Python to 3.6.8 and fix pip error

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 jobs:
   data:
     docker:
-      - image: "circleci/python:3.6.1"
+      - image: "circleci/python:3.6.8"
     steps:
       - checkout:
           path: ~/repo
@@ -11,6 +11,7 @@ jobs:
           command: |
               python3 -m venv .env
               . .env/bin/activate
+              python setup.py install_egg_info
               pip install -r requirements.txt
               pip install -e .[development]
           name: "Installing dependencies"


### PR DESCRIPTION
pip was raising a ContextualVersionConflict due to reusing the same virtualenv between builds. Workaround might be making egg-info before `pip install -e`